### PR TITLE
EG-I82: close Package-N live-owner join graph

### DIFF
--- a/config/governance/technical_canonical_wiring_authorization_v1.json
+++ b/config/governance/technical_canonical_wiring_authorization_v1.json
@@ -953,7 +953,12 @@
     "src/trading/master_v2/regime_bull_bear_switch_evidence_readmodel_v1/constants_v1.py",
     "src/trading/master_v2/regime_bull_bear_switch_evidence_readmodel_v1/models_v1.py",
     "src/trading/master_v2/regime_bull_bear_switch_evidence_readmodel_v1/persistence_v1.py",
-    "tests/trading/master_v2/test_regime_bull_bear_switch_evidence_readmodel_v1.py"
+    "tests/trading/master_v2/test_regime_bull_bear_switch_evidence_readmodel_v1.py",
+    "src/governance/promotion_loop/experiment_lineage_ref_producer_v1.py",
+    "src/governance/promotion_loop/i16_lineage_remaining_planes_live_join_v1.py",
+    "src/governance/promotion_loop/i16_remaining_planes_join_attachment_v1.py",
+    "tests/governance/promotion_loop/test_i16_lineage_remaining_planes_live_join_v1.py",
+    "tests/governance/promotion_loop/test_i16_remaining_planes_join_attachment_v1.py"
   ],
   "allowed_surface_classes": [
     "TECHNICAL_CANONICAL_REPLAY_INPUT_BUILDER_WIRING",
@@ -1014,7 +1019,8 @@
     "TECHNICAL_BOLLINGER_MR_MIDBAND_EXIT_REENTRY_COOLDOWN_HOLDOUT_PREREGISTRATION_WIRING",
     "TECHNICAL_CANONICAL_VOLATILITY_HOT_PATH_CONTRACT_CLOSURE_WIRING",
     "TECHNICAL_CAPABILITY_7_1_SIMULATED_ENTRY_REDUCE_EXIT_ACTIONABILITY_WIRING",
-    "TECHNICAL_PRODUCTIVE_TYPED_VOLATILITY_PRODUCER_AND_CMC_HOT_PATH_BINDING_WIRING"
+    "TECHNICAL_PRODUCTIVE_TYPED_VOLATILITY_PRODUCER_AND_CMC_HOT_PATH_BINDING_WIRING",
+    "TECHNICAL_EG_I82_PACKAGE_N_LIVE_OWNER_JOIN_WIRING"
   ],
   "authorization_token": "TECHNICAL_CANONICAL_WIRING_AUTHORIZATION_V1",
   "authorized_path_prefixes": [],
@@ -1065,6 +1071,7 @@
     "Includes canonical Dynamic Scope trailing state continuity repair: RuntimeScopeState SSOT across integrated/backtest cycles; CanonicalScopeSnapshot identity-only; CHOP bound as scope policy (no emission heuristic); no runtime/authority/order/live activation.",
     "Includes Double Play sole authority fail-closed quarantine: Ops SwitchGate projection-only, scenario tick.scope_event TEST_ONLY guarded, backtest position feedback observation-only (no SideState overwrite); CHOP bound as scope policy; UNKNOWN remains NOT_BOUND; no runtime/order/live activation; TEST_ONLY injection harness test paths explicitly allowlisted.",
     "Includes CHOP scope-event policy binding v1: ScopeEvent.CHOP_DETECTED bound as RuntimeScopeState scope policy only; Composition consumer projection; UNKNOWN remains NOT_BOUND_FAIL_CLOSED; no Direction/Switch/SideState mutation by CHOP; no runtime/order/live activation.",
+    "Includes EG-I82 Package-N live-owner identity-join sidecar for I16 remaining-plane files only (exact-file allowlist); no promotion authority, runtime, orders, credentials, scheduler, migration, or backfill. Other promotion_loop paths remain unauthorized.",
     "Includes testnet/scenario injection fail-closed default + required typed tick provenance: allow_test_scope_event_injection defaults False; explicit bool opt-in + OfflineScenarioTickProvenanceV1 required; no Direction/Side/Switch authority; chop_guard default-minimal transition_allowed aligned to CHOP scope-policy application; no runtime/order/live activation.",
     "Includes adverse-exit/downscope dual-dimension transport: generator prefers DOWNSCOPE/UPSCOPE over ADVERSE_EXIT for ScopeEvent; adverse remains in matched_conditions for Exit PolicySignal; ADVERSE_EXIT maps fail-closed unless downscope fact present; transition_state remains sole SideState owner; no runtime/order/live activation.",
     "Includes longer chronological PIT public-history acquisition scaffold, bounded OKX history-depth probe, and sealed production-lifecycle long-panel binding/acquisition (research-only, dry-run/no-credentials defaults, external archive root required for writes); no economic optimization; no strategy/risk/execution/Master-V2/Double-Play mutation. Owner surface: LONGER_CHRONOLOGICAL_PIT_PUBLIC_HISTORY_ACQUISITION_SCAFFOLD_AND_DEPTH_PROBE_V1. Review basis: acquisition/probe/seal workstream; remains in force until superseded by a later acquisition operator GO.",
@@ -1151,6 +1158,7 @@
     "MASTER_V2_CANONICAL_VOLATILITY_NUMERIC_MAX_AGE_ADDITIONAL_EVIDENCE_SESSION_CONTRACT_HARDENING_V1: authorize fail-closed hardening of additional-evidence session preregistration candidate validator (exact schema-version and scope bindings, closed-world unknown-field rejection including authority fields, contract digest consistency, focused tests/docs). Contract/validator only — no preregistration creation, authorization issuance/consumption, network, session execution, threshold selection, enforcement, or promotion.",
     "CAPABILITY_7_1_SIMULATED_ENTRY_REDUCE_EXIT_ACTIONABILITY_EVIDENCE_V1 exact-file allowlist for intent-pipeline bridge decision_outcome propagation into capital-risk sizing input (binding completeness only; CORE_SEMANTICS/RISK_SIZING_SEMANTICS unchanged).",
     "PRODUCTIVE_TYPED_VOLATILITY_PRODUCER_AND_CMC_HOT_PATH_BINDING_V1 exact-file allowlist for PT1M mark observation finalizer under master_v2 (wiring/observation finalization only; no core trading logic mutation; no numeric max-age enforcement).",
-    "CAPABILITY_REGIME_BULL_BEAR_SWITCH_EVIDENCE_READMODEL_V1: authorize exact-file EVIDENCE_ONLY / NON_RESTART_AUTHORITY capture carrier + post-transition capture binding in integrated offline replay + focused tests. No Master-V2/Double-Play restart persistence domain; CanonicalDynamicScopeStateV1.side_state remains sole SideState restart owner; CORE_SEMANTICS_CHANGED=false; no live/testnet/orders."
+    "CAPABILITY_REGIME_BULL_BEAR_SWITCH_EVIDENCE_READMODEL_V1: authorize exact-file EVIDENCE_ONLY / NON_RESTART_AUTHORITY capture carrier + post-transition capture binding in integrated offline replay + focused tests. No Master-V2/Double-Play restart persistence domain; CanonicalDynamicScopeStateV1.side_state remains sole SideState restart owner; CORE_SEMANTICS_CHANGED=false; no live/testnet/orders.",
+    "EG_I82_PACKAGE_N_LIVE_OWNER_JOIN_CLOSEOUT: authorize exact-file I16 lineage remaining-plane identity-join sidecar + focused tests under Package-N SHA256-only join. No promotion authority, runtime activation, orders, credentials, scheduler, migration, or backfill. Other promotion_loop paths remain unauthorized."
   ]
 }

--- a/docs/governance/PEAK_TRADE_MAP_OF_TRUTH.md
+++ b/docs/governance/PEAK_TRADE_MAP_OF_TRUTH.md
@@ -946,6 +946,20 @@ CANONICAL_SEMANTICS=docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md#15.3
 
 ---
 
+## 8.2 EG-I82-JOIN closeout (navigation only)
+
+| Pfad | Rolle |
+|------|-------|
+| [`docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md`](../runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md) §5.8 | SSOT-Zeiger auf EG-I82-JOIN-Closeout (navigation only; Semantik ausschließlich im Master Runbook) |
+
+```text
+THIS_SECTION_DEFINES_NO_SEMANTICS=true
+THIS_DOCUMENT_POINTS_ONLY_TO_CANONICAL_OWNERS=true
+CANONICAL_SEMANTICS=docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md#5.8
+```
+
+---
+
 ## 9. Wichtigste Runbooks
 
 | Dokument | Rolle |

--- a/docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
+++ b/docs/ops/specs/LEVELUP_V0_CANONICAL_SURFACE.md
@@ -1,7 +1,7 @@
 # LevelUp v0 — Canonical Ops/Spec Surface (additive)
 
 **status:** active  
-**last_updated:** 2026-04-17  
+**last_updated:** 2026-08-13  
 **purpose:** Kanonische **Auffindbarkeit** und **Claim-Grenzen** für die kleine LevelUp-v0-Schicht (Manifest-/IO-/CLI-Grundlage). Keine neue Governance-, Risk- oder Safety-Autorität.
 
 **docs_token:** `DOCS_TOKEN_LEVELUP_V0_CANONICAL_SURFACE`
@@ -39,7 +39,10 @@ Ausrichtung an den verbindlichen Vokabular-/Authority-/Provenance-Regeln: [`CANO
 | Pfad | Rolle |
 |------|--------|
 | `src/levelup/__init__.py` | Öffentliche Re-Exports der v0-API. |
-| `src/levelup/v0_models.py` | Pydantic-Modelle, Schema-String `levelup&#47;manifest&#47;v0`. |
+| `src/levelup/v0_models.py` | Pydantic-Modelle, Schema-String `levelup&#47;manifest&#47;v0`. Additive EG-I82 parse sidecar `parse_levelup_manifest_with_identity_join_v1` (Package-N SHA256 IDENTITY; `extra="forbid"` unverändert). |
+| `src/levelup/i52_levelup_join_attachment_v1.py` | Dormant I52 join-attachment helper (non-activating). |
+| `src/levelup/i52_levelup_live_contract_join_v1.py` | Dormant I52 live-contract join registration (non-activating). |
+| `src/levelup/i52_levelup_named_lane_identity_join_v1.py` | Named-lane I52 IDENTITY join (Package-N SHA256 sidecar; no v0 schema mutation). |
 | `src/levelup/v0_io.py` | JSON einlesen/ausgeben (Path). |
 | `src/levelup/cli.py` | CLI-Einstieg (`validate`, `dump-empty`, `format`, `canonical-check`, `export-json-schema`, `describe-slice`, `list-slices`, `check-evidence`, `check-evidence-coverage`, `check-evidence-readiness`, `check-evidence-bundle`, `check-evidence-integrity`, `check-evidence-attestation`, `check-evidence-attestation-contract`, `check-evidence-attestation-consistency`, `check-evidence-attestation-readiness`, `check-evidence-attestation-uniqueness`, `check-evidence-attestation-integrity`, `check-evidence-readiness-overall`). |
 | `schemas/levelup/levelup_manifest_v0.schema.json` | Repo-committed JSON Schema für `LevelUpManifestV0` (gleiche Quelle wie `export-json-schema` / `levelup_manifest_v0_json_schema()` in `v0_models.py`). |
@@ -67,6 +70,7 @@ Ausrichtung an den verbindlichen Vokabular-/Authority-/Provenance-Regeln: [`CANO
 Alles Folgende bezieht sich auf den **Ist**-Stand der genannten Dateien:
 
 - **Schema:** `LevelUpManifestV0.schema_version` ist fix `levelup&#47;manifest&#47;v0` (`src/levelup/v0_models.py`).
+- **EG-I82 identity join (additive sidecar, non-activating):** `parse_levelup_manifest_with_identity_join_v1` hängt Package-N SHA256 IDENTITY als Sidecar an; `LevelUpManifestV0`-Felder, JSON-Schema und `extra="forbid"` bleiben unverändert. Historische Manifeste bleiben lesbar. Keine Live-/Order-/Runtime-Aktivierung. Nachweis: `tests/levelup/test_i52_levelup_named_lane_identity_join_v1.py`, Master Runbook §5.8.
 - **Committed JSON Schema (reviewbar):** `schemas/levelup/levelup_manifest_v0.schema.json` materialisiert das Pydantic-JSON-Schema für `LevelUpManifestV0`. Synchronisation: `uv run python scripts/ops/sync_levelup_manifest_json_schema.py` (nutzt dieselbe Erzeugung wie `export-json-schema` über `levelup_manifest_v0_json_schema()`). Drift-Tests: `test_committed_levelup_manifest_json_schema_matches_model` und Abgleich in `test_cli_export_json_schema_success` in `tests/levelup/test_v0_manifest.py`.
 - **Manifest-Titel:** `LevelUpManifestV0.title` wird an den Enden getrimmt; nur nicht-leer nach dem Trim ist gültig (Leer- bzw. Nur-Whitespace-Titel werden abgewiesen). Positiv-/Negativfälle: `test_manifest_root_title_strips_surrounding_whitespace`, `test_manifest_root_title_rejects_empty_after_strip` in `tests/levelup/test_v0_manifest.py`.
 - **Slice-IDs:** `slice_id`-Werte müssen innerhalb eines Manifests **eindeutig** sein (`test_manifest_rejects_duplicate_slice_id` in `tests/levelup/test_v0_manifest.py`).

--- a/docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md
+++ b/docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md
@@ -968,6 +968,63 @@ LEGACY_PARALLEL_AUTHORITY_DETECTED=false
 REGIME_UNCLASSIFIED_FAIL_CLOSED_IS_DEFECT=false
 ```
 
+## 5.8 EG-I82-JOIN Package-N live-owner identity-join closeout
+
+Forensic identity-join closeout only. This subsection records that
+experiment-identity join across six registered live owners is
+`CLOSED_PROVEN`. It does not authorize runtime, trading, orders,
+network sessions, Cap 7.2 expansion, Testnet, Live, credentials,
+migration, backfill, or any successor phase.
+
+``` text
+EG_I82_JOIN_STATUS=CLOSED_PROVEN
+EG_I82_JOIN_CLOSURE_PROVEN=true
+END_TO_END_JOIN_GRAPH_PROVEN=true
+REAL_LIVE_OWNER_COUNT=6
+EXPECTED_LANE_COUNT=7
+EXPECTED_EDGE_COUNT=42
+EDGES_PROVEN=42
+CANONICAL_JOIN_KEY=package_n_sha256
+PACKAGE_N_SHA256_ONLY_JOIN_KEY=true
+STATIC_FLAG_AGGREGATION_ONLY=false
+FULL_GRAPH_TRAVERSAL_PROVEN=true
+NEGATIVE_MATRIX_FAIL_CLOSED=true
+HISTORICAL_READABILITY_PRESERVED=true
+TRADING_LOGIC_MUTATION=false
+RUNTIME_MUTATION=false
+RUNTIME_AUTHORIZATION_EFFECT=NONE
+NETWORK_EFFECT=NONE
+ORDER_EFFECT=NONE
+MIGRATION_EXECUTED=false
+BACKFILL_EXECUTED=false
+CAP7_2_SCOPE_EXPANDED=false
+SRC_EXECUTION_IMPORT_ADDED=false
+SUCCESSOR_PHASE_AUTHORIZED=false
+```
+
+Required graph: six real live owners (I16 lineage producer, I17
+paper-shadow preregistration, I52 Level-Up v0 models, I56 evidence
+capsule, I61 live-session eval, I65 explorer) times seven named lanes
+(IDENTITY, ALIAS, RUN, CAMPAIGN, SESSION, EVIDENCE, CONTENT_HASH) =
+42&#47;42. Package-N SHA256 is the only authoritative join key.
+`experiment_id`, `run_id` and other legacy or operational IDs never
+replace IDENTITY. End-to-end proof traverses the registered live-owner
+parse&#47;join contracts; it is not a static `PROVEN=true` flag
+aggregation. The fail-closed negative matrix remains required
+(missing edge, wrong join key, identity conflict, RUN&#47;ALIAS as
+IDENTITY, synthetic identity, implicit absence, cross-lane&#47;plane,
+extra&#47;duplicate edge). Historical I52 `extra="forbid"`, I61 Fill&#47;
+`compute_metrics`, and I65 `_row_to_summary` readability are preserved.
+
+Proof&#47;attestation surfaces (non-activating):
+
+-   `src&#47;experiments&#47;eg_i82_end_to_end_live_owner_graph_attestation_v1.py`
+-   `tests&#47;experiments&#47;test_eg_i82_end_to_end_live_owner_graph_attestation_v1.py`
+-   `src&#47;experiments&#47;eg_i82_join_verifier_v1.py`
+
+This closeout does not start a follow-on remediation unit and does not
+change Cap 11&#47;§11.13 authorization.
+
 ------------------------------------------------------------------------
 
 # 6. Canonical State Ownership and Persistence Model

--- a/src/analytics/explorer.py
+++ b/src/analytics/explorer.py
@@ -37,11 +37,12 @@ Usage:
 
 from __future__ import annotations
 
+import copy
 import json
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
 import pandas as pd
 
@@ -51,6 +52,10 @@ from src.core.experiments import (
     VALID_RUN_TYPES,
     get_experiment_by_id,
     load_experiments_df,
+)
+from src.experiments.cross_lane_identity_join_v1 import CrossLaneIdentityJoinV1
+from src.analytics.i65_explorer_named_lane_identity_join_v1 import (
+    join_i65_named_lane_identity_v1,
 )
 
 
@@ -807,3 +812,58 @@ def quick_sweep_summary(
         SweepOverview oder None
     """
     return ExperimentExplorer().summarize_sweep(sweep_name, metric=metric, top_n=top_n)
+
+
+@dataclass(frozen=True)
+class ExperimentSummaryNamedLaneIdentityJoinResultV1:
+    contract: ExperimentSummary
+    join: CrossLaneIdentityJoinV1
+
+
+@dataclass(frozen=True)
+class ExperimentRowNamedLaneIdentityJoinResultV1:
+    contract: Dict[str, Any]
+    join: CrossLaneIdentityJoinV1
+
+
+def parse_experiment_summary_with_identity_join_v1(
+    raw: Mapping[str, Any],
+    **sidecars: Any,
+) -> ExperimentSummaryNamedLaneIdentityJoinResultV1:
+    """Parse a live I65 summary and fail-closed join Package-N IDENTITY sidecar."""
+    snapshot = copy.deepcopy(dict(raw)) if isinstance(raw, Mapping) else None
+    join = join_i65_named_lane_identity_v1(raw, surface="summary", **sidecars)
+    if not isinstance(raw, Mapping) or snapshot is None:
+        raise ValueError("malformed plane data rejected: I65 summary is not an object")
+    contract = ExperimentSummary(
+        experiment_id=str(raw["experiment_id"]),
+        run_type=str(raw["run_type"]),
+        run_name=str(raw["run_name"]),
+        strategy_name=raw.get("strategy_name"),
+        sweep_name=raw.get("sweep_name"),
+        scan_name=raw.get("scan_name"),
+        portfolio_name=raw.get("portfolio_name"),
+        symbol=raw.get("symbol"),
+        tags=list(raw.get("tags") or []),
+        created_at=raw.get("created_at"),
+        metrics=dict(raw.get("metrics") or {}),
+        params=dict(raw.get("params") or {}),
+    )
+    if dict(raw) != snapshot:
+        raise ValueError("I65 summary input was mutated")
+    return ExperimentSummaryNamedLaneIdentityJoinResultV1(contract=contract, join=join)
+
+
+def parse_experiment_row_with_identity_join_v1(
+    raw: Mapping[str, Any],
+    **sidecars: Any,
+) -> ExperimentRowNamedLaneIdentityJoinResultV1:
+    """Parse a live I65 registry row and fail-closed join Package-N IDENTITY sidecar."""
+    snapshot = copy.deepcopy(dict(raw)) if isinstance(raw, Mapping) else None
+    join = join_i65_named_lane_identity_v1(raw, surface="row", **sidecars)
+    if not isinstance(raw, Mapping) or snapshot is None:
+        raise ValueError("malformed plane data rejected: I65 row is not an object")
+    contract = copy.deepcopy(dict(raw))
+    if dict(raw) != snapshot:
+        raise ValueError("I65 row input was mutated")
+    return ExperimentRowNamedLaneIdentityJoinResultV1(contract=contract, join=join)

--- a/src/analytics/i65_explorer_join_attachment_v1.py
+++ b/src/analytics/i65_explorer_join_attachment_v1.py
@@ -1,0 +1,244 @@
+"""EG-I82-JOIN U-I82-R9 — dormant I65 explorer join attachment.
+
+Attaches Package-N SHA256 IDENTITY onto an I65 explorer join payload.
+Splits IDENTITY from RUN: experiment_identity_id is SHA256 only; run_id
+stays UUID RUN; legacy experiment_id is RUN_PROVENANCE_ALIAS only.
+Does not rewrite explorer.py / ExperimentSummary / UUID run_id generator,
+does not register into runtime/execution, and does not import Cap 7.2.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+from src.analytics.legacy_identity_row_interpretation_v1 import (
+    LEGACY_EXPERIMENT_ID_CLASSIFICATION,
+    IdentityRequestMode,
+    LegacyIdentityRowInterpretationError,
+    interpret_legacy_identity_row_v1,
+)
+from src.experiments.cross_lane_identity_join_record_v1 import (
+    CrossLaneIdentityJoinRecordError,
+    build_cross_lane_identity_join_record_v1,
+)
+from src.experiments.cross_lane_identity_join_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    JOIN_PLANES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    PlanePresence,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+)
+from src.meta.learning_loop.contract_safety_v1 import is_valid_sha256_hex
+
+CONTRACT_ID = "i65_explorer_join_attachment_v1"
+
+_R2_KEYS = (
+    "experiment_identity_id",
+    "run_id",
+    "experiment_id",
+    "legacy_alias_md5_12",
+    "legacy_experiment_id_md5_12",
+)
+_KNOWN_KEYS = frozenset(
+    {
+        *_R2_KEYS,
+        "campaign_id",
+        "session_id",
+        "evidence_ref",
+        "content_sha256",
+        "historical_provenance",
+    }
+)
+_FORBIDDEN_KEYS = frozenset(
+    {
+        "orders",
+        "credentials",
+        "secrets",
+        "payload",
+        "raw",
+        "raw_payload",
+        "transcript",
+        "promotion_authority",
+        "apply_authority",
+        "live_arming",
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "registry_run_id",
+        "mlflow_run_id",
+        "evidence_id",
+        "config_hash",
+        "git_sha",
+    }
+)
+_NON_IDENTITY_I65_FIELDS = (
+    "run_id",
+    "experiment_id",
+    "campaign_id",
+    "session_id",
+    "evidence_ref",
+)
+
+
+class I65ExplorerJoinAttachmentError(ValueError):
+    """Fail-closed I65 explorer join attachment error."""
+
+
+def _reject(message: str) -> None:
+    raise I65ExplorerJoinAttachmentError(message)
+
+
+def _optional_str(payload: Mapping[str, Any], key: str) -> str | None:
+    if key not in payload:
+        return None
+    value = payload[key]
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        _reject(f"{key} must be a string when present")
+    if not value.strip() or value != value.strip():
+        _reject(f"{key} is present but empty or whitespace-padded")
+    return value
+
+
+def _present(plane: str, value: str, join_key: str) -> dict[str, str]:
+    return {
+        "plane": plane,
+        "presence": PlanePresence.PRESENT.value,
+        "join_key": join_key,
+        "value": value,
+    }
+
+
+def _absent(plane: str) -> dict[str, str]:
+    return {"plane": plane, "presence": PlanePresence.ABSENT_DECLARED.value}
+
+
+def _resolve_identity(payload: Mapping[str, Any]) -> str:
+    identity = _optional_str(payload, "experiment_identity_id")
+    if identity is None:
+        _reject("I65 IDENTITY missing: experiment_identity_id required")
+    if not is_package_n_sha256_canonical_id(identity):
+        _reject("experiment_identity_id must be Package-N SHA256")
+    return identity
+
+
+def _content_sha256(payload: Mapping[str, Any]) -> str | None:
+    value = _optional_str(payload, "content_sha256")
+    if value is None:
+        return None
+    if not is_valid_sha256_hex(value):
+        _reject("content_sha256 must be 64-char lowercase sha256 hex when CONTENT_HASH is PRESENT")
+    return value
+
+
+def _classify_legacy_fields(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    row_subset = {key: payload[key] for key in _R2_KEYS if key in payload}
+    try:
+        return interpret_legacy_identity_row_v1(
+            row_subset,
+            identity_request=IdentityRequestMode.IDENTITY_CANONICAL,
+        )
+    except LegacyIdentityRowInterpretationError as exc:
+        raise I65ExplorerJoinAttachmentError(f"I65 field separation rejected: {exc}") from exc
+
+
+def attach_i65_explorer_join_v1(i65_identity: Mapping[str, Any]) -> CrossLaneIdentityJoinV1:
+    """Attach Package-N SHA256 IDENTITY onto an I65 explorer join payload."""
+    if not isinstance(i65_identity, Mapping):
+        _reject("I65 identity payload must be an object")
+    forbidden = sorted(str(key) for key in i65_identity.keys() if str(key) in _FORBIDDEN_KEYS)
+    if forbidden:
+        _reject(f"forbidden I65 join field: {forbidden[0]}")
+    extra = sorted(str(key) for key in i65_identity.keys() if str(key) not in _KNOWN_KEYS)
+    if extra:
+        _reject(f"unknown I65 join field: {extra[0]}")
+
+    identity_id = _resolve_identity(i65_identity)
+    interpreted = _classify_legacy_fields(i65_identity)
+    if interpreted.experiment_identity_id != identity_id:
+        _reject("conflicting identities: R2 classification disagrees with Package-N SHA256")
+
+    run_id = interpreted.run_id
+    alias = interpreted.legacy_alias_md5_12
+    campaign_id = _optional_str(i65_identity, "campaign_id")
+    session_id = _optional_str(i65_identity, "session_id")
+    evidence = _optional_str(i65_identity, "evidence_ref")
+    content_hash = _content_sha256(i65_identity)
+    provenance = i65_identity.get("historical_provenance")
+    if provenance is not None and not isinstance(provenance, Mapping):
+        _reject("historical_provenance must be an object")
+    provenance_copy = copy.deepcopy(dict(provenance)) if isinstance(provenance, Mapping) else {}
+    if interpreted.legacy_experiment_id is not None:
+        provenance_copy.setdefault("legacy_experiment_id", interpreted.legacy_experiment_id)
+        provenance_copy.setdefault(
+            "legacy_experiment_id_classification",
+            interpreted.legacy_experiment_id_classification or LEGACY_EXPERIMENT_ID_CLASSIFICATION,
+        )
+    if run_id is not None:
+        provenance_copy.setdefault("run_id", run_id)
+
+    if run_id is not None and run_id == identity_id:
+        _reject("run_id must not substitute for Package-N SHA256 IDENTITY")
+    if (
+        interpreted.legacy_experiment_id is not None
+        and interpreted.legacy_experiment_id == identity_id
+    ):
+        _reject("legacy experiment_id must not substitute for Package-N SHA256 IDENTITY")
+    for label in _NON_IDENTITY_I65_FIELDS:
+        value = _optional_str(i65_identity, label)
+        if value is not None and value == identity_id:
+            _reject(f"{label} must not substitute for Package-N SHA256 IDENTITY")
+
+    contributions = {
+        "IDENTITY": _present("IDENTITY", identity_id, identity_id),
+        "ALIAS": _present("ALIAS", alias, identity_id) if alias is not None else _absent("ALIAS"),
+        "RUN": _present("RUN", run_id, identity_id) if run_id is not None else _absent("RUN"),
+        "CAMPAIGN": (
+            _present("CAMPAIGN", campaign_id, identity_id)
+            if campaign_id is not None
+            else _absent("CAMPAIGN")
+        ),
+        "SESSION": (
+            _present("SESSION", session_id, identity_id)
+            if session_id is not None
+            else _absent("SESSION")
+        ),
+        "EVIDENCE": (
+            _present("EVIDENCE", evidence, identity_id)
+            if evidence is not None
+            else _absent("EVIDENCE")
+        ),
+        "CONTENT_HASH": (
+            _present("CONTENT_HASH", content_hash, identity_id)
+            if content_hash is not None
+            else _absent("CONTENT_HASH")
+        ),
+    }
+    ordered = [contributions[plane] for plane in JOIN_PLANES]
+    try:
+        return build_cross_lane_identity_join_record_v1(
+            ordered,
+            package_n_identity_id=identity_id,
+            historical_provenance=provenance_copy or None,
+        )
+    except CrossLaneIdentityJoinRecordError as exc:
+        raise I65ExplorerJoinAttachmentError(
+            f"I65 explorer join rejected by R3 primitive: {exc}"
+        ) from exc
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "I65ExplorerJoinAttachmentError",
+    "LEGACY_EXPERIMENT_ID_CLASSIFICATION",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "attach_i65_explorer_join_v1",
+]

--- a/src/analytics/i65_explorer_live_contract_join_v1.py
+++ b/src/analytics/i65_explorer_live_contract_join_v1.py
@@ -1,0 +1,422 @@
+"""EG-I82-JOIN U-I82-R16 — dormant I65 live-contract join registration.
+
+Binds Package-N SHA256 IDENTITY onto validated I65 ExperimentSummary /
+historical registry-row payloads without rewriting explorer.py,
+ExperimentSummary, or the UUID run_id generator, without hooking
+Cap 7.2 / src.execution, and without persistence, migration, or backfill.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+from src.analytics.i65_explorer_join_attachment_v1 import (
+    I65ExplorerJoinAttachmentError,
+    attach_i65_explorer_join_v1,
+)
+from src.experiments.cross_lane_identity_join_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+)
+
+CONTRACT_ID = "i65_explorer_live_contract_join_v1"
+I65_LIVE_CONTRACT_REGISTERED = True
+
+LIVE_CONTRACT_SURFACES: tuple[str, ...] = (
+    "summary",
+    "row",
+)
+
+_REQUIRED_SUMMARY_KEYS = frozenset({"experiment_id", "run_type", "run_name"})
+_OPTIONAL_SUMMARY_KEYS = frozenset(
+    {
+        "strategy_name",
+        "sweep_name",
+        "scan_name",
+        "portfolio_name",
+        "symbol",
+        "tags",
+        "created_at",
+        "metrics",
+        "params",
+    }
+)
+_ROW_IDENTITY_KEYS = frozenset(
+    {
+        "run_id",
+        "experiment_id",
+        "legacy_alias_md5_12",
+        "legacy_experiment_id_md5_12",
+    }
+)
+_OPTIONAL_ROW_RECORD_KEYS = frozenset(
+    {
+        "run_type",
+        "run_name",
+        "timestamp",
+        "strategy_key",
+        "symbol",
+        "portfolio_name",
+        "sweep_name",
+        "scan_name",
+        "total_return",
+        "cagr",
+        "max_drawdown",
+        "sharpe",
+        "report_dir",
+        "report_prefix",
+        "params_json",
+        "stats_json",
+        "metadata_json",
+        "tags",
+    }
+)
+_KNOWN_ENVELOPE_KEYS = frozenset(
+    {
+        "experiment_identity_id",
+        "summary",
+        "row",
+        "experiment_id",
+        "run_id",
+        "campaign_id",
+        "session_id",
+        "legacy_alias_md5_12",
+        "evidence_ref",
+        "content_sha256",
+        "historical_provenance",
+    }
+)
+_FORBIDDEN_ENVELOPE_KEYS = frozenset(
+    {
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "registry_run_id",
+        "mlflow_run_id",
+        "orders",
+        "credentials",
+        "secrets",
+        "payload",
+        "raw",
+        "raw_payload",
+        "transcript",
+        "promotion_authority",
+        "apply_authority",
+        "live_arming",
+        "I16",
+        "I17",
+        "I52",
+        "I56",
+        "I61",
+        "I65",
+        "plane_presence",
+        "join_key",
+        "fills",
+        "ts",
+        "side",
+        "qty",
+        "fill_price",
+    }
+)
+_LIVE_IDENTITY_SUBSTITUTE_KEYS = frozenset(
+    {
+        "experiment_identity_id",
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "plane_presence",
+        "join_key",
+        "I16",
+        "I17",
+        "I52",
+        "I56",
+        "I61",
+    }
+)
+_CROSS_PLANE_LIVE_KEYS = frozenset(
+    {
+        "fills",
+        "ts",
+        "side",
+        "qty",
+        "fill_price",
+        "capsule_id",
+        "total_fills",
+        "session_dir",
+    }
+)
+
+
+class I65ExplorerLiveContractJoinError(ValueError):
+    """Fail-closed I65 live-contract join registration error."""
+
+
+def _reject(message: str) -> None:
+    raise I65ExplorerLiveContractJoinError(message)
+
+
+def is_i65_live_contract_registered() -> bool:
+    """True iff the dormant I65 live-contract join surface is registered."""
+    return I65_LIVE_CONTRACT_REGISTERED is True
+
+
+def _optional_str(payload: Mapping[str, Any], key: str) -> str | None:
+    if key not in payload:
+        return None
+    value = payload[key]
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        _reject(f"{key} must be a string when present")
+    if not value.strip() or value != value.strip():
+        _reject(f"{key} is present but empty or whitespace-padded")
+    return value
+
+
+def _require_identity(envelope: Mapping[str, Any]) -> str:
+    if "experiment_identity_id" not in envelope:
+        _reject("implicit absence rejected: I65 live-contract IDENTITY is missing")
+    identity = envelope.get("experiment_identity_id")
+    if identity is None:
+        _reject("implicit absence rejected: I65 live-contract IDENTITY is missing")
+    if not isinstance(identity, str) or not is_package_n_sha256_canonical_id(identity):
+        _reject(
+            "noncanonical ID substitution rejected: experiment_identity_id must be Package-N SHA256"
+        )
+    return identity
+
+
+def _snapshot_live_payload(raw: object, *, surface: str) -> dict[str, Any]:
+    if raw is None:
+        _reject(f"implicit absence rejected: I65 live surface {surface} is missing")
+    if isinstance(raw, (list, tuple)):
+        if not raw:
+            _reject(f"implicit absence rejected: I65 live surface {surface} is missing")
+        if len(raw) != 1:
+            _reject(
+                f"ambiguous join rejected: I65 live surface {surface} has multiple Package-N assignments"
+            )
+        return _snapshot_live_payload(raw[0], surface=surface)
+    if not isinstance(raw, Mapping):
+        _reject(f"malformed plane data rejected: I65 live surface {surface} is not an object")
+    return copy.deepcopy(dict(raw))
+
+
+def _reject_live_identity_substitution(payload: Mapping[str, Any], *, surface: str) -> None:
+    substitutes = sorted(
+        str(key) for key in payload.keys() if str(key) in _LIVE_IDENTITY_SUBSTITUTE_KEYS
+    )
+    if substitutes:
+        _reject(
+            f"noncanonical ID substitution rejected: live surface {surface} uses {substitutes[0]} "
+            "as Package-N identity"
+        )
+    cross_plane = sorted(str(key) for key in payload.keys() if str(key) in _CROSS_PLANE_LIVE_KEYS)
+    if cross_plane:
+        _reject(
+            f"cross-plane substitution rejected: I65 live surface {surface} carries {cross_plane[0]}"
+        )
+
+
+def _select_live_surface(envelope: Mapping[str, Any]) -> tuple[str, dict[str, Any]]:
+    present = [name for name in LIVE_CONTRACT_SURFACES if name in envelope]
+    if not present:
+        _reject("implicit absence rejected: I65 live contract surface is missing")
+    if len(present) != 1:
+        _reject("ambiguous join rejected: I65 live contract has multiple Package-N assignments")
+    surface = present[0]
+    return surface, _snapshot_live_payload(envelope[surface], surface=surface)
+
+
+def _reject_sha256_as_legacy_id(value: str, *, label: str) -> None:
+    if is_package_n_sha256_canonical_id(value):
+        _reject(
+            f"noncanonical ID substitution rejected: {label} must not be treated as Package-N SHA256"
+        )
+
+
+def _validate_summary(payload: Mapping[str, Any]) -> dict[str, Any]:
+    extra = sorted(
+        str(key)
+        for key in payload.keys()
+        if str(key) not in _REQUIRED_SUMMARY_KEYS | _OPTIONAL_SUMMARY_KEYS
+    )
+    if extra:
+        _reject(f"malformed plane data rejected: unknown I65 summary field: {extra[0]}")
+    missing = sorted(key for key in _REQUIRED_SUMMARY_KEYS if key not in payload)
+    if missing:
+        _reject(f"malformed plane data rejected: I65 summary missing {missing[0]}")
+    experiment_id = payload["experiment_id"]
+    if not isinstance(experiment_id, str) or not experiment_id.strip():
+        _reject("malformed plane data rejected: I65 summary experiment_id is invalid")
+    if experiment_id != experiment_id.strip():
+        _reject("malformed plane data rejected: I65 summary experiment_id is invalid")
+    _reject_sha256_as_legacy_id(experiment_id, label="summary.experiment_id")
+    for required in ("run_type", "run_name"):
+        value = payload[required]
+        if not isinstance(value, str) or not value.strip() or value != value.strip():
+            _reject(f"malformed plane data rejected: I65 summary {required} is invalid")
+    if "tags" in payload and payload["tags"] is not None and not isinstance(payload["tags"], list):
+        _reject("malformed plane data rejected: I65 summary tags is not a list")
+    if (
+        "metrics" in payload
+        and payload["metrics"] is not None
+        and not isinstance(payload["metrics"], Mapping)
+    ):
+        _reject("malformed plane data rejected: I65 summary metrics is not an object")
+    if (
+        "params" in payload
+        and payload["params"] is not None
+        and not isinstance(payload["params"], Mapping)
+    ):
+        _reject("malformed plane data rejected: I65 summary params is not an object")
+    return {"run_id": experiment_id, "experiment_id": experiment_id}
+
+
+def _validate_row(payload: Mapping[str, Any]) -> dict[str, Any]:
+    extra = sorted(
+        str(key)
+        for key in payload.keys()
+        if str(key) not in _ROW_IDENTITY_KEYS | _OPTIONAL_ROW_RECORD_KEYS
+    )
+    if extra:
+        _reject(f"malformed plane data rejected: unknown I65 row field: {extra[0]}")
+    run_id = _optional_str(payload, "run_id")
+    experiment_id = _optional_str(payload, "experiment_id")
+    if run_id is None and experiment_id is None:
+        _reject("implicit absence rejected: I65 row has no run_id or experiment_id")
+    if run_id is not None:
+        _reject_sha256_as_legacy_id(run_id, label="row.run_id")
+    if experiment_id is not None:
+        _reject_sha256_as_legacy_id(experiment_id, label="row.experiment_id")
+    if run_id is not None and experiment_id is not None and run_id != experiment_id:
+        _reject("conflicting identity rejected: row.experiment_id disagrees with row.run_id")
+    out: dict[str, Any] = {}
+    if run_id is not None:
+        out["run_id"] = run_id
+    if experiment_id is not None:
+        out["experiment_id"] = experiment_id
+    alias = _optional_str(payload, "legacy_alias_md5_12")
+    secondary = _optional_str(payload, "legacy_experiment_id_md5_12")
+    if alias is not None and secondary is not None and alias != secondary:
+        _reject("conflicting identity rejected: MD5 alias fields disagree")
+    if alias is not None:
+        out["legacy_alias_md5_12"] = alias
+    elif secondary is not None:
+        out["legacy_alias_md5_12"] = secondary
+    return out
+
+
+_SURFACE_VALIDATORS = {
+    "summary": _validate_summary,
+    "row": _validate_row,
+}
+
+
+def _agree_optional(left: str | None, right: str | None, *, label: str) -> str | None:
+    if left is not None and right is not None and left != right:
+        _reject(f"conflicting identity rejected: {label} values disagree")
+    return left if left is not None else right
+
+
+def _join_payload(
+    *,
+    identity_id: str,
+    live: Mapping[str, Any],
+    envelope: Mapping[str, Any],
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"experiment_identity_id": identity_id}
+    run_id = _agree_optional(
+        live.get("run_id") if isinstance(live.get("run_id"), str) else None,
+        _optional_str(envelope, "run_id"),
+        label="run_id",
+    )
+    experiment_id = _agree_optional(
+        live.get("experiment_id") if isinstance(live.get("experiment_id"), str) else None,
+        _optional_str(envelope, "experiment_id"),
+        label="experiment_id",
+    )
+    alias = _agree_optional(
+        live.get("legacy_alias_md5_12")
+        if isinstance(live.get("legacy_alias_md5_12"), str)
+        else None,
+        _optional_str(envelope, "legacy_alias_md5_12"),
+        label="legacy_alias_md5_12",
+    )
+    if run_id is not None:
+        payload["run_id"] = run_id
+    if experiment_id is not None:
+        payload["experiment_id"] = experiment_id
+    if alias is not None:
+        payload["legacy_alias_md5_12"] = alias
+    for key in ("campaign_id", "session_id", "evidence_ref", "content_sha256"):
+        value = _optional_str(envelope, key)
+        if value is not None:
+            payload[key] = value
+    provenance = envelope.get("historical_provenance")
+    if provenance is not None:
+        payload["historical_provenance"] = copy.deepcopy(provenance)
+    return payload
+
+
+def register_i65_live_contract_join_v1(
+    live_join: Mapping[str, Any],
+) -> CrossLaneIdentityJoinV1:
+    """Register an I65 live-contract payload onto the Package-N SHA256 join path."""
+    if not isinstance(live_join, Mapping):
+        _reject("malformed plane data rejected: I65 live-contract envelope is not an object")
+    snapshot = copy.deepcopy(dict(live_join))
+    forbidden = sorted(str(key) for key in live_join.keys() if str(key) in _FORBIDDEN_ENVELOPE_KEYS)
+    if forbidden:
+        if forbidden[0] in {"I16", "I17", "I52", "I56", "I61"}:
+            _reject(f"cross-lane substitution rejected: {forbidden[0]}")
+        if forbidden[0] in {"plane_presence", "join_key"} | _CROSS_PLANE_LIVE_KEYS:
+            _reject(f"cross-plane substitution rejected: {forbidden[0]}")
+        _reject(f"noncanonical ID substitution rejected: {forbidden[0]}")
+    extra = sorted(str(key) for key in live_join.keys() if str(key) not in _KNOWN_ENVELOPE_KEYS)
+    if extra:
+        _reject(f"malformed plane data rejected: unknown I65 live-contract field: {extra[0]}")
+
+    identity_id = _require_identity(live_join)
+    surface, live_payload = _select_live_surface(live_join)
+    _reject_live_identity_substitution(live_payload, surface=surface)
+    validated = _SURFACE_VALIDATORS[surface](live_payload)
+    attachment = _join_payload(identity_id=identity_id, live=validated, envelope=live_join)
+    try:
+        record = attach_i65_explorer_join_v1(attachment)
+    except I65ExplorerJoinAttachmentError as exc:
+        message = str(exc)
+        if "must not substitute" in message:
+            _reject(f"cross-plane substitution rejected: {exc}")
+        if "conflicting" in message:
+            _reject(f"conflicting identity rejected: {exc}")
+        if "Package-N SHA256" in message or "field separation rejected" in message:
+            _reject(f"noncanonical ID substitution rejected: {exc}")
+        raise I65ExplorerLiveContractJoinError(
+            f"I65 live-contract join rejected by R9 attachment: {exc}"
+        ) from exc
+
+    if dict(live_join) != snapshot:
+        _reject("I65 live-contract envelope input was mutated")
+    return record
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "I65ExplorerLiveContractJoinError",
+    "I65_LIVE_CONTRACT_REGISTERED",
+    "LIVE_CONTRACT_SURFACES",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "is_i65_live_contract_registered",
+    "register_i65_live_contract_join_v1",
+]

--- a/src/analytics/i65_explorer_named_lane_identity_join_v1.py
+++ b/src/analytics/i65_explorer_named_lane_identity_join_v1.py
@@ -1,0 +1,365 @@
+"""EG-I82-JOIN U-I82-R23 — I65 named-lane IDENTITY join on explorer.
+
+Attaches Package-N SHA256 IDENTITY onto the named I65 live contract
+surfaces without rewriting ExperimentSummary, explorer lookups, or the
+UUID run_id generator, without Cap 7.2 / src.execution, and without
+persistence, migration, or backfill. Live experiment_id/run_id remain
+RUN provenance and cannot fill IDENTITY. Historical rows stay readable.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+from src.analytics.i65_explorer_join_attachment_v1 import (
+    I65ExplorerJoinAttachmentError,
+    attach_i65_explorer_join_v1,
+)
+from src.experiments.cross_lane_identity_join_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+)
+
+CONTRACT_ID = "i65_explorer_named_lane_identity_join_v1"
+I65_NAMED_LANE_IDENTITY_JOIN_REGISTERED = True
+
+LIVE_CONTRACT_SURFACES: tuple[str, ...] = (
+    "summary",
+    "row",
+)
+
+_REQUIRED_SUMMARY_KEYS = frozenset({"experiment_id", "run_type", "run_name"})
+_OPTIONAL_SUMMARY_KEYS = frozenset(
+    {
+        "strategy_name",
+        "sweep_name",
+        "scan_name",
+        "portfolio_name",
+        "symbol",
+        "tags",
+        "created_at",
+        "metrics",
+        "params",
+    }
+)
+_ROW_IDENTITY_KEYS = frozenset(
+    {
+        "run_id",
+        "experiment_id",
+        "legacy_alias_md5_12",
+        "legacy_experiment_id_md5_12",
+    }
+)
+_OPTIONAL_ROW_RECORD_KEYS = frozenset(
+    {
+        "run_type",
+        "run_name",
+        "timestamp",
+        "strategy_key",
+        "symbol",
+        "portfolio_name",
+        "sweep_name",
+        "scan_name",
+        "total_return",
+        "cagr",
+        "max_drawdown",
+        "sharpe",
+        "report_dir",
+        "report_prefix",
+        "params_json",
+        "stats_json",
+        "metadata_json",
+        "tags",
+    }
+)
+_FORBIDDEN_LIVE_KEYS = frozenset(
+    {
+        "experiment_identity_id",
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "campaign_id",
+        "session_id",
+        "registry_run_id",
+        "mlflow_run_id",
+        "orders",
+        "credentials",
+        "promotion_authority",
+        "apply_authority",
+        "live_arming",
+        "I16",
+        "I17",
+        "I52",
+        "I56",
+        "I61",
+        "I65",
+        "plane_presence",
+        "join_key",
+    }
+)
+_FORBIDDEN_LIVE_CONTENT_KEYS = frozenset(
+    {
+        "payload",
+        "raw",
+        "raw_payload",
+        "transcript",
+        "secrets",
+        "orders",
+        "credentials",
+        "fills",
+        "ts",
+        "side",
+        "qty",
+        "fill_price",
+        "capsule_id",
+        "total_fills",
+        "session_dir",
+    }
+)
+_CROSS_LANE_KEYS = frozenset({"I16", "I17", "I52", "I56", "I61"})
+_CROSS_PLANE_KEYS = frozenset(
+    {
+        "plane_presence",
+        "join_key",
+        "fills",
+        "ts",
+        "side",
+        "qty",
+        "fill_price",
+        "capsule_id",
+        "total_fills",
+        "session_dir",
+    }
+)
+
+
+class I65ExplorerNamedLaneIdentityJoinError(ValueError):
+    """Fail-closed I65 named-lane IDENTITY join error."""
+
+
+def _reject(message: str) -> None:
+    raise I65ExplorerNamedLaneIdentityJoinError(message)
+
+
+def is_i65_named_lane_identity_join_registered() -> bool:
+    """True iff the I65 named-lane IDENTITY join is registered on live I65 surfaces."""
+    return I65_NAMED_LANE_IDENTITY_JOIN_REGISTERED is True
+
+
+def _optional_sidecar(value: str | None, *, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip() or value != value.strip():
+        _reject(f"malformed plane data rejected: sidecar {field} is invalid")
+    return value
+
+
+def _optional_live_str(payload: Mapping[str, Any], key: str) -> str | None:
+    if key not in payload:
+        return None
+    value = payload[key]
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip() or value != value.strip():
+        _reject(f"malformed plane data rejected: I65 {key} is invalid")
+    return value
+
+
+def _require_identity(identity: object) -> str:
+    if identity is None:
+        _reject("implicit absence rejected: I65 named-lane IDENTITY is missing")
+    if not isinstance(identity, str) or not is_package_n_sha256_canonical_id(identity):
+        _reject(
+            "noncanonical ID substitution rejected: experiment_identity_id must be Package-N SHA256"
+        )
+    return identity
+
+
+def _reject_sha256_as_legacy_id(value: str, *, label: str) -> None:
+    if is_package_n_sha256_canonical_id(value):
+        _reject(
+            "noncanonical ID substitution rejected: "
+            f"{label} must not be treated as Package-N SHA256"
+        )
+
+
+def _reject_forbidden_keys(payload: Mapping[str, Any], *, surface: str) -> None:
+    keys = {str(key) for key in payload.keys()}
+    forbidden = sorted(keys & _FORBIDDEN_LIVE_KEYS)
+    if forbidden:
+        if forbidden[0] in _CROSS_LANE_KEYS:
+            _reject(f"cross-lane substitution rejected: {forbidden[0]}")
+        if forbidden[0] in _CROSS_PLANE_KEYS:
+            _reject(f"cross-plane substitution rejected: {forbidden[0]}")
+        _reject(f"noncanonical ID substitution rejected: {forbidden[0]}")
+    content = sorted(keys & _FORBIDDEN_LIVE_CONTENT_KEYS)
+    if content:
+        if content[0] in _CROSS_PLANE_KEYS:
+            _reject(f"cross-plane substitution rejected: {content[0]}")
+        _reject(f"malformed plane data rejected: I65 live surface {surface} carries {content[0]}")
+    allowed = (
+        _REQUIRED_SUMMARY_KEYS | _OPTIONAL_SUMMARY_KEYS
+        if surface == "summary"
+        else _ROW_IDENTITY_KEYS | _OPTIONAL_ROW_RECORD_KEYS
+    )
+    extra = sorted(keys - allowed - _FORBIDDEN_LIVE_KEYS - _FORBIDDEN_LIVE_CONTENT_KEYS)
+    if extra:
+        _reject(f"malformed plane data rejected: unknown I65 {surface} field: {extra[0]}")
+
+
+def _extract_summary(live: Mapping[str, Any]) -> dict[str, Any]:
+    missing = sorted(key for key in _REQUIRED_SUMMARY_KEYS if key not in live)
+    if missing:
+        _reject(f"malformed plane data rejected: I65 summary missing {missing[0]}")
+    experiment_id = live["experiment_id"]
+    if not isinstance(experiment_id, str) or not experiment_id.strip():
+        _reject("malformed plane data rejected: I65 summary experiment_id is invalid")
+    if experiment_id != experiment_id.strip():
+        _reject("malformed plane data rejected: I65 summary experiment_id is invalid")
+    _reject_sha256_as_legacy_id(experiment_id, label="summary.experiment_id")
+    for required in ("run_type", "run_name"):
+        value = live[required]
+        if not isinstance(value, str) or not value.strip() or value != value.strip():
+            _reject(f"malformed plane data rejected: I65 summary {required} is invalid")
+    if "tags" in live and live["tags"] is not None and not isinstance(live["tags"], list):
+        _reject("malformed plane data rejected: I65 summary tags is not a list")
+    if (
+        "metrics" in live
+        and live["metrics"] is not None
+        and not isinstance(live["metrics"], Mapping)
+    ):
+        _reject("malformed plane data rejected: I65 summary metrics is not an object")
+    if "params" in live and live["params"] is not None and not isinstance(live["params"], Mapping):
+        _reject("malformed plane data rejected: I65 summary params is not an object")
+    return {"run_id": experiment_id, "experiment_id": experiment_id}
+
+
+def _extract_row(live: Mapping[str, Any]) -> dict[str, Any]:
+    run_id = _optional_live_str(live, "run_id")
+    experiment_id = _optional_live_str(live, "experiment_id")
+    if run_id is None and experiment_id is None:
+        _reject("implicit absence rejected: I65 row has no run_id or experiment_id")
+    if run_id is not None:
+        _reject_sha256_as_legacy_id(run_id, label="row.run_id")
+    if experiment_id is not None:
+        _reject_sha256_as_legacy_id(experiment_id, label="row.experiment_id")
+    if run_id is not None and experiment_id is not None and run_id != experiment_id:
+        _reject("conflicting identity rejected: row.experiment_id disagrees with row.run_id")
+    out: dict[str, Any] = {}
+    if run_id is not None:
+        out["run_id"] = run_id
+    if experiment_id is not None:
+        out["experiment_id"] = experiment_id
+    alias = _optional_live_str(live, "legacy_alias_md5_12")
+    secondary = _optional_live_str(live, "legacy_experiment_id_md5_12")
+    if alias is not None and secondary is not None and alias != secondary:
+        _reject("conflicting identity rejected: MD5 alias fields disagree")
+    if alias is not None:
+        out["legacy_alias_md5_12"] = alias
+    elif secondary is not None:
+        out["legacy_alias_md5_12"] = secondary
+    return out
+
+
+def join_i65_named_lane_identity_v1(
+    live: object,
+    *,
+    surface: str,
+    experiment_identity_id: str | None = None,
+    run_id: str | None = None,
+    campaign_id: str | None = None,
+    session_id: str | None = None,
+    legacy_alias_md5_12: str | None = None,
+    content_sha256: str | None = None,
+    evidence_ref: str | None = None,
+    historical_provenance: Mapping[str, Any] | None = None,
+) -> CrossLaneIdentityJoinV1:
+    """Join Package-N SHA256 IDENTITY onto a named I65 live contract payload.
+
+    Does not mutate inputs and does not rewrite persisted I65 rows or ExperimentSummary.
+    """
+    if surface not in LIVE_CONTRACT_SURFACES:
+        _reject(f"malformed plane data rejected: unknown I65 live surface {surface}")
+    if isinstance(live, (list, tuple)):
+        _reject("ambiguous join rejected: I65 live surface has multiple Package-N assignments")
+    if not isinstance(live, Mapping):
+        _reject("malformed plane data rejected: I65 live payload is not an object")
+    snapshot = copy.deepcopy(dict(live))
+    _reject_forbidden_keys(live, surface=surface)
+
+    identity = _require_identity(experiment_identity_id)
+    if run_id is not None:
+        _reject("noncanonical ID substitution rejected: run_id")
+    extracted = _extract_summary(live) if surface == "summary" else _extract_row(live)
+    sidecar_campaign = _optional_sidecar(campaign_id, field="campaign_id")
+    sidecar_session = _optional_sidecar(session_id, field="session_id")
+    sidecar_alias = _optional_sidecar(legacy_alias_md5_12, field="legacy_alias_md5_12")
+    sidecar_hash = _optional_sidecar(content_sha256, field="content_sha256")
+    sidecar_evidence = _optional_sidecar(evidence_ref, field="evidence_ref")
+
+    live_alias = extracted.get("legacy_alias_md5_12")
+    if sidecar_alias is not None and live_alias and sidecar_alias != live_alias:
+        _reject("conflicting identity rejected: ALIAS values disagree")
+
+    payload: dict[str, Any] = {"experiment_identity_id": identity}
+    if extracted.get("run_id") is not None:
+        payload["run_id"] = extracted["run_id"]
+    if extracted.get("experiment_id") is not None:
+        payload["experiment_id"] = extracted["experiment_id"]
+    if live_alias:
+        payload["legacy_alias_md5_12"] = live_alias
+    elif sidecar_alias is not None:
+        payload["legacy_alias_md5_12"] = sidecar_alias
+    if sidecar_campaign is not None:
+        payload["campaign_id"] = sidecar_campaign
+    if sidecar_session is not None:
+        payload["session_id"] = sidecar_session
+    if sidecar_hash is not None:
+        payload["content_sha256"] = sidecar_hash
+    if sidecar_evidence is not None:
+        payload["evidence_ref"] = sidecar_evidence
+    if historical_provenance is not None:
+        if not isinstance(historical_provenance, Mapping):
+            _reject("malformed plane data rejected: historical_provenance must be an object")
+        provenance_copy = copy.deepcopy(dict(historical_provenance))
+        nested = provenance_copy.get("experiment_identity_id")
+        if nested is not None and nested != identity:
+            _reject("conflicting identity rejected: historical_provenance.experiment_identity_id")
+        payload["historical_provenance"] = provenance_copy
+
+    try:
+        record = attach_i65_explorer_join_v1(payload)
+    except I65ExplorerJoinAttachmentError as exc:
+        message = str(exc)
+        if "must not substitute" in message:
+            _reject(f"cross-plane substitution rejected: {exc}")
+        if "conflicting" in message:
+            _reject(f"conflicting identity rejected: {exc}")
+        if "Package-N SHA256" in message or "must not be UUID" in message:
+            _reject(f"noncanonical ID substitution rejected: {exc}")
+        raise I65ExplorerNamedLaneIdentityJoinError(
+            f"I65 named-lane IDENTITY join rejected by R9 attachment: {exc}"
+        ) from exc
+
+    if dict(live) != snapshot:
+        _reject("I65 live payload input was mutated")
+    return record
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "I65ExplorerNamedLaneIdentityJoinError",
+    "I65_NAMED_LANE_IDENTITY_JOIN_REGISTERED",
+    "LIVE_CONTRACT_SURFACES",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "is_i65_named_lane_identity_join_registered",
+    "join_i65_named_lane_identity_v1",
+]

--- a/src/analytics/legacy_identity_row_interpretation_v1.py
+++ b/src/analytics/legacy_identity_row_interpretation_v1.py
@@ -1,0 +1,248 @@
+"""EG-I82-JOIN U-I82-R2 — dormant historical I65 identity row reader.
+
+Interprets existing I65 registry/explorer rows without rewriting them.
+Legacy experiment_id/run_id remain RUN provenance. Canonical identity is
+Package-N SHA256 only, via the R1 join contract. No synthesis, no migration.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    CONTRACT_ID as JOIN_CONTRACT_ID,
+    CONTRACT_VERSION,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    JOIN_PLANES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    PlanePresence,
+    RUNTIME_AUTHORITY_IMPACT,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinError,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+    validate_cross_lane_identity_join_v1,
+)
+
+CONTRACT_ID = "legacy_identity_row_interpretation_v1"
+LEGACY_EXPERIMENT_ID_CLASSIFICATION = "RUN_PROVENANCE_ALIAS"
+
+_IDENTITY_SOURCE_KEYS = (
+    "run_id",
+    "experiment_id",
+    "experiment_identity_id",
+    "legacy_alias_md5_12",
+    "legacy_experiment_id_md5_12",
+)
+
+
+class IdentityRequestMode(str, Enum):
+    PROVENANCE = "PROVENANCE"
+    IDENTITY_CANONICAL = "IDENTITY_CANONICAL"
+
+
+class LegacyIdentityRowInterpretationError(ValueError):
+    """Fail-closed historical I65 identity-row interpretation error."""
+
+
+def _reject(message: str) -> None:
+    raise LegacyIdentityRowInterpretationError(message)
+
+
+def _optional_present_str(row: Mapping[str, Any], key: str) -> str | None:
+    if key not in row:
+        return None
+    value = row[key]
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        _reject(f"{key} must be a string when present")
+    if not value.strip() or value != value.strip():
+        _reject(f"{key} is present but empty or whitespace-padded (ambiguous)")
+    return value
+
+
+def _snapshot_identity_fields(row: Mapping[str, Any]) -> dict[str, Any]:
+    snapshot: dict[str, Any] = {}
+    for key in _IDENTITY_SOURCE_KEYS:
+        if key in row:
+            snapshot[key] = copy.deepcopy(row[key])
+    return snapshot
+
+
+def _alias_md5_12(row: Mapping[str, Any]) -> str | None:
+    primary = _optional_present_str(row, "legacy_alias_md5_12")
+    secondary = _optional_present_str(row, "legacy_experiment_id_md5_12")
+    if primary is not None and secondary is not None and primary != secondary:
+        _reject("conflicting identities: MD5 alias fields disagree")
+    return primary if primary is not None else secondary
+
+
+def _build_join_record(
+    *,
+    run_id: str | None,
+    alias_md5_12: str | None,
+    experiment_identity_id: str | None,
+    historical_provenance: Mapping[str, Any],
+) -> CrossLaneIdentityJoinV1:
+    plane_presence = {plane: PlanePresence.ABSENT_DECLARED.value for plane in JOIN_PLANES}
+    payload: dict[str, Any] = {
+        "schema_version": CONTRACT_VERSION,
+        "contract_version": CONTRACT_VERSION,
+        "contract_id": JOIN_CONTRACT_ID,
+        "plane_presence": plane_presence,
+        "historical_provenance": dict(historical_provenance),
+        "safety": {
+            "runtime_authority_impact": RUNTIME_AUTHORITY_IMPACT,
+            "evidence_does_not_authorize_runtime": True,
+            "MULTI_FUTURE_RUNTIME_AUTHORIZED": MULTI_FUTURE_RUNTIME_AUTHORIZED,
+            "SECOND_EXECUTION_AUTHORITY_AUTHORIZED": SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+            "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS": (
+                CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS
+            ),
+        },
+    }
+    if experiment_identity_id is not None:
+        plane_presence["IDENTITY"] = PlanePresence.PRESENT.value
+        payload["experiment_identity_id"] = experiment_identity_id
+    if run_id is not None:
+        plane_presence["RUN"] = PlanePresence.PRESENT.value
+        payload["run_id"] = run_id
+    if alias_md5_12 is not None:
+        plane_presence["ALIAS"] = PlanePresence.PRESENT.value
+        payload["legacy_alias_md5_12"] = alias_md5_12
+    try:
+        return validate_cross_lane_identity_join_v1(payload)
+    except CrossLaneIdentityJoinError as exc:
+        raise LegacyIdentityRowInterpretationError(
+            f"R1 join contract rejected historical interpretation: {exc}"
+        ) from exc
+
+
+@dataclass(frozen=True)
+class LegacyIdentityRowInterpretationV1:
+    contract_id: str
+    identity_request_mode: str
+    run_id: str | None
+    legacy_experiment_id: str | None
+    legacy_experiment_id_classification: str | None
+    legacy_alias_md5_12: str | None
+    experiment_identity_id: str | None
+    identity_status: str
+    identity_canonical: bool
+    join_record: CrossLaneIdentityJoinV1
+    historical_provenance: Mapping[str, Any]
+
+    def to_canonical_mapping(self) -> dict[str, Any]:
+        return {
+            "contract_id": self.contract_id,
+            "identity_request_mode": self.identity_request_mode,
+            "run_id": self.run_id,
+            "legacy_experiment_id": self.legacy_experiment_id,
+            "legacy_experiment_id_classification": self.legacy_experiment_id_classification,
+            "legacy_alias_md5_12": self.legacy_alias_md5_12,
+            "experiment_identity_id": self.experiment_identity_id,
+            "identity_status": self.identity_status,
+            "identity_canonical": self.identity_canonical,
+            "join_record": self.join_record.to_canonical_mapping(),
+            "historical_provenance": copy.deepcopy(dict(self.historical_provenance)),
+        }
+
+
+def interpret_legacy_identity_row_v1(
+    row: Mapping[str, Any],
+    *,
+    identity_request: IdentityRequestMode | str = IdentityRequestMode.PROVENANCE,
+) -> LegacyIdentityRowInterpretationV1:
+    """Read an I65 row as provenance. Never mutates `row` and never synthesizes SHA256."""
+    if not isinstance(row, Mapping):
+        _reject("historical I65 row must be an object")
+
+    if isinstance(identity_request, IdentityRequestMode):
+        request_mode = identity_request
+    elif identity_request in {
+        IdentityRequestMode.PROVENANCE.value,
+        IdentityRequestMode.IDENTITY_CANONICAL.value,
+    }:
+        request_mode = IdentityRequestMode(identity_request)
+    else:
+        _reject(f"unknown identity_request mode: {identity_request!r}")
+
+    provenance_snapshot = _snapshot_identity_fields(row)
+    frozen_provenance = MappingProxyType(copy.deepcopy(provenance_snapshot))
+
+    run_id = _optional_present_str(row, "run_id")
+    legacy_experiment_id = _optional_present_str(row, "experiment_id")
+    raw_identity = _optional_present_str(row, "experiment_identity_id")
+    alias_md5_12 = _alias_md5_12(row)
+
+    if run_id is None and legacy_experiment_id is None and raw_identity is None:
+        _reject("historical I65 row has no run_id, experiment_id, or experiment_identity_id")
+
+    if run_id is not None and legacy_experiment_id is not None and legacy_experiment_id != run_id:
+        _reject("conflicting identities: experiment_id disagrees with run_id")
+
+    legacy_classification: str | None = None
+    if legacy_experiment_id is not None:
+        if is_package_n_sha256_canonical_id(legacy_experiment_id):
+            _reject(
+                "legacy experiment_id must not be treated as Package-N SHA256; "
+                "canonical identity requires experiment_identity_id"
+            )
+        legacy_classification = LEGACY_EXPERIMENT_ID_CLASSIFICATION
+
+    canonical_id: str | None = None
+    if raw_identity is not None:
+        if not is_package_n_sha256_canonical_id(raw_identity):
+            _reject("experiment_identity_id is present but is not a Package-N SHA256 canonical id")
+        if run_id is not None and raw_identity == run_id:
+            _reject("conflicting identities: experiment_identity_id equals run_id")
+        if legacy_experiment_id is not None and raw_identity == legacy_experiment_id:
+            _reject("conflicting identities: experiment_identity_id equals legacy experiment_id")
+        canonical_id = raw_identity
+
+    if request_mode is IdentityRequestMode.IDENTITY_CANONICAL and canonical_id is None:
+        _reject("IDENTITY_CANONICAL requested but Package-N SHA256 identity is ABSENT_DECLARED")
+
+    join_record = _build_join_record(
+        run_id=run_id,
+        alias_md5_12=alias_md5_12,
+        experiment_identity_id=canonical_id,
+        historical_provenance=frozen_provenance,
+    )
+
+    identity_status = (
+        PlanePresence.PRESENT.value
+        if canonical_id is not None
+        else PlanePresence.ABSENT_DECLARED.value
+    )
+    return LegacyIdentityRowInterpretationV1(
+        contract_id=CONTRACT_ID,
+        identity_request_mode=request_mode.value,
+        run_id=run_id,
+        legacy_experiment_id=legacy_experiment_id,
+        legacy_experiment_id_classification=legacy_classification,
+        legacy_alias_md5_12=alias_md5_12,
+        experiment_identity_id=canonical_id,
+        identity_status=identity_status,
+        identity_canonical=canonical_id is not None,
+        join_record=join_record,
+        historical_provenance=join_record.historical_provenance,
+    )
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "IdentityRequestMode",
+    "LEGACY_EXPERIMENT_ID_CLASSIFICATION",
+    "LegacyIdentityRowInterpretationError",
+    "LegacyIdentityRowInterpretationV1",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "interpret_legacy_identity_row_v1",
+]

--- a/src/experiments/cross_lane_identity_join_record_v1.py
+++ b/src/experiments/cross_lane_identity_join_record_v1.py
@@ -1,0 +1,268 @@
+"""EG-I82-JOIN U-I82-R3 — dormant join-record primitive over the R1 contract.
+
+Aggregates explicit per-plane contributions into a CrossLaneIdentityJoinV1.
+Canonical join key is Package-N SHA256 only. No lane attachment, no persistence,
+no runtime registration, no second identity semantics.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Any, Mapping, Sequence
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    CONTRACT_ID as JOIN_CONTRACT_ID,
+    CONTRACT_VERSION,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    JOIN_PLANES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    PLANE_VALUE_FIELDS,
+    PlanePresence,
+    RUNTIME_AUTHORITY_IMPACT,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinError,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+    validate_cross_lane_identity_join_v1,
+)
+
+CONTRACT_ID = "cross_lane_identity_join_record_v1"
+
+_CONTRIBUTION_KEYS = frozenset({"plane", "presence", "join_key", "value"})
+_FORBIDDEN_CONTRIBUTION_KEYS = frozenset(
+    {
+        "orders",
+        "credentials",
+        "promotion_authority",
+        "apply_authority",
+        "live_arming",
+        "experiment_id",
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+    }
+)
+
+
+class CrossLaneIdentityJoinRecordError(ValueError):
+    """Fail-closed join-record primitive error."""
+
+
+def _reject(message: str) -> None:
+    raise CrossLaneIdentityJoinRecordError(message)
+
+
+def _presence_value(raw: object) -> str:
+    if raw is None or (isinstance(raw, str) and not raw.strip()):
+        _reject("plane presence status is missing")
+    if isinstance(raw, PlanePresence):
+        return raw.value
+    if not isinstance(raw, str):
+        _reject("plane presence status is missing")
+    if raw not in {PlanePresence.PRESENT.value, PlanePresence.ABSENT_DECLARED.value}:
+        _reject(f"unknown plane presence status: {raw!r}")
+    return raw
+
+
+def _plane_name(raw: object) -> str:
+    if not isinstance(raw, str) or not raw.strip():
+        _reject("join contribution plane is missing")
+    if raw not in JOIN_PLANES:
+        _reject(f"unknown join plane rejected: {raw}")
+    return raw
+
+
+def _optional_str(raw: object, *, field: str) -> str | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, str):
+        _reject(f"{field} must be a string when present")
+    if not raw.strip() or raw != raw.strip():
+        _reject(f"{field} is present but empty or whitespace-padded")
+    return raw
+
+
+@dataclass(frozen=True)
+class JoinPlaneContributionV1:
+    plane: str
+    presence: str
+    join_key: str | None
+    value: str | None
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, Any]) -> JoinPlaneContributionV1:
+        if not isinstance(payload, Mapping):
+            _reject("join contribution must be an object")
+        forbidden = sorted(
+            str(key) for key in payload.keys() if str(key) in _FORBIDDEN_CONTRIBUTION_KEYS
+        )
+        if forbidden:
+            _reject(f"forbidden join contribution key: {forbidden[0]}")
+        extra = sorted(str(key) for key in payload.keys() if str(key) not in _CONTRIBUTION_KEYS)
+        if extra:
+            _reject(f"unknown join contribution field: {extra[0]}")
+        plane = _plane_name(payload.get("plane"))
+        presence = _presence_value(payload.get("presence"))
+        join_key = (
+            _optional_str(payload.get("join_key"), field="join_key")
+            if "join_key" in payload
+            else None
+        )
+        value = _optional_str(payload.get("value"), field="value") if "value" in payload else None
+        return cls(plane=plane, presence=presence, join_key=join_key, value=value)
+
+
+def _normalize_contributions(
+    contributions: Sequence[JoinPlaneContributionV1 | Mapping[str, Any]],
+) -> list[JoinPlaneContributionV1]:
+    if not isinstance(contributions, Sequence) or isinstance(contributions, (str, bytes)):
+        _reject("join contributions must be a sequence")
+    normalized: list[JoinPlaneContributionV1] = []
+    for item in contributions:
+        if isinstance(item, JoinPlaneContributionV1):
+            normalized.append(item)
+        elif isinstance(item, Mapping):
+            normalized.append(JoinPlaneContributionV1.from_mapping(item))
+        else:
+            _reject("join contribution must be an object")
+    return normalized
+
+
+def _proven_package_n_id(
+    *,
+    package_n_identity_id: str | None,
+    package_n_manifest: Mapping[str, Any] | None,
+) -> str | None:
+    manifest_id: str | None = None
+    if package_n_manifest is not None:
+        if not isinstance(package_n_manifest, Mapping):
+            _reject("package_n_manifest must be an object")
+        raw = package_n_manifest.get("experiment_identity_id")
+        if not is_package_n_sha256_canonical_id(raw):
+            _reject("package_n_manifest.experiment_identity_id must be Package-N SHA256")
+        manifest_id = str(raw)
+    if package_n_identity_id is not None:
+        if not is_package_n_sha256_canonical_id(package_n_identity_id):
+            _reject("package_n_identity_id must be Package-N SHA256")
+        if manifest_id is not None and package_n_identity_id != manifest_id:
+            _reject("conflicting Package-N SHA256 identities")
+        return package_n_identity_id
+    return manifest_id
+
+
+def _require_join_key(join_key: str | None, *, plane: str) -> str:
+    if join_key is None:
+        _reject(f"PRESENT plane {plane} is missing Package-N SHA256 join_key")
+    if not is_package_n_sha256_canonical_id(join_key):
+        _reject("join_key must be a Package-N SHA256 canonical id")
+    return join_key
+
+
+def build_cross_lane_identity_join_record_v1(
+    contributions: Sequence[JoinPlaneContributionV1 | Mapping[str, Any]],
+    *,
+    package_n_identity_id: str | None = None,
+    package_n_manifest: Mapping[str, Any] | None = None,
+    historical_provenance: Mapping[str, Any] | None = None,
+) -> CrossLaneIdentityJoinV1:
+    """Build a dormant R1 join record from explicit plane contributions. Does not mutate inputs."""
+    if historical_provenance is not None and not isinstance(historical_provenance, Mapping):
+        _reject("historical_provenance must be an object")
+    source_contributions = _normalize_contributions(contributions)
+    proven_id = _proven_package_n_id(
+        package_n_identity_id=package_n_identity_id,
+        package_n_manifest=package_n_manifest,
+    )
+    provenance_copy: dict[str, Any] = (
+        copy.deepcopy(dict(historical_provenance)) if historical_provenance is not None else {}
+    )
+
+    by_plane: dict[str, JoinPlaneContributionV1] = {}
+    for item in source_contributions:
+        if item.plane in by_plane:
+            _reject(f"duplicate plane contribution rejected: {item.plane}")
+        by_plane[item.plane] = item
+
+    missing = [plane for plane in JOIN_PLANES if plane not in by_plane]
+    if missing:
+        _reject(f"incomplete join record: missing plane {missing[0]}")
+
+    agreed_join_key = proven_id
+    plane_presence: dict[str, str] = {}
+    values: dict[str, str | None] = {field: None for field in PLANE_VALUE_FIELDS.values()}
+
+    for plane in JOIN_PLANES:
+        item = by_plane[plane]
+        plane_presence[plane] = item.presence
+        if item.presence == PlanePresence.ABSENT_DECLARED.value:
+            if item.join_key is not None or item.value is not None:
+                _reject(
+                    f"ABSENT_DECLARED plane {plane} must not carry join_key or value "
+                    "(synthetic identity forbidden)"
+                )
+            continue
+        join_key = _require_join_key(item.join_key, plane=plane)
+        if item.value is None:
+            _reject(f"PRESENT plane {plane} is missing value")
+        if agreed_join_key is None:
+            agreed_join_key = join_key
+        elif join_key != agreed_join_key:
+            _reject("conflicting Package-N SHA256 identities")
+        if plane == "IDENTITY":
+            if item.value != join_key:
+                _reject("IDENTITY value must equal Package-N SHA256 join_key")
+            if not is_package_n_sha256_canonical_id(item.value):
+                _reject("IDENTITY value must be a Package-N SHA256 canonical id")
+        values[PLANE_VALUE_FIELDS[plane]] = item.value
+
+    present_planes = [
+        plane for plane, status in plane_presence.items() if status == PlanePresence.PRESENT.value
+    ]
+    if present_planes and agreed_join_key is None:
+        _reject("PRESENT contribution is missing Package-N SHA256 join_key")
+    if present_planes and plane_presence["IDENTITY"] != PlanePresence.PRESENT.value:
+        _reject("PRESENT planes require IDENTITY PRESENT with the same Package-N SHA256")
+    if plane_presence["IDENTITY"] == PlanePresence.PRESENT.value and agreed_join_key is None:
+        _reject("IDENTITY PRESENT requires Package-N SHA256 join_key")
+
+    payload: dict[str, Any] = {
+        "schema_version": CONTRACT_VERSION,
+        "contract_version": CONTRACT_VERSION,
+        "contract_id": JOIN_CONTRACT_ID,
+        "plane_presence": plane_presence,
+        "safety": {
+            "runtime_authority_impact": RUNTIME_AUTHORITY_IMPACT,
+            "evidence_does_not_authorize_runtime": True,
+            "MULTI_FUTURE_RUNTIME_AUTHORIZED": MULTI_FUTURE_RUNTIME_AUTHORIZED,
+            "SECOND_EXECUTION_AUTHORITY_AUTHORIZED": SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+            "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS": (
+                CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS
+            ),
+        },
+    }
+    if provenance_copy:
+        payload["historical_provenance"] = provenance_copy
+    for plane, field in PLANE_VALUE_FIELDS.items():
+        if plane_presence[plane] == PlanePresence.PRESENT.value:
+            payload[field] = values[field]
+
+    try:
+        return validate_cross_lane_identity_join_v1(payload)
+    except CrossLaneIdentityJoinError as exc:
+        raise CrossLaneIdentityJoinRecordError(
+            f"R1 join contract rejected join record: {exc}"
+        ) from exc
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "CrossLaneIdentityJoinRecordError",
+    "JoinPlaneContributionV1",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "build_cross_lane_identity_join_record_v1",
+]

--- a/src/experiments/cross_lane_identity_join_v1.py
+++ b/src/experiments/cross_lane_identity_join_v1.py
@@ -1,0 +1,392 @@
+"""EG-I82-JOIN U-I82-R1 — dormant fail-closed cross-lane identity join contract.
+
+Canonical join identity is Package-N SHA256 (64-char lowercase hex).
+This module defines types and validation only. It does not attach lanes,
+migrate historical records, activate runtime, or cut over emitters.
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from src.meta.learning_loop.contract_safety_v1 import (
+    SCHEMA_VERSION_V1,
+    is_valid_sha256_hex,
+    is_valid_uuid,
+)
+
+CONTRACT_ID = "cross_lane_identity_join_v1"
+CONTRACT_VERSION = SCHEMA_VERSION_V1
+RUNTIME_AUTHORITY_IMPACT = "NONE"
+MULTI_FUTURE_RUNTIME_AUTHORIZED = False
+SECOND_EXECUTION_AUTHORITY_AUTHORIZED = False
+CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS = 1
+
+_MD5_12_RE = re.compile(r"^[0-9a-f]{12}$", re.IGNORECASE)
+_MD5_32_RE = re.compile(r"^[0-9a-f]{32}$", re.IGNORECASE)
+
+_PLANE_VALUE_FIELDS: dict[str, str] = {
+    "IDENTITY": "experiment_identity_id",
+    "ALIAS": "legacy_alias_md5_12",
+    "RUN": "run_id",
+    "CAMPAIGN": "campaign_id",
+    "SESSION": "session_id",
+    "EVIDENCE": "evidence_ref",
+    "CONTENT_HASH": "content_sha256",
+}
+
+JOIN_PLANES: tuple[str, ...] = tuple(_PLANE_VALUE_FIELDS.keys())
+PLANE_VALUE_FIELDS: Mapping[str, str] = MappingProxyType(dict(_PLANE_VALUE_FIELDS))
+
+_KNOWN_TOP_LEVEL_KEYS = frozenset(
+    {
+        "schema_version",
+        "contract_version",
+        "contract_id",
+        "plane_presence",
+        "historical_provenance",
+        "safety",
+        *_PLANE_VALUE_FIELDS.values(),
+    }
+)
+
+_FORBIDDEN_IDENTITY_CLAIM_KEYS = frozenset(
+    {
+        "experiment_id",
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+    }
+)
+
+_IDENTITY_SUBSTITUTION_PLANES = ("RUN", "SESSION", "CAMPAIGN", "ALIAS")
+
+
+class PlanePresence(str, Enum):
+    PRESENT = "PRESENT"
+    ABSENT_DECLARED = "ABSENT_DECLARED"
+
+
+class JoinPlane(str, Enum):
+    IDENTITY = "IDENTITY"
+    ALIAS = "ALIAS"
+    RUN = "RUN"
+    CAMPAIGN = "CAMPAIGN"
+    SESSION = "SESSION"
+    EVIDENCE = "EVIDENCE"
+    CONTENT_HASH = "CONTENT_HASH"
+
+
+class CrossLaneIdentityJoinError(ValueError):
+    """Fail-closed cross-lane identity join contract error."""
+
+
+def is_package_n_sha256_canonical_id(value: object) -> bool:
+    """True iff value is a Package-N canonical identity (64-char lowercase sha256 hex)."""
+    if not isinstance(value, str):
+        return False
+    if is_valid_uuid(value):
+        return False
+    if _MD5_12_RE.fullmatch(value) is not None:
+        return False
+    if _MD5_32_RE.fullmatch(value) is not None:
+        return False
+    return is_valid_sha256_hex(value)
+
+
+def _reject(message: str) -> None:
+    raise CrossLaneIdentityJoinError(message)
+
+
+def _is_absent_value(value: object) -> bool:
+    return value is None
+
+
+def _require_non_empty_str(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or not value.strip() or value != value.strip():
+        _reject(f"{field} must be a non-empty string without surrounding whitespace")
+    return value
+
+
+def _freeze_mapping(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    frozen: dict[str, Any] = {}
+    for key, value in payload.items():
+        if isinstance(value, Mapping):
+            frozen[str(key)] = _freeze_mapping(value)
+        elif isinstance(value, list):
+            frozen[str(key)] = tuple(
+                _freeze_mapping(item) if isinstance(item, Mapping) else copy.deepcopy(item)
+                for item in value
+            )
+        else:
+            frozen[str(key)] = copy.deepcopy(value)
+    return MappingProxyType(frozen)
+
+
+def read_historical_provenance(
+    payload: Mapping[str, Any] | CrossLaneIdentityJoinV1,
+) -> Mapping[str, Any]:
+    """Return a read-only copy of historical provenance. Never rewrites source values."""
+    if isinstance(payload, CrossLaneIdentityJoinV1):
+        return payload.historical_provenance
+    if not isinstance(payload, Mapping):
+        _reject("historical provenance source must be an object")
+    raw = payload.get("historical_provenance", {})
+    if raw is None:
+        raw = {}
+    if not isinstance(raw, Mapping):
+        _reject("historical_provenance must be an object")
+    return _freeze_mapping(raw)
+
+
+def _validate_plane_presence(raw: object) -> dict[str, PlanePresence]:
+    if not isinstance(raw, Mapping):
+        _reject("plane_presence is required and must be an object")
+    unknown = sorted(str(key) for key in raw.keys() if str(key) not in _PLANE_VALUE_FIELDS)
+    if unknown:
+        _reject(f"unknown join plane rejected: {unknown[0]}")
+    missing = [plane for plane in JOIN_PLANES if plane not in raw]
+    if missing:
+        _reject(f"plane_presence missing required plane status: {missing[0]}")
+    parsed: dict[str, PlanePresence] = {}
+    for plane in JOIN_PLANES:
+        status = raw[plane]
+        if status is None or (isinstance(status, str) and not status.strip()):
+            _reject(f"plane_presence.{plane} status is missing")
+        if not isinstance(status, str):
+            _reject(f"plane_presence.{plane} status is missing")
+        if status not in {PlanePresence.PRESENT.value, PlanePresence.ABSENT_DECLARED.value}:
+            _reject(f"plane_presence.{plane} must be PRESENT or ABSENT_DECLARED, got {status!r}")
+        parsed[plane] = PlanePresence(status)
+    return parsed
+
+
+def _value_for_plane(payload: Mapping[str, Any], plane: str) -> object:
+    return payload.get(_PLANE_VALUE_FIELDS[plane])
+
+
+def _validate_alias(value: str) -> None:
+    if _MD5_12_RE.fullmatch(value) is None:
+        _reject("legacy_alias_md5_12 must be 12 hex chars when ALIAS is PRESENT")
+
+
+def _validate_content_hash(value: str) -> None:
+    if not is_valid_sha256_hex(value):
+        _reject("content_sha256 must be 64-char lowercase sha256 hex when CONTENT_HASH is PRESENT")
+
+
+def _reject_identity_substitutes(identity_id: str) -> None:
+    if is_valid_uuid(identity_id):
+        _reject("UUID/run_id is not a Package-N SHA256 canonical id")
+    if (
+        _MD5_12_RE.fullmatch(identity_id) is not None
+        or _MD5_32_RE.fullmatch(identity_id) is not None
+    ):
+        _reject("MD5 alias is not a Package-N SHA256 canonical id")
+    if not is_package_n_sha256_canonical_id(identity_id):
+        _reject("experiment_identity_id must be a Package-N SHA256 canonical id")
+
+
+def _reject_conflicting_identities(
+    payload: Mapping[str, Any],
+    *,
+    identity_id: str | None,
+    plane_presence: Mapping[str, PlanePresence],
+) -> None:
+    for key in _FORBIDDEN_IDENTITY_CLAIM_KEYS:
+        if key in payload:
+            other = payload[key]
+            if identity_id is None or other != identity_id:
+                _reject(f"conflicting identities rejected: extra identity claim {key}")
+            _reject(f"conflicting identities rejected: extra identity claim {key}")
+    if identity_id is None:
+        return
+    for plane in _IDENTITY_SUBSTITUTION_PLANES:
+        if plane_presence[plane] is not PlanePresence.PRESENT:
+            continue
+        other = _value_for_plane(payload, plane)
+        if other == identity_id:
+            _reject(
+                f"conflicting identities rejected: IDENTITY equals {plane} value "
+                f"({_PLANE_VALUE_FIELDS[plane]})"
+            )
+
+
+def _validate_safety(raw: object) -> Mapping[str, Any] | None:
+    if raw is None:
+        return None
+    if not isinstance(raw, Mapping):
+        _reject("safety must be an object")
+    if (
+        "runtime_authority_impact" in raw
+        and raw.get("runtime_authority_impact") != RUNTIME_AUTHORITY_IMPACT
+    ):
+        _reject("safety.runtime_authority_impact must be NONE")
+    if (
+        "evidence_does_not_authorize_runtime" in raw
+        and raw.get("evidence_does_not_authorize_runtime") is not True
+    ):
+        _reject("safety.evidence_does_not_authorize_runtime must be true")
+    if raw.get("MULTI_FUTURE_RUNTIME_AUTHORIZED") is True:
+        _reject("MULTI_FUTURE_RUNTIME_AUTHORIZED must remain false")
+    if raw.get("SECOND_EXECUTION_AUTHORITY_AUTHORIZED") is True:
+        _reject("SECOND_EXECUTION_AUTHORITY_AUTHORIZED must remain false")
+    unknown = sorted(
+        str(key)
+        for key in raw.keys()
+        if str(key)
+        not in {
+            "runtime_authority_impact",
+            "evidence_does_not_authorize_runtime",
+            "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+            "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+            "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+        }
+    )
+    if unknown:
+        _reject(f"unknown safety field rejected: {unknown[0]}")
+    if (
+        "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS" in raw
+        and raw.get("CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS")
+        != CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS
+    ):
+        _reject("CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS must remain 1")
+    return _freeze_mapping(raw)
+
+
+@dataclass(frozen=True)
+class CrossLaneIdentityJoinV1:
+    schema_version: str
+    contract_version: str
+    contract_id: str
+    plane_presence: Mapping[str, str]
+    experiment_identity_id: str | None
+    legacy_alias_md5_12: str | None
+    run_id: str | None
+    campaign_id: str | None
+    session_id: str | None
+    evidence_ref: str | None
+    content_sha256: str | None
+    historical_provenance: Mapping[str, Any]
+    safety: Mapping[str, Any] | None
+
+    def to_canonical_mapping(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "contract_version": self.contract_version,
+            "contract_id": self.contract_id,
+            "plane_presence": {plane: self.plane_presence[plane] for plane in JOIN_PLANES},
+        }
+        for plane, field in _PLANE_VALUE_FIELDS.items():
+            if self.plane_presence[plane] == PlanePresence.PRESENT.value:
+                payload[field] = getattr(self, field)
+        if self.historical_provenance:
+            payload["historical_provenance"] = copy.deepcopy(dict(self.historical_provenance))
+        if self.safety is not None:
+            payload["safety"] = copy.deepcopy(dict(self.safety))
+        return payload
+
+
+def validate_cross_lane_identity_join_v1(payload: Mapping[str, Any]) -> CrossLaneIdentityJoinV1:
+    """Validate a dormant join contract record. Does not mutate payload or historical values."""
+    if not isinstance(payload, Mapping):
+        _reject("join record root must be an object")
+
+    for key in _FORBIDDEN_IDENTITY_CLAIM_KEYS:
+        if key in payload:
+            _reject(f"conflicting identities rejected: extra identity claim {key}")
+
+    extra = sorted(str(key) for key in payload.keys() if str(key) not in _KNOWN_TOP_LEVEL_KEYS)
+    if extra:
+        _reject(f"unknown join field rejected: {extra[0]}")
+
+    schema_version = payload.get("schema_version")
+    if schema_version != CONTRACT_VERSION:
+        _reject("schema_version must equal 1.0")
+    contract_version = payload.get("contract_version")
+    if contract_version != CONTRACT_VERSION:
+        _reject("contract_version must equal 1.0")
+    contract_id = payload.get("contract_id")
+    if contract_id != CONTRACT_ID:
+        _reject("contract_id must equal cross_lane_identity_join_v1")
+
+    plane_presence = _validate_plane_presence(payload.get("plane_presence"))
+    values: dict[str, str | None] = {field: None for field in _PLANE_VALUE_FIELDS.values()}
+
+    for plane, field in _PLANE_VALUE_FIELDS.items():
+        status = plane_presence[plane]
+        raw_value = payload.get(field)
+        if status is PlanePresence.ABSENT_DECLARED:
+            if field in payload and not _is_absent_value(raw_value):
+                _reject(f"{field} must be absent or null when {plane} is ABSENT_DECLARED")
+            continue
+        if field not in payload or _is_absent_value(raw_value):
+            if plane == "IDENTITY":
+                _reject("canonical Package-N SHA256 id missing while IDENTITY is PRESENT")
+            _reject(f"{field} is required when {plane} is PRESENT")
+        text = _require_non_empty_str(raw_value, field=field)
+        if plane == "IDENTITY":
+            _reject_identity_substitutes(text)
+        elif plane == "ALIAS":
+            _validate_alias(text)
+        elif plane == "CONTENT_HASH":
+            _validate_content_hash(text)
+        values[field] = text
+
+    identity_id = values["experiment_identity_id"]
+    _reject_conflicting_identities(payload, identity_id=identity_id, plane_presence=plane_presence)
+
+    historical_provenance = read_historical_provenance(payload)
+    if (
+        plane_presence["IDENTITY"] is PlanePresence.PRESENT
+        and identity_id is not None
+        and "experiment_identity_id" in historical_provenance
+        and historical_provenance["experiment_identity_id"] != identity_id
+    ):
+        _reject("conflicting identities rejected: historical provenance canonical id mismatch")
+
+    safety = _validate_safety(payload.get("safety")) if "safety" in payload else None
+
+    return CrossLaneIdentityJoinV1(
+        schema_version=CONTRACT_VERSION,
+        contract_version=CONTRACT_VERSION,
+        contract_id=CONTRACT_ID,
+        plane_presence=MappingProxyType(
+            {plane: plane_presence[plane].value for plane in JOIN_PLANES}
+        ),
+        experiment_identity_id=values["experiment_identity_id"],
+        legacy_alias_md5_12=values["legacy_alias_md5_12"],
+        run_id=values["run_id"],
+        campaign_id=values["campaign_id"],
+        session_id=values["session_id"],
+        evidence_ref=values["evidence_ref"],
+        content_sha256=values["content_sha256"],
+        historical_provenance=historical_provenance,
+        safety=safety,
+    )
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CONTRACT_VERSION",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "CrossLaneIdentityJoinError",
+    "CrossLaneIdentityJoinV1",
+    "JOIN_PLANES",
+    "JoinPlane",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "PLANE_VALUE_FIELDS",
+    "PlanePresence",
+    "RUNTIME_AUTHORITY_IMPACT",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "is_package_n_sha256_canonical_id",
+    "read_historical_provenance",
+    "validate_cross_lane_identity_join_v1",
+]

--- a/src/experiments/eg_i82_end_to_end_live_owner_graph_attestation_v1.py
+++ b/src/experiments/eg_i82_end_to_end_live_owner_graph_attestation_v1.py
@@ -1,0 +1,852 @@
+"""EG-I82-JOIN U-I82-R24 — durable end-to-end live-owner graph attestation.
+
+Traverses the six registered named-lane live-owner parse/join contracts and
+attests all 42 required Plane×Lane edges as one fail-closed graph bound to a
+single Package-N SHA256 identity. This is not a static PROVEN-flag aggregator.
+
+Does not activate Cap 7.2 or src.execution, and does not persist, migrate,
+backfill, or rewrite historical CSV/registry records.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping, Sequence
+
+from src.analytics.explorer import parse_experiment_summary_with_identity_join_v1
+from src.analytics.i65_explorer_named_lane_identity_join_v1 import (
+    I65ExplorerNamedLaneIdentityJoinError,
+    is_i65_named_lane_identity_join_registered,
+)
+from src.experiments.cross_lane_identity_join_v1 import (
+    CONTRACT_VERSION,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    JOIN_PLANES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    PLANE_VALUE_FIELDS,
+    PlanePresence,
+    RUNTIME_AUTHORITY_IMPACT,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+)
+from src.experiments.eg_i82_join_verifier_v1 import (
+    EgI82JoinVerifierError,
+    NAMED_JOIN_LANES,
+    verify_eg_i82_cross_lane_join_v1,
+)
+from src.experiments.experiment_identity_manifest_v1 import ARTIFACT_FILENAME
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import LineageRef
+from src.governance.promotion_loop.experiment_lineage_ref_producer_v1 import (
+    ExperimentLineageRefProducerError,
+    build_experiment_lineage_ref_from_manifest,
+)
+from src.governance.promotion_loop.i16_lineage_remaining_planes_live_join_v1 import (
+    I16LineageRemainingPlanesLiveJoinError,
+    is_i16_lineage_remaining_planes_join_registered,
+    join_i16_lineage_remaining_planes_v1,
+)
+from src.ingress.capsules.evidence_capsule import parse_evidence_capsule_with_identity_join_v1
+from src.ingress.capsules.i56_ingress_named_lane_identity_join_v1 import (
+    I56IngressNamedLaneIdentityJoinError,
+    is_i56_named_lane_identity_join_registered,
+)
+from src.levelup.i52_levelup_named_lane_identity_join_v1 import (
+    I52LevelUpNamedLaneIdentityJoinError,
+    is_i52_named_lane_identity_join_registered,
+)
+from src.levelup.v0_models import parse_levelup_manifest_with_identity_join_v1
+from src.live_eval.i61_live_eval_named_lane_identity_join_v1 import (
+    I61LiveEvalNamedLaneIdentityJoinError,
+    is_i61_named_lane_identity_join_registered,
+)
+from src.live_eval.live_session_eval import parse_live_session_metrics_with_identity_join_v1
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.i17_paper_shadow_named_lane_identity_join_v1 import (
+    I17PaperShadowNamedLaneIdentityJoinError,
+    is_i17_named_lane_identity_join_registered,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.preregistration_contract_v1 import (
+    PreregistrationContractError,
+    parse_preregistration_contract_with_identity_join_v1,
+)
+
+CONTRACT_ID = "eg_i82_end_to_end_live_owner_graph_attestation_v1"
+EG_I82_END_TO_END_LIVE_OWNER_GRAPH_ATTESTATION_REGISTERED = True
+EXPECTED_EDGE_COUNT = 42
+EXPECTED_LANE_COUNT = 7
+EXPECTED_OWNER_COUNT = 6
+
+REAL_LIVE_OWNER_PATHS: Mapping[str, str] = MappingProxyType(
+    {
+        "I16": "src/governance/promotion_loop/experiment_lineage_ref_producer_v1.py",
+        "I17": (
+            "src/ops/paper_shadow_observation_operator_go_session_preregistration_v1/"
+            "preregistration_contract_v1.py"
+        ),
+        "I52": "src/levelup/v0_models.py",
+        "I56": "src/ingress/capsules/evidence_capsule.py",
+        "I61": "src/live_eval/live_session_eval.py",
+        "I65": "src/analytics/explorer.py",
+    }
+)
+
+REQUIRED_GRAPH_EDGE_IDS: tuple[str, ...] = tuple(
+    f"{lane}x{plane}" for lane in NAMED_JOIN_LANES for plane in JOIN_PLANES
+)
+
+_REGISTRATION_CHECKERS: Mapping[str, Any] = MappingProxyType(
+    {
+        "I16": is_i16_lineage_remaining_planes_join_registered,
+        "I17": is_i17_named_lane_identity_join_registered,
+        "I52": is_i52_named_lane_identity_join_registered,
+        "I56": is_i56_named_lane_identity_join_registered,
+        "I61": is_i61_named_lane_identity_join_registered,
+        "I65": is_i65_named_lane_identity_join_registered,
+    }
+)
+
+_LANE_ENVELOPE_KEYS: Mapping[str, frozenset[str]] = MappingProxyType(
+    {
+        "I16": frozenset(
+            {"manifest", "artifact_path", "run_id", "campaign_id", "session_id", "ref"}
+        ),
+        "I17": frozenset(
+            {
+                "live",
+                "experiment_identity_id",
+                "run_id",
+                "legacy_alias_md5_12",
+                "content_sha256",
+                "historical_provenance",
+            }
+        ),
+        "I52": frozenset(
+            {
+                "live",
+                "experiment_identity_id",
+                "run_id",
+                "campaign_id",
+                "session_id",
+                "legacy_alias_md5_12",
+                "content_sha256",
+                "evidence_ref",
+                "historical_provenance",
+            }
+        ),
+        "I56": frozenset(
+            {
+                "live",
+                "experiment_identity_id",
+                "campaign_id",
+                "session_id",
+                "legacy_alias_md5_12",
+                "content_sha256",
+                "evidence_ref",
+                "historical_provenance",
+            }
+        ),
+        "I61": frozenset(
+            {
+                "live",
+                "experiment_identity_id",
+                "run_id",
+                "campaign_id",
+                "session_id",
+                "session_dir",
+                "legacy_alias_md5_12",
+                "content_sha256",
+                "evidence_ref",
+                "historical_provenance",
+            }
+        ),
+        "I65": frozenset(
+            {
+                "live",
+                "experiment_identity_id",
+                "campaign_id",
+                "session_id",
+                "legacy_alias_md5_12",
+                "content_sha256",
+                "evidence_ref",
+                "historical_provenance",
+            }
+        ),
+    }
+)
+
+_NONCANONICAL_IDENTITY_KEYS = frozenset(
+    {
+        "run_id",
+        "experiment_id",
+        "campaign_id",
+        "session_id",
+        "evidence_id",
+        "evidence_ref",
+        "alias",
+        "legacy_alias_md5_12",
+        "legacy_experiment_id",
+        "package_n_sha256",
+        "canonical_id",
+        "canonical_identity_id",
+        "identity_id",
+        "ref_id",
+        "content_sha256",
+    }
+)
+_CLASSIFIED_PREFIXES = (
+    "implicit absence rejected",
+    "noncanonical ID substitution rejected",
+    "conflicting identity rejected",
+    "cross-lane substitution rejected",
+    "cross-plane substitution rejected",
+    "malformed plane data rejected",
+    "ambiguous join rejected",
+    "missing required edge rejected",
+    "duplicate/conflicting edge registration rejected",
+    "unexpected extra edge rejected",
+    "missing owner registration rejected",
+    "static join record rejected",
+)
+
+
+class EgI82EndToEndLiveOwnerGraphAttestationError(ValueError):
+    """Fail-closed EG-I82 end-to-end live-owner graph attestation error."""
+
+
+def _reject(message: str) -> None:
+    raise EgI82EndToEndLiveOwnerGraphAttestationError(message)
+
+
+def is_eg_i82_end_to_end_live_owner_graph_attestation_registered() -> bool:
+    """True iff the durable live-owner graph attestation surface is registered."""
+    return EG_I82_END_TO_END_LIVE_OWNER_GRAPH_ATTESTATION_REGISTERED is True
+
+
+def _freeze_mapping(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    frozen: dict[str, Any] = {}
+    for key, value in payload.items():
+        if isinstance(value, Mapping):
+            frozen[str(key)] = _freeze_mapping(value)
+        elif isinstance(value, list):
+            frozen[str(key)] = tuple(
+                _freeze_mapping(item) if isinstance(item, Mapping) else copy.deepcopy(item)
+                for item in value
+            )
+        else:
+            frozen[str(key)] = copy.deepcopy(value)
+    return MappingProxyType(frozen)
+
+
+def _snapshot(value: object) -> object:
+    if isinstance(value, Mapping):
+        return {str(key): _snapshot(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_snapshot(item) for item in value]
+    if isinstance(value, LineageRef):
+        return {
+            "ref_type": str(value.ref_type),
+            "ref_id": value.ref_id,
+            "digest": value.digest,
+            "artifact_path": value.artifact_path,
+            "relation": str(value.relation),
+            "owner_domain": value.owner_domain,
+        }
+    return copy.deepcopy(value)
+
+
+def _raise_from_live(exc: BaseException, *, lane: str) -> None:
+    if isinstance(exc, EgI82EndToEndLiveOwnerGraphAttestationError):
+        raise exc
+    message = str(exc)
+    lowered = message.lower()
+    for prefix in _CLASSIFIED_PREFIXES:
+        if lowered.startswith(prefix.lower()) or prefix.lower() in lowered:
+            _reject(message)
+    if "ambiguous" in lowered:
+        _reject(f"ambiguous join rejected: named lane {lane}: {exc}")
+    for other in NAMED_JOIN_LANES:
+        if other != lane and other in message and ("extra" in lowered or "forbidden" in lowered):
+            _reject(f"cross-lane substitution rejected: named lane {lane}: {exc}")
+    if (
+        "uuid" in lowered
+        or "md5" in lowered
+        or "package-n" in lowered
+        or "run_id" in lowered
+        or "experiment_id" in lowered
+    ):
+        _reject(f"noncanonical ID substitution rejected: named lane {lane}: {exc}")
+    if "conflict" in lowered:
+        _reject(f"conflicting identity rejected: named lane {lane}: {exc}")
+    if "cross-lane" in lowered:
+        _reject(f"cross-lane substitution rejected: named lane {lane}: {exc}")
+    if "cross-plane" in lowered:
+        _reject(f"cross-plane substitution rejected: named lane {lane}: {exc}")
+    _reject(f"malformed plane data rejected: named lane {lane}: {exc}")
+
+
+def _require_owner_mapping(raw: object, *, lane: str) -> Mapping[str, Any]:
+    if raw is None:
+        _reject(f"implicit absence rejected: named lane {lane} is missing")
+    if isinstance(raw, (list, tuple)):
+        _reject(f"ambiguous join rejected: named lane {lane} has multiple Package-N assignments")
+    if isinstance(raw, CrossLaneIdentityJoinV1):
+        _reject(f"static join record rejected: named lane {lane} is not a live owner payload")
+    if not isinstance(raw, Mapping):
+        _reject(f"malformed plane data rejected: named lane {lane} is not an object")
+    extra = sorted(str(key) for key in raw.keys() if str(key) not in _LANE_ENVELOPE_KEYS[lane])
+    if extra:
+        if extra[0] in NAMED_JOIN_LANES:
+            _reject(f"cross-lane substitution rejected: named lane {lane} contains {extra[0]}")
+        if extra[0] in {"plane_presence", "join_key"}:
+            _reject(f"cross-plane substitution rejected: named lane {lane} contains {extra[0]}")
+        if extra[0] in _NONCANONICAL_IDENTITY_KEYS:
+            _reject(f"noncanonical ID substitution rejected: named lane {lane} uses {extra[0]}")
+        _reject(f"malformed plane data rejected: named lane {lane} unknown field {extra[0]}")
+    looks_static = (
+        "plane_presence" in raw
+        and "experiment_identity_id" in raw
+        and "manifest" not in raw
+        and "live" not in raw
+    )
+    if looks_static:
+        _reject(f"static join record rejected: named lane {lane} is not a live owner payload")
+    return raw
+
+
+def _optional_sidecar(payload: Mapping[str, Any], key: str) -> str | None:
+    if key not in payload:
+        return None
+    value = payload[key]
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip() or value != value.strip():
+        _reject(f"malformed plane data rejected: sidecar {key} is invalid")
+    return value
+
+
+def _require_identity_sidecar(payload: Mapping[str, Any], *, lane: str) -> str:
+    if "experiment_identity_id" not in payload or payload.get("experiment_identity_id") is None:
+        _reject(f"implicit absence rejected: named lane {lane} IDENTITY is missing")
+    identity = payload.get("experiment_identity_id")
+    if not is_package_n_sha256_canonical_id(identity):
+        _reject(
+            "noncanonical ID substitution rejected: named lane "
+            f"{lane} IDENTITY is not Package-N SHA256"
+        )
+    return str(identity)
+
+
+def _require_live_payload(payload: Mapping[str, Any], *, lane: str) -> Mapping[str, Any]:
+    if "live" not in payload:
+        _reject(f"implicit absence rejected: named lane {lane} live payload is missing")
+    live = payload["live"]
+    if live is None:
+        _reject(f"implicit absence rejected: named lane {lane} live payload is missing")
+    if isinstance(live, (list, tuple)):
+        _reject(f"ambiguous join rejected: named lane {lane} live payload has multiple assignments")
+    if not isinstance(live, Mapping):
+        _reject(f"malformed plane data rejected: named lane {lane} live payload is not an object")
+    return live
+
+
+def _require_registrations() -> None:
+    for lane, checker in _REGISTRATION_CHECKERS.items():
+        if checker() is not True:
+            _reject(f"missing owner registration rejected: {lane}")
+
+
+def _traverse_i16(payload: Mapping[str, Any]) -> CrossLaneIdentityJoinV1:
+    if "manifest" not in payload or payload.get("manifest") is None:
+        _reject("implicit absence rejected: named lane I16 manifest is missing")
+    manifest = payload["manifest"]
+    if not isinstance(manifest, Mapping):
+        _reject("malformed plane data rejected: named lane I16 manifest is not an object")
+    artifact_path = payload.get("artifact_path", ARTIFACT_FILENAME)
+    if not isinstance(artifact_path, str) or not artifact_path.strip():
+        _reject("malformed plane data rejected: named lane I16 artifact_path is invalid")
+    run_id = _optional_sidecar(payload, "run_id")
+    campaign_id = _optional_sidecar(payload, "campaign_id")
+    session_id = _optional_sidecar(payload, "session_id")
+    ref_raw = payload.get("ref")
+    try:
+        if ref_raw is None:
+            ref = build_experiment_lineage_ref_from_manifest(
+                manifest,
+                artifact_path=artifact_path,
+                run_id=run_id,
+                campaign_id=campaign_id,
+                session_id=session_id,
+            )
+        elif not isinstance(ref_raw, LineageRef):
+            _reject("malformed plane data rejected: named lane I16 ref is not a LineageRef")
+            raise AssertionError("unreachable")
+        else:
+            ref = ref_raw
+        return join_i16_lineage_remaining_planes_v1(
+            manifest,
+            ref=ref,
+            artifact_path=artifact_path,
+            run_id=run_id,
+            campaign_id=campaign_id,
+            session_id=session_id,
+        )
+    except (
+        I16LineageRemainingPlanesLiveJoinError,
+        ExperimentLineageRefProducerError,
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+    ) as exc:
+        _raise_from_live(exc, lane="I16")
+        raise AssertionError("unreachable") from exc
+
+
+def _traverse_i17(payload: Mapping[str, Any]) -> CrossLaneIdentityJoinV1:
+    live = _require_live_payload(payload, lane="I17")
+    identity = _require_identity_sidecar(payload, lane="I17")
+    try:
+        result = parse_preregistration_contract_with_identity_join_v1(
+            live,
+            experiment_identity_id=identity,
+            run_id=_optional_sidecar(payload, "run_id"),
+            legacy_alias_md5_12=_optional_sidecar(payload, "legacy_alias_md5_12"),
+            content_sha256=_optional_sidecar(payload, "content_sha256"),
+            historical_provenance=payload.get("historical_provenance"),
+        )
+        return result.join
+    except (
+        I17PaperShadowNamedLaneIdentityJoinError,
+        PreregistrationContractError,
+        TypeError,
+        ValueError,
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+    ) as exc:
+        _raise_from_live(exc, lane="I17")
+        raise AssertionError("unreachable") from exc
+
+
+def _traverse_i52(payload: Mapping[str, Any]) -> CrossLaneIdentityJoinV1:
+    live = _require_live_payload(payload, lane="I52")
+    identity = _require_identity_sidecar(payload, lane="I52")
+    try:
+        result = parse_levelup_manifest_with_identity_join_v1(
+            live,
+            experiment_identity_id=identity,
+            run_id=_optional_sidecar(payload, "run_id"),
+            campaign_id=_optional_sidecar(payload, "campaign_id"),
+            session_id=_optional_sidecar(payload, "session_id"),
+            legacy_alias_md5_12=_optional_sidecar(payload, "legacy_alias_md5_12"),
+            content_sha256=_optional_sidecar(payload, "content_sha256"),
+            evidence_ref=_optional_sidecar(payload, "evidence_ref"),
+            historical_provenance=payload.get("historical_provenance"),
+        )
+        return result.join
+    except (
+        I52LevelUpNamedLaneIdentityJoinError,
+        TypeError,
+        ValueError,
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+    ) as exc:
+        _raise_from_live(exc, lane="I52")
+        raise AssertionError("unreachable") from exc
+
+
+def _traverse_i56(payload: Mapping[str, Any]) -> CrossLaneIdentityJoinV1:
+    live = _require_live_payload(payload, lane="I56")
+    identity = _require_identity_sidecar(payload, lane="I56")
+    if "run_id" in payload:
+        _reject("noncanonical ID substitution rejected: named lane I56 uses run_id")
+    try:
+        result = parse_evidence_capsule_with_identity_join_v1(
+            live,
+            experiment_identity_id=identity,
+            campaign_id=_optional_sidecar(payload, "campaign_id"),
+            session_id=_optional_sidecar(payload, "session_id"),
+            legacy_alias_md5_12=_optional_sidecar(payload, "legacy_alias_md5_12"),
+            content_sha256=_optional_sidecar(payload, "content_sha256"),
+            evidence_ref=_optional_sidecar(payload, "evidence_ref"),
+            historical_provenance=payload.get("historical_provenance"),
+        )
+        return result.join
+    except (
+        I56IngressNamedLaneIdentityJoinError,
+        TypeError,
+        ValueError,
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+    ) as exc:
+        _raise_from_live(exc, lane="I56")
+        raise AssertionError("unreachable") from exc
+
+
+def _traverse_i61(payload: Mapping[str, Any]) -> CrossLaneIdentityJoinV1:
+    live = _require_live_payload(payload, lane="I61")
+    identity = _require_identity_sidecar(payload, lane="I61")
+    try:
+        result = parse_live_session_metrics_with_identity_join_v1(
+            live,
+            experiment_identity_id=identity,
+            run_id=_optional_sidecar(payload, "run_id"),
+            campaign_id=_optional_sidecar(payload, "campaign_id"),
+            session_id=_optional_sidecar(payload, "session_id"),
+            session_dir=_optional_sidecar(payload, "session_dir"),
+            legacy_alias_md5_12=_optional_sidecar(payload, "legacy_alias_md5_12"),
+            content_sha256=_optional_sidecar(payload, "content_sha256"),
+            evidence_ref=_optional_sidecar(payload, "evidence_ref"),
+            historical_provenance=payload.get("historical_provenance"),
+        )
+        return result.join
+    except (
+        I61LiveEvalNamedLaneIdentityJoinError,
+        TypeError,
+        ValueError,
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+    ) as exc:
+        _raise_from_live(exc, lane="I61")
+        raise AssertionError("unreachable") from exc
+
+
+def _traverse_i65(payload: Mapping[str, Any]) -> CrossLaneIdentityJoinV1:
+    live = _require_live_payload(payload, lane="I65")
+    identity = _require_identity_sidecar(payload, lane="I65")
+    if "run_id" in payload:
+        _reject("noncanonical ID substitution rejected: named lane I65 uses run_id")
+    try:
+        result = parse_experiment_summary_with_identity_join_v1(
+            live,
+            experiment_identity_id=identity,
+            campaign_id=_optional_sidecar(payload, "campaign_id"),
+            session_id=_optional_sidecar(payload, "session_id"),
+            legacy_alias_md5_12=_optional_sidecar(payload, "legacy_alias_md5_12"),
+            content_sha256=_optional_sidecar(payload, "content_sha256"),
+            evidence_ref=_optional_sidecar(payload, "evidence_ref"),
+            historical_provenance=payload.get("historical_provenance"),
+        )
+        return result.join
+    except (
+        I65ExplorerNamedLaneIdentityJoinError,
+        TypeError,
+        ValueError,
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+    ) as exc:
+        _raise_from_live(exc, lane="I65")
+        raise AssertionError("unreachable") from exc
+
+
+_TRAVERSERS: Mapping[str, Any] = MappingProxyType(
+    {
+        "I16": _traverse_i16,
+        "I17": _traverse_i17,
+        "I52": _traverse_i52,
+        "I56": _traverse_i56,
+        "I61": _traverse_i61,
+        "I65": _traverse_i65,
+    }
+)
+
+
+@dataclass(frozen=True)
+class EgI82GraphEdgeAttestationV1:
+    edge_id: str
+    lane: str
+    plane: str
+    presence: str
+    canonical_join_key: str
+    proven: bool
+
+    def to_canonical_mapping(self) -> dict[str, Any]:
+        return {
+            "edge_id": self.edge_id,
+            "lane": self.lane,
+            "plane": self.plane,
+            "presence": self.presence,
+            "canonical_join_key": self.canonical_join_key,
+            "proven": self.proven,
+        }
+
+
+def require_eg_i82_complete_live_edge_matrix_v1(
+    edges: Sequence[Mapping[str, Any]],
+    *,
+    package_n_sha256: str,
+) -> tuple[EgI82GraphEdgeAttestationV1, ...]:
+    """Fail-closed exact 42-edge matrix. Extra edges are never part of the canonical graph."""
+    if not is_package_n_sha256_canonical_id(package_n_sha256):
+        _reject("noncanonical ID substitution rejected: graph join key is not Package-N SHA256")
+    if not isinstance(edges, Sequence) or isinstance(edges, (str, bytes)):
+        _reject("malformed plane data rejected: edge matrix is not a sequence")
+
+    seen: dict[str, Mapping[str, Any]] = {}
+    for item in edges:
+        if not isinstance(item, Mapping):
+            _reject("malformed plane data rejected: edge entry is not an object")
+        lane = item.get("lane")
+        plane = item.get("plane")
+        edge_id = item.get("edge_id")
+        if edge_id is None and isinstance(lane, str) and isinstance(plane, str):
+            edge_id = f"{lane}x{plane}"
+        if not isinstance(edge_id, str) or not edge_id.strip():
+            _reject("malformed plane data rejected: edge_id missing")
+        if edge_id in seen:
+            _reject(f"duplicate/conflicting edge registration rejected: {edge_id}")
+        if edge_id not in REQUIRED_GRAPH_EDGE_IDS:
+            _reject(
+                f"unexpected extra edge rejected: {edge_id} is not part of the canonical 42-edge graph"
+            )
+        parts = edge_id.split("x", 1)
+        if len(parts) != 2:
+            _reject(f"malformed plane data rejected: edge_id {edge_id}")
+        derived_lane, derived_plane = parts
+        if lane is None:
+            lane = derived_lane
+        if plane is None:
+            plane = derived_plane
+        if lane != derived_lane or plane != derived_plane:
+            _reject(f"malformed plane data rejected: edge {edge_id} lane/plane mismatch")
+        if lane not in NAMED_JOIN_LANES:
+            _reject(
+                f"unexpected extra edge rejected: {edge_id} is not part of the canonical 42-edge graph"
+            )
+        if plane not in JOIN_PLANES:
+            _reject(
+                f"unexpected extra edge rejected: {edge_id} is not part of the canonical 42-edge graph"
+            )
+        presence = item.get("presence")
+        if presence not in (
+            PlanePresence.PRESENT.value,
+            PlanePresence.ABSENT_DECLARED.value,
+        ):
+            _reject(f"implicit absence rejected: {edge_id} presence is not declared")
+        join_key = item.get("canonical_join_key", package_n_sha256)
+        if join_key != package_n_sha256:
+            _reject(f"conflicting identity rejected: {edge_id} join key disagrees")
+        if not is_package_n_sha256_canonical_id(join_key):
+            _reject(f"noncanonical ID substitution rejected: {edge_id} join key")
+        seen[edge_id] = item
+
+    missing = [edge_id for edge_id in REQUIRED_GRAPH_EDGE_IDS if edge_id not in seen]
+    if missing:
+        _reject(f"missing required edge rejected: {missing[0]}")
+
+    attested: list[EgI82GraphEdgeAttestationV1] = []
+    for edge_id in REQUIRED_GRAPH_EDGE_IDS:
+        item = seen[edge_id]
+        lane, plane = edge_id.split("x", 1)
+        attested.append(
+            EgI82GraphEdgeAttestationV1(
+                edge_id=edge_id,
+                lane=str(item.get("lane", lane)),
+                plane=str(item.get("plane", plane)),
+                presence=str(item["presence"]),
+                canonical_join_key=package_n_sha256,
+                proven=True,
+            )
+        )
+    return tuple(attested)
+
+
+def _edges_from_live_records(
+    records: Mapping[str, CrossLaneIdentityJoinV1],
+    *,
+    package_n_sha256: str,
+) -> list[dict[str, Any]]:
+    edges: list[dict[str, Any]] = []
+    for lane in NAMED_JOIN_LANES:
+        record = records[lane]
+        presence_map = record.plane_presence
+        identity = record.experiment_identity_id
+        if identity != package_n_sha256:
+            _reject(f"conflicting identity rejected: named lane {lane} IDENTITY disagrees")
+        if presence_map.get("IDENTITY") != PlanePresence.PRESENT.value:
+            _reject(f"missing required edge rejected: {lane}xIDENTITY must be PRESENT")
+        for plane in JOIN_PLANES:
+            if plane not in presence_map:
+                _reject(f"missing required edge rejected: {lane}x{plane}")
+            presence = presence_map[plane]
+            if presence not in (
+                PlanePresence.PRESENT.value,
+                PlanePresence.ABSENT_DECLARED.value,
+            ):
+                _reject(f"implicit absence rejected: {lane}x{plane}")
+            if presence == PlanePresence.PRESENT.value:
+                value = getattr(record, PLANE_VALUE_FIELDS[plane])
+                if value is None:
+                    _reject(f"implicit absence rejected: {lane}x{plane} PRESENT without value")
+            edges.append(
+                {
+                    "edge_id": f"{lane}x{plane}",
+                    "lane": lane,
+                    "plane": plane,
+                    "presence": presence,
+                    "canonical_join_key": package_n_sha256,
+                }
+            )
+    return edges
+
+
+@dataclass(frozen=True)
+class EgI82EndToEndLiveOwnerGraphAttestationV1:
+    schema_version: str
+    contract_version: str
+    contract_id: str
+    attestation_registered: bool
+    package_n_sha256: str
+    live_owner_paths: Mapping[str, str]
+    named_lanes: tuple[str, ...]
+    expected_edge_count: int
+    edges_evaluated: int
+    edges_proven: int
+    edges_disproven: int
+    edges_not_proven: int
+    edges_not_applicable: int
+    all_required_edges_proven: bool
+    static_flag_aggregation_only: bool
+    full_graph_traversal: bool
+    end_to_end_join_graph_proven: bool
+    eg_i82_join_closure_proven: bool
+    eg_i82_join_status: str
+    edges: tuple[EgI82GraphEdgeAttestationV1, ...]
+    lane_identity_presence: Mapping[str, str]
+    safety: Mapping[str, Any]
+
+    def to_canonical_mapping(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "contract_version": self.contract_version,
+            "contract_id": self.contract_id,
+            "attestation_registered": self.attestation_registered,
+            "package_n_sha256": self.package_n_sha256,
+            "live_owner_paths": {lane: REAL_LIVE_OWNER_PATHS[lane] for lane in NAMED_JOIN_LANES},
+            "named_lanes": list(self.named_lanes),
+            "expected_edge_count": self.expected_edge_count,
+            "edges_evaluated": self.edges_evaluated,
+            "edges_proven": self.edges_proven,
+            "edges_disproven": self.edges_disproven,
+            "edges_not_proven": self.edges_not_proven,
+            "edges_not_applicable": self.edges_not_applicable,
+            "all_required_edges_proven": self.all_required_edges_proven,
+            "static_flag_aggregation_only": self.static_flag_aggregation_only,
+            "full_graph_traversal": self.full_graph_traversal,
+            "end_to_end_join_graph_proven": self.end_to_end_join_graph_proven,
+            "eg_i82_join_closure_proven": self.eg_i82_join_closure_proven,
+            "eg_i82_join_status": self.eg_i82_join_status,
+            "edges": [edge.to_canonical_mapping() for edge in self.edges],
+            "lane_identity_presence": {
+                lane: self.lane_identity_presence[lane] for lane in NAMED_JOIN_LANES
+            },
+            "safety": copy.deepcopy(dict(self.safety)),
+        }
+
+
+def attest_eg_i82_end_to_end_live_owner_graph_v1(
+    owners: Mapping[str, Any],
+) -> EgI82EndToEndLiveOwnerGraphAttestationV1:
+    """Traverse live-owner contracts and attest the canonical 42-edge join graph."""
+    if not isinstance(owners, Mapping):
+        _reject("malformed plane data rejected: owners root must be an object")
+    snapshot = _snapshot(owners)
+    extra = sorted(str(key) for key in owners.keys() if str(key) not in NAMED_JOIN_LANES)
+    if extra:
+        if extra[0] in _NONCANONICAL_IDENTITY_KEYS:
+            _reject(f"noncanonical ID substitution rejected: context key {extra[0]}")
+        _reject(
+            f"unexpected extra edge rejected: {extra[0]} is not part of the canonical 42-edge graph"
+        )
+    missing_owners = [lane for lane in NAMED_JOIN_LANES if lane not in owners]
+    if missing_owners:
+        _reject(f"implicit absence rejected: named lane {missing_owners[0]} is missing")
+
+    _require_registrations()
+
+    records: dict[str, CrossLaneIdentityJoinV1] = {}
+    for lane in NAMED_JOIN_LANES:
+        payload = _require_owner_mapping(owners[lane], lane=lane)
+        records[lane] = _TRAVERSERS[lane](payload)
+
+    try:
+        cross = verify_eg_i82_cross_lane_join_v1(records)
+    except EgI82JoinVerifierError as exc:
+        _raise_from_live(exc, lane="GRAPH")
+        raise AssertionError("unreachable") from exc
+
+    package_n = cross.package_n_sha256
+    if not is_package_n_sha256_canonical_id(package_n):
+        _reject("noncanonical ID substitution rejected: agreed identity is not Package-N SHA256")
+    for lane, record in records.items():
+        if record.experiment_identity_id != package_n:
+            _reject(f"conflicting identity rejected: named lane {lane} IDENTITY disagrees")
+        if record.plane_presence.get("IDENTITY") != PlanePresence.PRESENT.value:
+            _reject(f"missing required edge rejected: {lane}xIDENTITY must be PRESENT")
+
+    raw_edges = _edges_from_live_records(records, package_n_sha256=str(package_n))
+    attested_edges = require_eg_i82_complete_live_edge_matrix_v1(
+        raw_edges,
+        package_n_sha256=str(package_n),
+    )
+    proven_count = sum(1 for edge in attested_edges if edge.proven)
+    closed = (
+        len(attested_edges) == EXPECTED_EDGE_COUNT
+        and proven_count == EXPECTED_EDGE_COUNT
+        and all(edge.canonical_join_key == package_n for edge in attested_edges)
+    )
+    if not closed:
+        _reject("missing required edge rejected: live-owner graph is incomplete")
+
+    if _snapshot(owners) != snapshot:
+        _reject("owners input was mutated")
+
+    return EgI82EndToEndLiveOwnerGraphAttestationV1(
+        schema_version=CONTRACT_VERSION,
+        contract_version=CONTRACT_VERSION,
+        contract_id=CONTRACT_ID,
+        attestation_registered=True,
+        package_n_sha256=str(package_n),
+        live_owner_paths=REAL_LIVE_OWNER_PATHS,
+        named_lanes=NAMED_JOIN_LANES,
+        expected_edge_count=EXPECTED_EDGE_COUNT,
+        edges_evaluated=EXPECTED_EDGE_COUNT,
+        edges_proven=EXPECTED_EDGE_COUNT,
+        edges_disproven=0,
+        edges_not_proven=0,
+        edges_not_applicable=0,
+        all_required_edges_proven=True,
+        static_flag_aggregation_only=False,
+        full_graph_traversal=True,
+        end_to_end_join_graph_proven=True,
+        eg_i82_join_closure_proven=True,
+        eg_i82_join_status="CLOSED_PROVEN",
+        edges=attested_edges,
+        lane_identity_presence=MappingProxyType(
+            {lane: records[lane].plane_presence["IDENTITY"] for lane in NAMED_JOIN_LANES}
+        ),
+        safety=_freeze_mapping(
+            {
+                "runtime_authority_impact": RUNTIME_AUTHORITY_IMPACT,
+                "evidence_does_not_authorize_runtime": True,
+                "MULTI_FUTURE_RUNTIME_AUTHORIZED": MULTI_FUTURE_RUNTIME_AUTHORIZED,
+                "SECOND_EXECUTION_AUTHORITY_AUTHORIZED": SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+                "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS": (
+                    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS
+                ),
+            }
+        ),
+    )
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "EG_I82_END_TO_END_LIVE_OWNER_GRAPH_ATTESTATION_REGISTERED",
+    "EXPECTED_EDGE_COUNT",
+    "EXPECTED_LANE_COUNT",
+    "EXPECTED_OWNER_COUNT",
+    "EgI82EndToEndLiveOwnerGraphAttestationError",
+    "EgI82EndToEndLiveOwnerGraphAttestationV1",
+    "EgI82GraphEdgeAttestationV1",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "REAL_LIVE_OWNER_PATHS",
+    "REQUIRED_GRAPH_EDGE_IDS",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "attest_eg_i82_end_to_end_live_owner_graph_v1",
+    "is_eg_i82_end_to_end_live_owner_graph_attestation_registered",
+    "require_eg_i82_complete_live_edge_matrix_v1",
+]

--- a/src/experiments/eg_i82_join_verifier_v1.py
+++ b/src/experiments/eg_i82_join_verifier_v1.py
@@ -1,0 +1,317 @@
+"""EG-I82-JOIN U-I82-R11 — dormant fail-closed cross-lane join verifier.
+
+Proof surface only. Compares named-lane join records against Package-N SHA256.
+Does not register I17/I52/I56/I61/I65 live contracts, does not activate
+Cap 7.2 or src.execution, and does not persist, migrate, or backfill.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping, Sequence
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    CONTRACT_VERSION,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    JOIN_PLANES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    PLANE_VALUE_FIELDS,
+    PlanePresence,
+    RUNTIME_AUTHORITY_IMPACT,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinError,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+    validate_cross_lane_identity_join_v1,
+)
+
+CONTRACT_ID = "eg_i82_join_verifier_v1"
+EG_I82_CROSS_LANE_VERIFIER_REGISTERED = True
+
+NAMED_JOIN_LANES: tuple[str, ...] = ("I16", "I17", "I52", "I56", "I61", "I65")
+LANE_DORMANT_CONTRACT_IDS: Mapping[str, str] = MappingProxyType(
+    {
+        "I16": "i16_package_n_join_emission_v1",
+        "I17": "i17_paper_shadow_join_attachment_v1",
+        "I52": "i52_levelup_join_attachment_v1",
+        "I56": "i56_ingress_join_attachment_v1",
+        "I61": "live_session_eval_identity_envelope_v1",
+        "I65": "i65_explorer_join_attachment_v1",
+    }
+)
+
+_NONCANONICAL_IDENTITY_KEYS = frozenset(
+    {
+        "run_id",
+        "experiment_id",
+        "campaign_id",
+        "session_id",
+        "evidence_id",
+        "evidence_ref",
+        "alias",
+        "legacy_alias_md5_12",
+        "legacy_experiment_id",
+        "package_n_sha256",
+        "canonical_id",
+        "canonical_identity_id",
+        "identity_id",
+        "ref_id",
+        "content_sha256",
+    }
+)
+_NON_IDENTITY_PLANES = tuple(plane for plane in JOIN_PLANES if plane != "IDENTITY")
+
+
+class EgI82JoinVerifierError(ValueError):
+    """Fail-closed EG-I82 cross-lane join verifier error."""
+
+
+def _reject(message: str) -> None:
+    raise EgI82JoinVerifierError(message)
+
+
+def is_eg_i82_cross_lane_verifier_registered() -> bool:
+    """True iff the dormant cross-lane verifier is registered and reachable."""
+    return EG_I82_CROSS_LANE_VERIFIER_REGISTERED is True
+
+
+def _freeze_mapping(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    frozen: dict[str, Any] = {}
+    for key, value in payload.items():
+        if isinstance(value, Mapping):
+            frozen[str(key)] = _freeze_mapping(value)
+        elif isinstance(value, list):
+            frozen[str(key)] = tuple(
+                _freeze_mapping(item) if isinstance(item, Mapping) else copy.deepcopy(item)
+                for item in value
+            )
+        else:
+            frozen[str(key)] = copy.deepcopy(value)
+    return MappingProxyType(frozen)
+
+
+def _snapshot_lane_payload(raw: object, *, lane: str) -> dict[str, Any]:
+    if raw is None:
+        _reject(f"implicit absence rejected: named lane {lane} is missing")
+    if isinstance(raw, CrossLaneIdentityJoinV1):
+        return raw.to_canonical_mapping()
+    if isinstance(raw, Sequence) and not isinstance(raw, (str, bytes, Mapping)):
+        if not raw:
+            _reject(f"implicit absence rejected: named lane {lane} is missing")
+        if len(raw) != 1:
+            _reject(
+                f"ambiguous join rejected: named lane {lane} has multiple Package-N assignments"
+            )
+        return _snapshot_lane_payload(raw[0], lane=lane)
+    if not isinstance(raw, Mapping):
+        _reject(f"malformed plane data rejected: named lane {lane} is not an object")
+    return copy.deepcopy(dict(raw))
+
+
+def _reject_noncanonical_lane_payload(payload: Mapping[str, Any], *, lane: str) -> None:
+    if "plane_presence" in payload:
+        return
+    substitutes = sorted(key for key in payload.keys() if str(key) in _NONCANONICAL_IDENTITY_KEYS)
+    if substitutes:
+        _reject(
+            f"noncanonical ID substitution rejected: named lane {lane} uses {substitutes[0]} "
+            "as Package-N identity"
+        )
+    _reject(f"implicit absence rejected: named lane {lane} has no declared plane_presence")
+
+
+def _classify_r1_error(exc: CrossLaneIdentityJoinError, *, lane: str) -> None:
+    message = str(exc)
+    lowered = message.lower()
+    if (
+        "canonical package-n sha256 id missing" in lowered
+        or "is required when" in lowered
+        or "status is missing" in lowered
+        or "missing required plane status" in lowered
+    ):
+        _reject(f"implicit absence rejected: named lane {lane}: {exc}")
+    if (
+        "uuid/run_id" in lowered
+        or "md5 alias" in lowered
+        or "not a package-n" in lowered
+        or "extra identity claim" in lowered
+    ):
+        _reject(f"noncanonical ID substitution rejected: named lane {lane}: {exc}")
+    if "conflicting" in lowered:
+        _reject(f"conflicting identity rejected: named lane {lane}: {exc}")
+    if "unknown" in lowered or "must be" in lowered or "malformed" in lowered:
+        _reject(f"malformed plane data rejected: named lane {lane}: {exc}")
+    _reject(f"malformed plane data rejected: named lane {lane}: {exc}")
+
+
+def _validate_lane_record(payload: Mapping[str, Any], *, lane: str) -> CrossLaneIdentityJoinV1:
+    _reject_noncanonical_lane_payload(payload, lane=lane)
+    try:
+        return validate_cross_lane_identity_join_v1(payload)
+    except CrossLaneIdentityJoinError as exc:
+        _classify_r1_error(exc, lane=lane)
+        raise AssertionError("unreachable") from exc
+
+
+def _plane_value(record: CrossLaneIdentityJoinV1, plane: str) -> str | None:
+    return getattr(record, PLANE_VALUE_FIELDS[plane])
+
+
+def _reject_cross_plane_substitution(records: Mapping[str, CrossLaneIdentityJoinV1]) -> None:
+    for lane, record in records.items():
+        identity = record.experiment_identity_id
+        if identity is None:
+            continue
+        if not is_package_n_sha256_canonical_id(identity):
+            _reject(f"noncanonical ID substitution rejected: named lane {lane}")
+        for plane in _NON_IDENTITY_PLANES:
+            other = _plane_value(record, plane)
+            if other is not None and other == identity:
+                _reject(
+                    f"cross-plane substitution rejected: named lane {lane} IDENTITY equals {plane}"
+                )
+
+
+def _reject_cross_lane_substitution(records: Mapping[str, CrossLaneIdentityJoinV1]) -> None:
+    for lane, record in records.items():
+        identity = record.experiment_identity_id
+        if identity is None:
+            continue
+        for other_lane, other_record in records.items():
+            if other_lane == lane:
+                continue
+            for plane in _NON_IDENTITY_PLANES:
+                other = _plane_value(other_record, plane)
+                if other is not None and other == identity:
+                    _reject(
+                        "cross-lane substitution rejected: "
+                        f"{lane} IDENTITY equals {other_lane} {plane}"
+                    )
+
+
+@dataclass(frozen=True)
+class EgI82CrossLaneJoinVerificationV1:
+    schema_version: str
+    contract_version: str
+    contract_id: str
+    verifier_registered: bool
+    package_n_sha256: str | None
+    lane_identity_presence: Mapping[str, str]
+    named_lanes: tuple[str, ...]
+    safety: Mapping[str, Any]
+
+    def to_canonical_mapping(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "contract_version": self.contract_version,
+            "contract_id": self.contract_id,
+            "verifier_registered": self.verifier_registered,
+            "package_n_sha256": self.package_n_sha256,
+            "lane_identity_presence": {
+                lane: self.lane_identity_presence[lane] for lane in NAMED_JOIN_LANES
+            },
+            "named_lanes": list(self.named_lanes),
+            "safety": copy.deepcopy(dict(self.safety)),
+        }
+
+
+def _mapping_snapshot(raw: Mapping[str, Any]) -> dict[str, Any]:
+    snapshot: dict[str, Any] = {}
+    for key, value in raw.items():
+        if isinstance(value, Mapping):
+            snapshot[str(key)] = _mapping_snapshot(value)
+        elif isinstance(value, list):
+            snapshot[str(key)] = [
+                _mapping_snapshot(item) if isinstance(item, Mapping) else copy.deepcopy(item)
+                for item in value
+            ]
+        else:
+            snapshot[str(key)] = copy.deepcopy(value)
+    return snapshot
+
+
+def verify_eg_i82_cross_lane_join_v1(
+    lanes: Mapping[str, Any],
+) -> EgI82CrossLaneJoinVerificationV1:
+    """Verify join consistency across named lanes. Does not mutate inputs or persist."""
+    if not isinstance(lanes, Mapping):
+        _reject("malformed plane data rejected: lanes root must be an object")
+    extra = sorted(str(key) for key in lanes.keys() if str(key) not in NAMED_JOIN_LANES)
+    if extra:
+        if extra[0] in _NONCANONICAL_IDENTITY_KEYS:
+            _reject(f"noncanonical ID substitution rejected: context key {extra[0]}")
+        _reject(f"malformed plane data rejected: unknown join lane {extra[0]}")
+
+    missing = [lane for lane in NAMED_JOIN_LANES if lane not in lanes]
+    if missing:
+        _reject(f"implicit absence rejected: named lane {missing[0]} is missing")
+
+    records: dict[str, CrossLaneIdentityJoinV1] = {}
+    mapping_snapshots: dict[str, dict[str, Any]] = {}
+    for lane in NAMED_JOIN_LANES:
+        raw = lanes[lane]
+        if isinstance(raw, Mapping) and not isinstance(raw, CrossLaneIdentityJoinV1):
+            mapping_snapshots[lane] = _mapping_snapshot(raw)
+        payload = _snapshot_lane_payload(raw, lane=lane)
+        records[lane] = _validate_lane_record(payload, lane=lane)
+
+    present_ids = [
+        record.experiment_identity_id
+        for record in records.values()
+        if record.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    ]
+    if any(item is None for item in present_ids):
+        _reject("implicit absence rejected: IDENTITY PRESENT without Package-N SHA256")
+    _reject_cross_plane_substitution(records)
+    _reject_cross_lane_substitution(records)
+    distinct = {item for item in present_ids if item is not None}
+    if len(distinct) > 1:
+        _reject("conflicting identity rejected: Package-N SHA256 values disagree across lanes")
+    agreed = next(iter(distinct)) if distinct else None
+    if agreed is not None and not is_package_n_sha256_canonical_id(agreed):
+        _reject("noncanonical ID substitution rejected: agreed identity is not Package-N SHA256")
+
+    for lane, snap in mapping_snapshots.items():
+        current = lanes[lane]
+        if not isinstance(current, Mapping) or _mapping_snapshot(current) != snap:
+            _reject("lanes input was mutated")
+
+    return EgI82CrossLaneJoinVerificationV1(
+        schema_version=CONTRACT_VERSION,
+        contract_version=CONTRACT_VERSION,
+        contract_id=CONTRACT_ID,
+        verifier_registered=True,
+        package_n_sha256=agreed,
+        lane_identity_presence=MappingProxyType(
+            {lane: records[lane].plane_presence["IDENTITY"] for lane in NAMED_JOIN_LANES}
+        ),
+        named_lanes=NAMED_JOIN_LANES,
+        safety=_freeze_mapping(
+            {
+                "runtime_authority_impact": RUNTIME_AUTHORITY_IMPACT,
+                "evidence_does_not_authorize_runtime": True,
+                "MULTI_FUTURE_RUNTIME_AUTHORIZED": MULTI_FUTURE_RUNTIME_AUTHORIZED,
+                "SECOND_EXECUTION_AUTHORITY_AUTHORIZED": SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+                "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS": (
+                    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS
+                ),
+            }
+        ),
+    )
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "EG_I82_CROSS_LANE_VERIFIER_REGISTERED",
+    "EgI82CrossLaneJoinVerificationV1",
+    "EgI82JoinVerifierError",
+    "LANE_DORMANT_CONTRACT_IDS",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "NAMED_JOIN_LANES",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "is_eg_i82_cross_lane_verifier_registered",
+    "verify_eg_i82_cross_lane_join_v1",
+]

--- a/src/experiments/i16_package_n_join_emission_v1.py
+++ b/src/experiments/i16_package_n_join_emission_v1.py
@@ -1,0 +1,123 @@
+"""EG-I82-JOIN U-I82-R10 — dormant I16 Package-N producer join emission.
+
+Registers the R4 I16 join attachment at the Package-N producer boundary.
+Canonical join key is experiment_identity_id from build_manifest only.
+Does not rewrite experiment_identity_manifest_v1.json, does not hook
+produce()/CLI/ExperimentRunner, and does not import Cap 7.2 or src.execution.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+)
+from src.experiments.experiment_identity_manifest_v1 import (
+    ExperimentIdentityManifestError,
+    build_manifest,
+    validate_experiment_identity_manifest_v1,
+)
+from src.governance.promotion_loop.i16_remaining_planes_join_attachment_v1 import (
+    I16RemainingPlanesJoinAttachmentError,
+    attach_i16_remaining_planes_join_v1,
+)
+
+CONTRACT_ID = "i16_package_n_join_emission_v1"
+
+_FORBIDDEN_MANIFEST_JOIN_KEYS = frozenset(
+    {
+        "run_id",
+        "campaign_id",
+        "session_id",
+        "experiment_id",
+        "registry_run_id",
+        "mlflow_run_id",
+        "orders",
+        "credentials",
+    }
+)
+
+
+class I16PackageNJoinEmissionError(ValueError):
+    """Fail-closed I16 Package-N producer join emission error."""
+
+
+def _reject(message: str) -> None:
+    raise I16PackageNJoinEmissionError(message)
+
+
+def emit_i16_package_n_join_v1(
+    package_n_manifest: Mapping[str, Any],
+) -> CrossLaneIdentityJoinV1:
+    """Emit an I16 join record from a canonical Package-N producer manifest."""
+    if not isinstance(package_n_manifest, Mapping):
+        _reject("Package-N manifest must be an object")
+    snapshot = copy.deepcopy(dict(package_n_manifest))
+    forbidden = sorted(
+        str(key) for key in package_n_manifest.keys() if str(key) in _FORBIDDEN_MANIFEST_JOIN_KEYS
+    )
+    if forbidden:
+        _reject(f"noncanonical ID substitution rejected: {forbidden[0]}")
+    try:
+        validate_experiment_identity_manifest_v1(package_n_manifest)
+    except ExperimentIdentityManifestError as exc:
+        raise I16PackageNJoinEmissionError(f"malformed Package-N producer manifest: {exc}") from exc
+
+    identity_id = package_n_manifest.get("experiment_identity_id")
+    if not is_package_n_sha256_canonical_id(identity_id):
+        _reject("experiment_identity_id must be Package-N SHA256")
+
+    provenance = package_n_manifest.get("provenance")
+    if provenance is not None and not isinstance(provenance, Mapping):
+        _reject("historical_provenance must be an object")
+    provenance_copy = copy.deepcopy(dict(provenance)) if isinstance(provenance, Mapping) else {}
+    source_id = provenance_copy.get("source_experiment_id")
+    if source_id is not None and source_id == identity_id:
+        _reject("source_experiment_id must not substitute for Package-N SHA256 IDENTITY")
+
+    payload = {
+        "experiment_identity_id": identity_id,
+        "legacy_aliases": copy.deepcopy(dict(package_n_manifest["legacy_aliases"])),
+        "integrity": copy.deepcopy(dict(package_n_manifest["integrity"])),
+        "historical_provenance": provenance_copy or None,
+    }
+    if payload["historical_provenance"] is None:
+        payload.pop("historical_provenance")
+
+    try:
+        record = attach_i16_remaining_planes_join_v1(payload)
+    except I16RemainingPlanesJoinAttachmentError as exc:
+        raise I16PackageNJoinEmissionError(
+            f"I16 producer join rejected by R4 attachment: {exc}"
+        ) from exc
+
+    if dict(package_n_manifest) != snapshot:
+        _reject("Package-N manifest input was mutated")
+    return record
+
+
+def emit_i16_package_n_join_from_producer_v1(
+    config: Any,
+    *,
+    source_experiment_id: str | None = None,
+) -> CrossLaneIdentityJoinV1:
+    """Build a Package-N manifest via the producer, then emit the I16 join."""
+    manifest = build_manifest(config, source_experiment_id=source_experiment_id)
+    return emit_i16_package_n_join_v1(manifest)
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "I16PackageNJoinEmissionError",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "emit_i16_package_n_join_from_producer_v1",
+    "emit_i16_package_n_join_v1",
+]

--- a/src/governance/promotion_loop/experiment_lineage_ref_producer_v1.py
+++ b/src/governance/promotion_loop/experiment_lineage_ref_producer_v1.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Mapping
 
+from src.experiments.cross_lane_identity_join_v1 import CrossLaneIdentityJoinV1
 from src.experiments.experiment_identity_manifest_v1 import (
     ARTIFACT_FILENAME,
     ExperimentIdentityManifestError,
@@ -18,6 +19,10 @@ from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
     LineageRelation,
     lineage_ref_from_mapping,
     lineage_ref_to_mapping,
+)
+from src.governance.promotion_loop.i16_lineage_remaining_planes_live_join_v1 import (
+    I16LineageRemainingPlanesLiveJoinError,
+    join_i16_lineage_remaining_planes_v1,
 )
 from src.meta.learning_loop.contract_safety_v1 import deterministic_json_dumps
 
@@ -34,6 +39,7 @@ class ExperimentLineageRefProducerResult:
     manifest_dir: Path
     manifest_path: Path
     ref: LineageRef
+    join: CrossLaneIdentityJoinV1
 
 
 def _resolve_existing_directory(manifest_dir: Path) -> Path:
@@ -109,12 +115,38 @@ def _load_validated_manifest(manifest_dir: Path) -> tuple[dict[str, Any], Path]:
     return raw, manifest_path
 
 
-def build_experiment_lineage_ref_from_manifest(
+def _attach_i16_remaining_planes_join(
+    manifest: Mapping[str, Any],
+    ref: LineageRef,
+    *,
+    artifact_path: str,
+    run_id: str | None,
+    campaign_id: str | None,
+    session_id: str | None,
+) -> CrossLaneIdentityJoinV1:
+    try:
+        return join_i16_lineage_remaining_planes_v1(
+            manifest,
+            ref=ref,
+            artifact_path=artifact_path,
+            run_id=run_id,
+            campaign_id=campaign_id,
+            session_id=session_id,
+        )
+    except I16LineageRemainingPlanesLiveJoinError as exc:
+        raise ExperimentLineageRefProducerError(
+            f"I16 remaining-plane join rejected: {exc}"
+        ) from exc
+
+
+def _build_experiment_lineage_ref_and_join(
     manifest: Mapping[str, Any],
     *,
-    artifact_path: str = ARTIFACT_FILENAME,
-) -> LineageRef:
-    """Build a validated EXPERIMENT LineageRef from an already validated Package N manifest."""
+    artifact_path: str,
+    run_id: str | None,
+    campaign_id: str | None,
+    session_id: str | None,
+) -> tuple[LineageRef, CrossLaneIdentityJoinV1]:
     _validate_artifact_relative_path(artifact_path)
 
     experiment_identity_id = manifest.get("experiment_identity_id")
@@ -128,7 +160,7 @@ def build_experiment_lineage_ref_from_manifest(
     if not isinstance(content_sha256, str) or not content_sha256.strip():
         raise ExperimentLineageRefProducerError("integrity.content_sha256 missing or invalid")
 
-    return LineageRef(
+    ref = LineageRef(
         ref_type=LineageRefType.EXPERIMENT,
         ref_id=experiment_identity_id,
         relation=LineageRelation.SOURCES,
@@ -137,20 +169,58 @@ def build_experiment_lineage_ref_from_manifest(
         digest=content_sha256,
         artifact_path=artifact_path,
     )
+    join = _attach_i16_remaining_planes_join(
+        manifest,
+        ref,
+        artifact_path=artifact_path,
+        run_id=run_id,
+        campaign_id=campaign_id,
+        session_id=session_id,
+    )
+    return ref, join
+
+
+def build_experiment_lineage_ref_from_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    artifact_path: str = ARTIFACT_FILENAME,
+    run_id: str | None = None,
+    campaign_id: str | None = None,
+    session_id: str | None = None,
+) -> LineageRef:
+    """Build a validated EXPERIMENT LineageRef from an already validated Package N manifest."""
+    ref, _join = _build_experiment_lineage_ref_and_join(
+        manifest,
+        artifact_path=artifact_path,
+        run_id=run_id,
+        campaign_id=campaign_id,
+        session_id=session_id,
+    )
+    return ref
 
 
 def produce_experiment_lineage_ref_v1(
     *,
     manifest_dir: Path | str,
+    run_id: str | None = None,
+    campaign_id: str | None = None,
+    session_id: str | None = None,
 ) -> ExperimentLineageRefProducerResult:
     """Extract a reference-only EXPERIMENT LineageRef from an explicit manifest directory."""
     resolved_manifest_dir = _resolve_existing_directory(Path(manifest_dir))
     manifest, manifest_path = _load_validated_manifest(resolved_manifest_dir)
-    ref = build_experiment_lineage_ref_from_manifest(manifest)
+    ref, join = _build_experiment_lineage_ref_and_join(
+        manifest,
+        artifact_path=ARTIFACT_FILENAME,
+        run_id=run_id,
+        campaign_id=campaign_id,
+        session_id=session_id,
+    )
     return ExperimentLineageRefProducerResult(
         manifest_dir=resolved_manifest_dir,
         manifest_path=manifest_path,
         ref=ref,
+        join=join,
     )
 
 
@@ -224,9 +294,17 @@ def produce_experiment_lineage_ref_v1_to_path(
     manifest_dir: Path | str,
     output_path: Path | str,
     fail_closed_if_exists: bool = True,
+    run_id: str | None = None,
+    campaign_id: str | None = None,
+    session_id: str | None = None,
 ) -> ExperimentLineageRefProducerResult:
     """End-to-end offline producer: explicit manifest_dir -> validated EXPERIMENT LineageRef JSON."""
-    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    result = produce_experiment_lineage_ref_v1(
+        manifest_dir=manifest_dir,
+        run_id=run_id,
+        campaign_id=campaign_id,
+        session_id=session_id,
+    )
     write_experiment_lineage_ref_v1_atomic(
         result.ref,
         output_path,

--- a/src/governance/promotion_loop/i16_lineage_remaining_planes_live_join_v1.py
+++ b/src/governance/promotion_loop/i16_lineage_remaining_planes_live_join_v1.py
@@ -1,0 +1,173 @@
+"""EG-I82-JOIN U-I82-R18 — I16 named-lane remaining-plane join on lineage producer.
+
+Attaches RUN/CAMPAIGN/SESSION onto Package-N SHA256 IDENTITY at the I16
+LineageRef producer without rewriting lineage JSON, without changing
+ref_id, and without Cap 7.2 / src.execution / persistence / migration.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+)
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import LineageRef, LineageRefType
+from src.governance.promotion_loop.i16_remaining_planes_join_attachment_v1 import (
+    I16RemainingPlanesJoinAttachmentError,
+    attach_i16_remaining_planes_join_v1,
+)
+
+CONTRACT_ID = "i16_lineage_remaining_planes_live_join_v1"
+I16_LINEAGE_REMAINING_PLANES_JOIN_REGISTERED = True
+
+LIVE_CONTRACT_SURFACES: tuple[str, ...] = ("lineage_ref",)
+
+_FORBIDDEN_SIDECAR_KEYS = frozenset(
+    {
+        "experiment_id",
+        "identity_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "registry_run_id",
+        "mlflow_run_id",
+        "orders",
+        "credentials",
+        "promotion_authority",
+        "apply_authority",
+        "live_arming",
+        "I17",
+        "I52",
+        "I56",
+        "I61",
+        "I65",
+        "plane_presence",
+        "join_key",
+    }
+)
+
+
+class I16LineageRemainingPlanesLiveJoinError(ValueError):
+    """Fail-closed I16 lineage remaining-plane live join error."""
+
+
+def _reject(message: str) -> None:
+    raise I16LineageRemainingPlanesLiveJoinError(message)
+
+
+def is_i16_lineage_remaining_planes_join_registered() -> bool:
+    """True iff the I16 lineage remaining-plane join is registered on the named producer."""
+    return I16_LINEAGE_REMAINING_PLANES_JOIN_REGISTERED is True
+
+
+def _optional_sidecar(value: str | None, *, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip() or value != value.strip():
+        _reject(f"malformed plane data rejected: sidecar {field} is invalid")
+    return value
+
+
+def join_i16_lineage_remaining_planes_v1(
+    manifest: Mapping[str, Any],
+    *,
+    ref: LineageRef,
+    artifact_path: str,
+    run_id: str | None = None,
+    campaign_id: str | None = None,
+    session_id: str | None = None,
+) -> CrossLaneIdentityJoinV1:
+    """Join I16 remaining planes onto a named-lane LineageRef. Does not mutate inputs."""
+    if not isinstance(manifest, Mapping):
+        _reject("malformed plane data rejected: lineage manifest is not an object")
+    if not isinstance(ref, LineageRef):
+        _reject("malformed plane data rejected: lineage ref is not a LineageRef")
+    snapshot = copy.deepcopy(dict(manifest))
+    forbidden = sorted(str(key) for key in manifest.keys() if str(key) in _FORBIDDEN_SIDECAR_KEYS)
+    if forbidden:
+        if forbidden[0] in {"I17", "I52", "I56", "I61", "I65"}:
+            _reject(f"cross-lane substitution rejected: {forbidden[0]}")
+        if forbidden[0] in {"plane_presence", "join_key"}:
+            _reject(f"cross-plane substitution rejected: {forbidden[0]}")
+        _reject(f"noncanonical ID substitution rejected: {forbidden[0]}")
+
+    if ref.ref_type != LineageRefType.EXPERIMENT:
+        _reject(f"malformed plane data rejected: ref_type must be EXPERIMENT, got {ref.ref_type}")
+    identity = manifest.get("experiment_identity_id")
+    if not is_package_n_sha256_canonical_id(identity):
+        _reject(
+            "noncanonical ID substitution rejected: experiment_identity_id must be Package-N SHA256"
+        )
+    if ref.ref_id != identity:
+        _reject("conflicting identity rejected: LineageRef.ref_id != experiment_identity_id")
+    if not is_package_n_sha256_canonical_id(ref.digest):
+        _reject("malformed plane data rejected: LineageRef.digest must be sha256 hex")
+
+    sidecar_run = _optional_sidecar(run_id, field="run_id")
+    sidecar_campaign = _optional_sidecar(campaign_id, field="campaign_id")
+    sidecar_session = _optional_sidecar(session_id, field="session_id")
+
+    payload: dict[str, Any] = {
+        "experiment_identity_id": identity,
+        "ref_id": ref.ref_id,
+        "digest": ref.digest,
+        "artifact_path": artifact_path,
+        "integrity": {"content_sha256": ref.digest},
+    }
+    aliases = manifest.get("legacy_aliases")
+    if isinstance(aliases, Mapping):
+        payload["legacy_aliases"] = copy.deepcopy(dict(aliases))
+    provenance = manifest.get("provenance")
+    if provenance is not None:
+        if not isinstance(provenance, Mapping):
+            _reject("malformed plane data rejected: provenance must be an object")
+        provenance_copy = copy.deepcopy(dict(provenance))
+        source_id = provenance_copy.get("source_experiment_id")
+        if source_id is not None and source_id == identity:
+            _reject(
+                "noncanonical ID substitution rejected: source_experiment_id must not be IDENTITY"
+            )
+        payload["historical_provenance"] = provenance_copy
+    if sidecar_run is not None:
+        payload["run_id"] = sidecar_run
+    if sidecar_campaign is not None:
+        payload["campaign_id"] = sidecar_campaign
+    if sidecar_session is not None:
+        payload["session_id"] = sidecar_session
+
+    try:
+        record = attach_i16_remaining_planes_join_v1(payload)
+    except I16RemainingPlanesJoinAttachmentError as exc:
+        message = str(exc)
+        if "must not substitute" in message:
+            _reject(f"cross-plane substitution rejected: {exc}")
+        if "conflicting" in message:
+            _reject(f"conflicting identity rejected: {exc}")
+        if "Package-N SHA256" in message or "must not be UUID" in message:
+            _reject(f"noncanonical ID substitution rejected: {exc}")
+        raise I16LineageRemainingPlanesLiveJoinError(
+            f"I16 lineage remaining-plane join rejected by R4 attachment: {exc}"
+        ) from exc
+
+    if dict(manifest) != snapshot:
+        _reject("lineage manifest input was mutated")
+    return record
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "I16LineageRemainingPlanesLiveJoinError",
+    "I16_LINEAGE_REMAINING_PLANES_JOIN_REGISTERED",
+    "LIVE_CONTRACT_SURFACES",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "is_i16_lineage_remaining_planes_join_registered",
+    "join_i16_lineage_remaining_planes_v1",
+]

--- a/src/governance/promotion_loop/i16_remaining_planes_join_attachment_v1.py
+++ b/src/governance/promotion_loop/i16_remaining_planes_join_attachment_v1.py
@@ -1,0 +1,237 @@
+"""EG-I82-JOIN U-I82-R4 — dormant I16 remaining-plane join attachment.
+
+Joins I16 RUN/CAMPAIGN/SESSION onto already-proven Package-N SHA256 IDENTITY.
+Does not rewrite lineage artifacts, does not change ref_id, and does not
+register into runtime/execution pipelines.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+from src.experiments.cross_lane_identity_join_record_v1 import (
+    CrossLaneIdentityJoinRecordError,
+    build_cross_lane_identity_join_record_v1,
+)
+from src.experiments.cross_lane_identity_join_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    JOIN_PLANES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    PlanePresence,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+)
+
+CONTRACT_ID = "i16_remaining_planes_join_attachment_v1"
+
+_KNOWN_KEYS = frozenset(
+    {
+        "experiment_identity_id",
+        "ref_id",
+        "run_id",
+        "campaign_id",
+        "session_id",
+        "legacy_alias_md5_12",
+        "legacy_aliases",
+        "evidence_ref",
+        "artifact_path",
+        "content_sha256",
+        "digest",
+        "integrity",
+        "historical_provenance",
+    }
+)
+_FORBIDDEN_KEYS = frozenset(
+    {
+        "orders",
+        "credentials",
+        "promotion_authority",
+        "apply_authority",
+        "live_arming",
+        "experiment_id",
+        "identity_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "registry_run_id",
+        "mlflow_run_id",
+    }
+)
+
+
+class I16RemainingPlanesJoinAttachmentError(ValueError):
+    """Fail-closed I16 remaining-plane join attachment error."""
+
+
+def _reject(message: str) -> None:
+    raise I16RemainingPlanesJoinAttachmentError(message)
+
+
+def _optional_str(payload: Mapping[str, Any], key: str) -> str | None:
+    if key not in payload:
+        return None
+    value = payload[key]
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        _reject(f"{key} must be a string when present")
+    if not value.strip() or value != value.strip():
+        _reject(f"{key} is present but empty or whitespace-padded")
+    return value
+
+
+def _present(plane: str, value: str, join_key: str) -> dict[str, str]:
+    return {
+        "plane": plane,
+        "presence": PlanePresence.PRESENT.value,
+        "join_key": join_key,
+        "value": value,
+    }
+
+
+def _absent(plane: str) -> dict[str, str]:
+    return {"plane": plane, "presence": PlanePresence.ABSENT_DECLARED.value}
+
+
+def _resolve_identity(payload: Mapping[str, Any]) -> str:
+    identity = _optional_str(payload, "experiment_identity_id")
+    ref_id = _optional_str(payload, "ref_id")
+    if identity is None and ref_id is None:
+        _reject("I16 IDENTITY missing: experiment_identity_id or ref_id required")
+    if identity is not None and not is_package_n_sha256_canonical_id(identity):
+        _reject("experiment_identity_id must be Package-N SHA256")
+    if ref_id is not None and not is_package_n_sha256_canonical_id(ref_id):
+        _reject("ref_id must be Package-N SHA256 and must not be UUID/run_id/MD5")
+    if identity is not None and ref_id is not None and identity != ref_id:
+        _reject("conflicting Package-N SHA256 identities: ref_id != experiment_identity_id")
+    resolved = identity or ref_id
+    if resolved is None or not is_package_n_sha256_canonical_id(resolved):
+        _reject("I16 IDENTITY must be Package-N SHA256")
+    return resolved
+
+
+def _alias_md5_12(payload: Mapping[str, Any]) -> str | None:
+    direct = _optional_str(payload, "legacy_alias_md5_12")
+    nested = payload.get("legacy_aliases")
+    nested_id: str | None = None
+    if nested is not None:
+        if not isinstance(nested, Mapping):
+            _reject("legacy_aliases must be an object")
+        raw = nested.get("legacy_experiment_id_md5_12")
+        if raw is not None:
+            if not isinstance(raw, str) or not raw.strip() or raw != raw.strip():
+                _reject("legacy_aliases.legacy_experiment_id_md5_12 is invalid")
+            nested_id = raw
+    if direct is not None and nested_id is not None and direct != nested_id:
+        _reject("conflicting identities: MD5 alias fields disagree")
+    return direct if direct is not None else nested_id
+
+
+def _content_sha256(payload: Mapping[str, Any]) -> str | None:
+    direct = _optional_str(payload, "content_sha256")
+    digest = _optional_str(payload, "digest")
+    nested = payload.get("integrity")
+    nested_id: str | None = None
+    if nested is not None:
+        if not isinstance(nested, Mapping):
+            _reject("integrity must be an object")
+        raw = nested.get("content_sha256")
+        if raw is not None:
+            if not isinstance(raw, str) or not raw.strip() or raw != raw.strip():
+                _reject("integrity.content_sha256 is invalid")
+            nested_id = raw
+    found = [item for item in (direct, digest, nested_id) if item is not None]
+    if len(set(found)) > 1:
+        _reject("conflicting CONTENT_HASH values")
+    return found[0] if found else None
+
+
+def _evidence_ref(payload: Mapping[str, Any]) -> str | None:
+    evidence = _optional_str(payload, "evidence_ref")
+    artifact = _optional_str(payload, "artifact_path")
+    if evidence is not None and artifact is not None and evidence != artifact:
+        _reject("conflicting EVIDENCE values")
+    return evidence if evidence is not None else artifact
+
+
+def attach_i16_remaining_planes_join_v1(
+    i16_identity: Mapping[str, Any],
+) -> CrossLaneIdentityJoinV1:
+    """Attach explicit RUN/CAMPAIGN/SESSION planes onto proven I16 Package-N IDENTITY."""
+    if not isinstance(i16_identity, Mapping):
+        _reject("I16 identity payload must be an object")
+    forbidden = sorted(str(key) for key in i16_identity.keys() if str(key) in _FORBIDDEN_KEYS)
+    if forbidden:
+        _reject(f"forbidden I16 join field: {forbidden[0]}")
+    extra = sorted(str(key) for key in i16_identity.keys() if str(key) not in _KNOWN_KEYS)
+    if extra:
+        _reject(f"unknown I16 join field: {extra[0]}")
+
+    identity_id = _resolve_identity(i16_identity)
+    run_id = _optional_str(i16_identity, "run_id")
+    campaign_id = _optional_str(i16_identity, "campaign_id")
+    session_id = _optional_str(i16_identity, "session_id")
+    alias = _alias_md5_12(i16_identity)
+    evidence = _evidence_ref(i16_identity)
+    content_hash = _content_sha256(i16_identity)
+    provenance = i16_identity.get("historical_provenance")
+    if provenance is not None and not isinstance(provenance, Mapping):
+        _reject("historical_provenance must be an object")
+    provenance_copy = copy.deepcopy(dict(provenance)) if isinstance(provenance, Mapping) else {}
+
+    for label, value in (
+        ("run_id", run_id),
+        ("campaign_id", campaign_id),
+        ("session_id", session_id),
+    ):
+        if value is not None and value == identity_id:
+            _reject(f"{label} must not substitute for Package-N SHA256 IDENTITY")
+
+    contributions = {
+        "IDENTITY": _present("IDENTITY", identity_id, identity_id),
+        "ALIAS": _present("ALIAS", alias, identity_id) if alias is not None else _absent("ALIAS"),
+        "RUN": _present("RUN", run_id, identity_id) if run_id is not None else _absent("RUN"),
+        "CAMPAIGN": (
+            _present("CAMPAIGN", campaign_id, identity_id)
+            if campaign_id is not None
+            else _absent("CAMPAIGN")
+        ),
+        "SESSION": (
+            _present("SESSION", session_id, identity_id)
+            if session_id is not None
+            else _absent("SESSION")
+        ),
+        "EVIDENCE": (
+            _present("EVIDENCE", evidence, identity_id)
+            if evidence is not None
+            else _absent("EVIDENCE")
+        ),
+        "CONTENT_HASH": (
+            _present("CONTENT_HASH", content_hash, identity_id)
+            if content_hash is not None
+            else _absent("CONTENT_HASH")
+        ),
+    }
+    ordered = [contributions[plane] for plane in JOIN_PLANES]
+    try:
+        return build_cross_lane_identity_join_record_v1(
+            ordered,
+            package_n_identity_id=identity_id,
+            historical_provenance=provenance_copy or None,
+        )
+    except CrossLaneIdentityJoinRecordError as exc:
+        raise I16RemainingPlanesJoinAttachmentError(
+            f"I16 remaining-plane join rejected by R3 primitive: {exc}"
+        ) from exc
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "I16RemainingPlanesJoinAttachmentError",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "attach_i16_remaining_planes_join_v1",
+]

--- a/src/ingress/capsules/evidence_capsule.py
+++ b/src/ingress/capsules/evidence_capsule.py
@@ -5,8 +5,14 @@ No raw payload, transcript, or secrets in the model or serialization.
 
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass, field
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Mapping
+
+from src.experiments.cross_lane_identity_join_v1 import CrossLaneIdentityJoinV1
+from src.ingress.capsules.i56_ingress_named_lane_identity_join_v1 import (
+    join_i56_named_lane_identity_v1,
+)
 
 
 @dataclass(frozen=True)
@@ -44,3 +50,60 @@ class EvidenceCapsule:
             "labels": dict(self.labels),
             "facts": dict(self.facts),
         }
+
+
+@dataclass(frozen=True)
+class EvidenceCapsuleNamedLaneIdentityJoinResultV1:
+    contract: EvidenceCapsule
+    join: CrossLaneIdentityJoinV1
+
+
+@dataclass(frozen=True)
+class ArtifactRefNamedLaneIdentityJoinResultV1:
+    contract: ArtifactRef
+    join: CrossLaneIdentityJoinV1
+
+
+def parse_evidence_capsule_with_identity_join_v1(
+    raw: Mapping[str, Any],
+    **sidecars: Any,
+) -> EvidenceCapsuleNamedLaneIdentityJoinResultV1:
+    """Parse a live I56 capsule and fail-closed join Package-N IDENTITY sidecar."""
+    snapshot = copy.deepcopy(dict(raw)) if isinstance(raw, Mapping) else None
+    join = join_i56_named_lane_identity_v1(raw, surface="capsule", **sidecars)
+    if not isinstance(raw, Mapping) or snapshot is None:
+        raise ValueError("malformed plane data rejected: I56 capsule is not an object")
+    artifacts_raw = raw.get("artifacts") or []
+    if not isinstance(artifacts_raw, list):
+        raise ValueError("malformed plane data rejected: I56 capsule artifacts is not a list")
+    refs = [
+        ArtifactRef(path=str(item["path"]), sha256=str(item["sha256"]))
+        for item in artifacts_raw
+        if isinstance(item, Mapping)
+    ]
+    capsule = EvidenceCapsule(
+        capsule_id=str(raw["capsule_id"]),
+        run_id=str(raw["run_id"]),
+        ts_ms=int(raw["ts_ms"]),
+        artifacts=refs,
+        labels=dict(raw.get("labels") or {}),
+        facts=dict(raw.get("facts") or {}),
+    )
+    if dict(raw) != snapshot:
+        raise ValueError("I56 capsule input was mutated")
+    return EvidenceCapsuleNamedLaneIdentityJoinResultV1(contract=capsule, join=join)
+
+
+def parse_artifact_ref_with_identity_join_v1(
+    raw: Mapping[str, Any],
+    **sidecars: Any,
+) -> ArtifactRefNamedLaneIdentityJoinResultV1:
+    """Parse a live I56 artifact ref and fail-closed join Package-N IDENTITY sidecar."""
+    snapshot = copy.deepcopy(dict(raw)) if isinstance(raw, Mapping) else None
+    join = join_i56_named_lane_identity_v1(raw, surface="artifact", **sidecars)
+    if not isinstance(raw, Mapping) or snapshot is None:
+        raise ValueError("malformed plane data rejected: I56 artifact is not an object")
+    artifact = ArtifactRef(path=str(raw["path"]), sha256=str(raw["sha256"]))
+    if dict(raw) != snapshot:
+        raise ValueError("I56 artifact input was mutated")
+    return ArtifactRefNamedLaneIdentityJoinResultV1(contract=artifact, join=join)

--- a/src/ingress/capsules/i56_ingress_join_attachment_v1.py
+++ b/src/ingress/capsules/i56_ingress_join_attachment_v1.py
@@ -1,0 +1,228 @@
+"""EG-I82-JOIN U-I82-R7 — dormant I56 Ingress join attachment.
+
+Attaches Package-N SHA256 IDENTITY onto I56 EvidenceCapsule join payloads.
+run_id remains RUN (including orchestrator default "default") and is never IDENTITY.
+capsule_id remains EVIDENCE and is never IDENTITY.
+Artifact sha256 remains CONTENT_HASH and is never IDENTITY.
+Does not rewrite EvidenceCapsule / orchestrator / CLI, does not register
+into runtime/execution, and does not import Cap 7.2.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+from src.experiments.cross_lane_identity_join_record_v1 import (
+    CrossLaneIdentityJoinRecordError,
+    build_cross_lane_identity_join_record_v1,
+)
+from src.experiments.cross_lane_identity_join_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    JOIN_PLANES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    PlanePresence,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+)
+from src.meta.learning_loop.contract_safety_v1 import is_valid_sha256_hex
+
+CONTRACT_ID = "i56_ingress_join_attachment_v1"
+
+_INGRESS_DEFAULT_RUN_ID = "default"
+
+_KNOWN_KEYS = frozenset(
+    {
+        "experiment_identity_id",
+        "capsule_id",
+        "run_id",
+        "campaign_id",
+        "session_id",
+        "legacy_alias_md5_12",
+        "evidence_ref",
+        "content_sha256",
+        "artifact_sha256",
+        "historical_provenance",
+    }
+)
+_FORBIDDEN_KEYS = frozenset(
+    {
+        "orders",
+        "credentials",
+        "secrets",
+        "payload",
+        "raw",
+        "raw_payload",
+        "transcript",
+        "promotion_authority",
+        "apply_authority",
+        "live_arming",
+        "experiment_id",
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "registry_run_id",
+        "mlflow_run_id",
+    }
+)
+_NON_IDENTITY_I56_FIELDS = (
+    "capsule_id",
+    "run_id",
+    "campaign_id",
+    "session_id",
+    "evidence_ref",
+)
+
+
+class I56IngressJoinAttachmentError(ValueError):
+    """Fail-closed I56 Ingress join attachment error."""
+
+
+def _reject(message: str) -> None:
+    raise I56IngressJoinAttachmentError(message)
+
+
+def _optional_str(payload: Mapping[str, Any], key: str) -> str | None:
+    if key not in payload:
+        return None
+    value = payload[key]
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        _reject(f"{key} must be a string when present")
+    if not value.strip() or value != value.strip():
+        _reject(f"{key} is present but empty or whitespace-padded")
+    return value
+
+
+def _present(plane: str, value: str, join_key: str) -> dict[str, str]:
+    return {
+        "plane": plane,
+        "presence": PlanePresence.PRESENT.value,
+        "join_key": join_key,
+        "value": value,
+    }
+
+
+def _absent(plane: str) -> dict[str, str]:
+    return {"plane": plane, "presence": PlanePresence.ABSENT_DECLARED.value}
+
+
+def _resolve_identity(payload: Mapping[str, Any]) -> str:
+    identity = _optional_str(payload, "experiment_identity_id")
+    if identity is None:
+        _reject("I56 IDENTITY missing: experiment_identity_id required")
+    if identity == _INGRESS_DEFAULT_RUN_ID:
+        _reject("run_id default cannot fill IDENTITY")
+    if identity.endswith(".capsule"):
+        _reject("capsule_id cannot fill IDENTITY")
+    if not is_package_n_sha256_canonical_id(identity):
+        _reject("experiment_identity_id must be Package-N SHA256")
+    return identity
+
+
+def _evidence_ref(payload: Mapping[str, Any]) -> str | None:
+    evidence = _optional_str(payload, "evidence_ref")
+    capsule_id = _optional_str(payload, "capsule_id")
+    if evidence is not None and capsule_id is not None and evidence != capsule_id:
+        _reject("conflicting EVIDENCE values")
+    return capsule_id if capsule_id is not None else evidence
+
+
+def _content_sha256(payload: Mapping[str, Any]) -> str | None:
+    direct = _optional_str(payload, "content_sha256")
+    artifact = _optional_str(payload, "artifact_sha256")
+    candidates: list[str] = []
+    for label, value in (("content_sha256", direct), ("artifact_sha256", artifact)):
+        if value is None:
+            continue
+        if not is_valid_sha256_hex(value):
+            _reject(f"{label} must be 64-char lowercase sha256 hex when CONTENT_HASH is PRESENT")
+        candidates.append(value)
+    if len(set(candidates)) > 1:
+        _reject("conflicting CONTENT_HASH values")
+    return candidates[0] if candidates else None
+
+
+def attach_i56_ingress_join_v1(i56_identity: Mapping[str, Any]) -> CrossLaneIdentityJoinV1:
+    """Attach Package-N SHA256 IDENTITY onto an I56 Ingress join payload."""
+    if not isinstance(i56_identity, Mapping):
+        _reject("I56 identity payload must be an object")
+    forbidden = sorted(str(key) for key in i56_identity.keys() if str(key) in _FORBIDDEN_KEYS)
+    if forbidden:
+        _reject(f"forbidden I56 join field: {forbidden[0]}")
+    extra = sorted(str(key) for key in i56_identity.keys() if str(key) not in _KNOWN_KEYS)
+    if extra:
+        _reject(f"unknown I56 join field: {extra[0]}")
+
+    identity_id = _resolve_identity(i56_identity)
+    capsule_id = _optional_str(i56_identity, "capsule_id")
+    run_id = _optional_str(i56_identity, "run_id")
+    campaign_id = _optional_str(i56_identity, "campaign_id")
+    session_id = _optional_str(i56_identity, "session_id")
+    alias = _optional_str(i56_identity, "legacy_alias_md5_12")
+    evidence = _evidence_ref(i56_identity)
+    content_hash = _content_sha256(i56_identity)
+    provenance = i56_identity.get("historical_provenance")
+    if provenance is not None and not isinstance(provenance, Mapping):
+        _reject("historical_provenance must be an object")
+    provenance_copy = copy.deepcopy(dict(provenance)) if isinstance(provenance, Mapping) else {}
+
+    if capsule_id is not None and capsule_id == identity_id:
+        _reject("capsule_id must not substitute for Package-N SHA256 IDENTITY")
+    if run_id is not None and run_id == identity_id:
+        _reject("run_id must not substitute for Package-N SHA256 IDENTITY")
+    for label in _NON_IDENTITY_I56_FIELDS:
+        value = _optional_str(i56_identity, label)
+        if value is not None and value == identity_id:
+            _reject(f"{label} must not substitute for Package-N SHA256 IDENTITY")
+
+    contributions = {
+        "IDENTITY": _present("IDENTITY", identity_id, identity_id),
+        "ALIAS": _present("ALIAS", alias, identity_id) if alias is not None else _absent("ALIAS"),
+        "RUN": _present("RUN", run_id, identity_id) if run_id is not None else _absent("RUN"),
+        "CAMPAIGN": (
+            _present("CAMPAIGN", campaign_id, identity_id)
+            if campaign_id is not None
+            else _absent("CAMPAIGN")
+        ),
+        "SESSION": (
+            _present("SESSION", session_id, identity_id)
+            if session_id is not None
+            else _absent("SESSION")
+        ),
+        "EVIDENCE": (
+            _present("EVIDENCE", evidence, identity_id)
+            if evidence is not None
+            else _absent("EVIDENCE")
+        ),
+        "CONTENT_HASH": (
+            _present("CONTENT_HASH", content_hash, identity_id)
+            if content_hash is not None
+            else _absent("CONTENT_HASH")
+        ),
+    }
+    ordered = [contributions[plane] for plane in JOIN_PLANES]
+    try:
+        return build_cross_lane_identity_join_record_v1(
+            ordered,
+            package_n_identity_id=identity_id,
+            historical_provenance=provenance_copy or None,
+        )
+    except CrossLaneIdentityJoinRecordError as exc:
+        raise I56IngressJoinAttachmentError(
+            f"I56 Ingress join rejected by R3 primitive: {exc}"
+        ) from exc
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "I56IngressJoinAttachmentError",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "attach_i56_ingress_join_v1",
+]

--- a/src/ingress/capsules/i56_ingress_live_contract_join_v1.py
+++ b/src/ingress/capsules/i56_ingress_live_contract_join_v1.py
@@ -1,0 +1,358 @@
+"""EG-I82-JOIN U-I82-R14 — dormant I56 live-contract join registration.
+
+Binds Package-N SHA256 IDENTITY onto validated I56 EvidenceCapsule/ArtifactRef
+payloads without rewriting those live schemas, without hooking Cap 7.2 /
+src.execution, and without persistence, migration, or backfill.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+)
+from src.ingress.capsules.evidence_capsule import ArtifactRef, EvidenceCapsule
+from src.ingress.capsules.i56_ingress_join_attachment_v1 import (
+    I56IngressJoinAttachmentError,
+    attach_i56_ingress_join_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import is_valid_sha256_hex
+
+CONTRACT_ID = "i56_ingress_live_contract_join_v1"
+I56_LIVE_CONTRACT_REGISTERED = True
+
+LIVE_CONTRACT_SURFACES: tuple[str, ...] = (
+    "capsule",
+    "artifact",
+)
+
+_CAPSULE_KEYS = frozenset({"capsule_id", "run_id", "ts_ms", "artifacts", "labels", "facts"})
+_ARTIFACT_KEYS = frozenset({"path", "sha256"})
+_KNOWN_ENVELOPE_KEYS = frozenset(
+    {
+        "experiment_identity_id",
+        "capsule",
+        "artifact",
+        "campaign_id",
+        "session_id",
+        "legacy_alias_md5_12",
+        "evidence_ref",
+        "content_sha256",
+        "historical_provenance",
+    }
+)
+_FORBIDDEN_ENVELOPE_KEYS = frozenset(
+    {
+        "capsule_id",
+        "run_id",
+        "experiment_id",
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "registry_run_id",
+        "mlflow_run_id",
+        "orders",
+        "credentials",
+        "secrets",
+        "payload",
+        "raw",
+        "raw_payload",
+        "transcript",
+        "promotion_authority",
+        "apply_authority",
+        "live_arming",
+        "I16",
+        "I17",
+        "I52",
+        "I56",
+        "I61",
+        "I65",
+        "plane_presence",
+        "join_key",
+    }
+)
+_LIVE_IDENTITY_SUBSTITUTE_KEYS = frozenset(
+    {
+        "experiment_identity_id",
+        "experiment_id",
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "plane_presence",
+        "join_key",
+        "I16",
+        "I17",
+        "I52",
+        "I61",
+        "I65",
+    }
+)
+_FORBIDDEN_LIVE_CONTENT_KEYS = frozenset(
+    {
+        "payload",
+        "raw",
+        "raw_payload",
+        "transcript",
+        "secrets",
+        "orders",
+        "credentials",
+    }
+)
+
+
+class I56IngressLiveContractJoinError(ValueError):
+    """Fail-closed I56 live-contract join registration error."""
+
+
+def _reject(message: str) -> None:
+    raise I56IngressLiveContractJoinError(message)
+
+
+def is_i56_live_contract_registered() -> bool:
+    """True iff the dormant I56 live-contract join surface is registered."""
+    return I56_LIVE_CONTRACT_REGISTERED is True
+
+
+def _optional_str(payload: Mapping[str, Any], key: str) -> str | None:
+    if key not in payload:
+        return None
+    value = payload[key]
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        _reject(f"{key} must be a string when present")
+    if not value.strip() or value != value.strip():
+        _reject(f"{key} is present but empty or whitespace-padded")
+    return value
+
+
+def _require_identity(envelope: Mapping[str, Any]) -> str:
+    if "experiment_identity_id" not in envelope:
+        _reject("implicit absence rejected: I56 live-contract IDENTITY is missing")
+    identity = envelope.get("experiment_identity_id")
+    if identity is None:
+        _reject("implicit absence rejected: I56 live-contract IDENTITY is missing")
+    if not isinstance(identity, str) or not is_package_n_sha256_canonical_id(identity):
+        _reject(
+            "noncanonical ID substitution rejected: experiment_identity_id must be Package-N SHA256"
+        )
+    return identity
+
+
+def _snapshot_live_payload(raw: object, *, surface: str) -> dict[str, Any]:
+    if raw is None:
+        _reject(f"implicit absence rejected: I56 live surface {surface} is missing")
+    if isinstance(raw, (list, tuple)):
+        if not raw:
+            _reject(f"implicit absence rejected: I56 live surface {surface} is missing")
+        if len(raw) != 1:
+            _reject(
+                f"ambiguous join rejected: I56 live surface {surface} has multiple Package-N assignments"
+            )
+        return _snapshot_live_payload(raw[0], surface=surface)
+    if not isinstance(raw, Mapping):
+        _reject(f"malformed plane data rejected: I56 live surface {surface} is not an object")
+    return copy.deepcopy(dict(raw))
+
+
+def _reject_live_identity_substitution(payload: Mapping[str, Any], *, surface: str) -> None:
+    substitutes = sorted(
+        str(key) for key in payload.keys() if str(key) in _LIVE_IDENTITY_SUBSTITUTE_KEYS
+    )
+    if substitutes:
+        _reject(
+            f"noncanonical ID substitution rejected: live surface {surface} uses {substitutes[0]} "
+            "as Package-N identity"
+        )
+    forbidden = sorted(
+        str(key) for key in payload.keys() if str(key) in _FORBIDDEN_LIVE_CONTENT_KEYS
+    )
+    if forbidden:
+        _reject(f"malformed plane data rejected: I56 live surface {surface} carries {forbidden[0]}")
+
+
+def _select_live_surface(envelope: Mapping[str, Any]) -> tuple[str, dict[str, Any]]:
+    present = [name for name in LIVE_CONTRACT_SURFACES if name in envelope]
+    if not present:
+        _reject("implicit absence rejected: I56 live contract surface is missing")
+    if len(present) != 1:
+        _reject("ambiguous join rejected: I56 live contract has multiple Package-N assignments")
+    surface = present[0]
+    return surface, _snapshot_live_payload(envelope[surface], surface=surface)
+
+
+def _unique_artifact_hash(artifacts: list[ArtifactRef]) -> str | None:
+    hashes = [item.sha256 for item in artifacts]
+    if not hashes:
+        return None
+    unique = set(hashes)
+    if len(unique) > 1:
+        _reject("conflicting identity rejected: CONTENT_HASH values disagree")
+    digest = hashes[0]
+    if not is_valid_sha256_hex(digest):
+        _reject("malformed plane data rejected: I56 artifact sha256 is invalid")
+    return digest
+
+
+def _validate_capsule(payload: Mapping[str, Any]) -> dict[str, Any]:
+    extra = sorted(str(key) for key in payload.keys() if str(key) not in _CAPSULE_KEYS)
+    if extra:
+        _reject(f"malformed plane data rejected: unknown I56 capsule field: {extra[0]}")
+    for required in ("capsule_id", "run_id", "ts_ms"):
+        if required not in payload:
+            _reject(f"malformed plane data rejected: I56 capsule missing {required}")
+    artifacts_raw = payload.get("artifacts", [])
+    if artifacts_raw is None:
+        artifacts_raw = []
+    if not isinstance(artifacts_raw, list):
+        _reject("malformed plane data rejected: I56 capsule artifacts is not a list")
+    refs: list[ArtifactRef] = []
+    for item in artifacts_raw:
+        if not isinstance(item, Mapping):
+            _reject("malformed plane data rejected: I56 artifact is not an object")
+        extra_art = sorted(str(key) for key in item.keys() if str(key) not in _ARTIFACT_KEYS)
+        if extra_art:
+            _reject(f"malformed plane data rejected: unknown I56 artifact field: {extra_art[0]}")
+        if "path" not in item or "sha256" not in item:
+            _reject("malformed plane data rejected: I56 artifact missing path or sha256")
+        refs.append(ArtifactRef(path=str(item["path"]), sha256=str(item["sha256"])))
+    labels = payload.get("labels") or {}
+    facts = payload.get("facts") or {}
+    if not isinstance(labels, Mapping) or not isinstance(facts, Mapping):
+        _reject("malformed plane data rejected: I56 capsule labels/facts must be objects")
+    try:
+        capsule = EvidenceCapsule(
+            capsule_id=str(payload["capsule_id"]),
+            run_id=str(payload["run_id"]),
+            ts_ms=int(payload["ts_ms"]),
+            artifacts=refs,
+            labels=dict(labels),
+            facts=dict(facts),
+        )
+    except (TypeError, ValueError) as exc:
+        _reject(f"malformed plane data rejected: I56 capsule is invalid: {exc}")
+    out: dict[str, Any] = {
+        "capsule_id": capsule.capsule_id,
+        "run_id": capsule.run_id,
+    }
+    digest = _unique_artifact_hash(capsule.artifacts)
+    if digest is not None:
+        out["artifact_sha256"] = digest
+    return out
+
+
+def _validate_artifact(payload: Mapping[str, Any]) -> dict[str, Any]:
+    extra = sorted(str(key) for key in payload.keys() if str(key) not in _ARTIFACT_KEYS)
+    if extra:
+        _reject(f"malformed plane data rejected: unknown I56 artifact field: {extra[0]}")
+    if "path" not in payload or "sha256" not in payload:
+        _reject("malformed plane data rejected: I56 artifact missing path or sha256")
+    try:
+        artifact = ArtifactRef(path=str(payload["path"]), sha256=str(payload["sha256"]))
+    except (TypeError, ValueError) as exc:
+        _reject(f"malformed plane data rejected: I56 artifact is invalid: {exc}")
+    if not is_valid_sha256_hex(artifact.sha256):
+        _reject("malformed plane data rejected: I56 artifact sha256 is invalid")
+    return {"artifact_sha256": artifact.sha256}
+
+
+_SURFACE_VALIDATORS = {
+    "capsule": _validate_capsule,
+    "artifact": _validate_artifact,
+}
+
+
+def _join_payload(
+    *,
+    identity_id: str,
+    live: Mapping[str, Any],
+    envelope: Mapping[str, Any],
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"experiment_identity_id": identity_id}
+    if live.get("capsule_id"):
+        payload["capsule_id"] = live["capsule_id"]
+    if live.get("run_id"):
+        payload["run_id"] = live["run_id"]
+    live_hash = live.get("artifact_sha256")
+    envelope_hash = _optional_str(envelope, "content_sha256")
+    if envelope_hash is not None and live_hash and envelope_hash != live_hash:
+        _reject("conflicting identity rejected: CONTENT_HASH values disagree")
+    if live_hash:
+        payload["artifact_sha256"] = live_hash
+    if envelope_hash is not None:
+        payload["content_sha256"] = envelope_hash
+    envelope_evidence = _optional_str(envelope, "evidence_ref")
+    live_evidence = live.get("capsule_id")
+    if envelope_evidence is not None and live_evidence and envelope_evidence != live_evidence:
+        _reject("conflicting identity rejected: EVIDENCE values disagree")
+    if envelope_evidence is not None:
+        payload["evidence_ref"] = envelope_evidence
+    for key in ("campaign_id", "session_id", "legacy_alias_md5_12"):
+        value = _optional_str(envelope, key)
+        if value is not None:
+            payload[key] = value
+    provenance = envelope.get("historical_provenance")
+    if provenance is not None:
+        payload["historical_provenance"] = copy.deepcopy(provenance)
+    return payload
+
+
+def register_i56_live_contract_join_v1(
+    live_join: Mapping[str, Any],
+) -> CrossLaneIdentityJoinV1:
+    """Register an I56 live-contract payload onto the Package-N SHA256 join path."""
+    if not isinstance(live_join, Mapping):
+        _reject("malformed plane data rejected: I56 live-contract envelope is not an object")
+    snapshot = copy.deepcopy(dict(live_join))
+    forbidden = sorted(str(key) for key in live_join.keys() if str(key) in _FORBIDDEN_ENVELOPE_KEYS)
+    if forbidden:
+        if forbidden[0] in {"I16", "I17", "I52", "I61", "I65"}:
+            _reject(f"cross-lane substitution rejected: {forbidden[0]}")
+        if forbidden[0] in {"plane_presence", "join_key"}:
+            _reject(f"cross-plane substitution rejected: {forbidden[0]}")
+        _reject(f"noncanonical ID substitution rejected: {forbidden[0]}")
+    extra = sorted(str(key) for key in live_join.keys() if str(key) not in _KNOWN_ENVELOPE_KEYS)
+    if extra:
+        _reject(f"malformed plane data rejected: unknown I56 live-contract field: {extra[0]}")
+
+    identity_id = _require_identity(live_join)
+    surface, live_payload = _select_live_surface(live_join)
+    _reject_live_identity_substitution(live_payload, surface=surface)
+    validated = _SURFACE_VALIDATORS[surface](live_payload)
+    attachment = _join_payload(identity_id=identity_id, live=validated, envelope=live_join)
+    try:
+        record = attach_i56_ingress_join_v1(attachment)
+    except I56IngressJoinAttachmentError as exc:
+        message = str(exc)
+        if "must not substitute" in message or "cannot fill IDENTITY" in message:
+            _reject(f"cross-plane substitution rejected: {exc}")
+        raise I56IngressLiveContractJoinError(
+            f"I56 live-contract join rejected by R7 attachment: {exc}"
+        ) from exc
+
+    if dict(live_join) != snapshot:
+        _reject("I56 live-contract envelope input was mutated")
+    return record
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "I56IngressLiveContractJoinError",
+    "I56_LIVE_CONTRACT_REGISTERED",
+    "LIVE_CONTRACT_SURFACES",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "is_i56_live_contract_registered",
+    "register_i56_live_contract_join_v1",
+]

--- a/src/ingress/capsules/i56_ingress_named_lane_identity_join_v1.py
+++ b/src/ingress/capsules/i56_ingress_named_lane_identity_join_v1.py
@@ -1,0 +1,274 @@
+"""EG-I82-JOIN U-I82-R21 — I56 named-lane IDENTITY join on EvidenceCapsule.
+
+Attaches Package-N SHA256 IDENTITY onto the named I56 live contract
+surfaces without rewriting EvidenceCapsule / ArtifactRef, without Cap 7.2 /
+src.execution, and without persistence, migration, or backfill.
+run_id remains RUN (including orchestrator default "default").
+capsule_id remains EVIDENCE. Artifact sha256 remains CONTENT_HASH.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+)
+from src.ingress.capsules.i56_ingress_join_attachment_v1 import (
+    I56IngressJoinAttachmentError,
+    attach_i56_ingress_join_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import is_valid_sha256_hex
+
+CONTRACT_ID = "i56_ingress_named_lane_identity_join_v1"
+I56_NAMED_LANE_IDENTITY_JOIN_REGISTERED = True
+
+LIVE_CONTRACT_SURFACES: tuple[str, ...] = (
+    "capsule",
+    "artifact",
+)
+
+_CAPSULE_KEYS = frozenset({"capsule_id", "run_id", "ts_ms", "artifacts", "labels", "facts"})
+_ARTIFACT_KEYS = frozenset({"path", "sha256"})
+
+_FORBIDDEN_LIVE_KEYS = frozenset(
+    {
+        "experiment_identity_id",
+        "experiment_id",
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "campaign_id",
+        "session_id",
+        "legacy_alias_md5_12",
+        "registry_run_id",
+        "mlflow_run_id",
+        "orders",
+        "credentials",
+        "promotion_authority",
+        "apply_authority",
+        "live_arming",
+        "I16",
+        "I17",
+        "I52",
+        "I56",
+        "I61",
+        "I65",
+        "plane_presence",
+        "join_key",
+    }
+)
+_FORBIDDEN_LIVE_CONTENT_KEYS = frozenset(
+    {
+        "payload",
+        "raw",
+        "raw_payload",
+        "transcript",
+        "secrets",
+        "orders",
+        "credentials",
+    }
+)
+_CROSS_LANE_KEYS = frozenset({"I16", "I17", "I52", "I61", "I65"})
+_CROSS_PLANE_KEYS = frozenset({"plane_presence", "join_key"})
+
+
+class I56IngressNamedLaneIdentityJoinError(ValueError):
+    """Fail-closed I56 named-lane IDENTITY join error."""
+
+
+def _reject(message: str) -> None:
+    raise I56IngressNamedLaneIdentityJoinError(message)
+
+
+def is_i56_named_lane_identity_join_registered() -> bool:
+    """True iff the I56 named-lane IDENTITY join is registered on live I56 surfaces."""
+    return I56_NAMED_LANE_IDENTITY_JOIN_REGISTERED is True
+
+
+def _optional_sidecar(value: str | None, *, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip() or value != value.strip():
+        _reject(f"malformed plane data rejected: sidecar {field} is invalid")
+    return value
+
+
+def _require_identity(identity: object) -> str:
+    if identity is None:
+        _reject("implicit absence rejected: I56 named-lane IDENTITY is missing")
+    if not isinstance(identity, str) or not is_package_n_sha256_canonical_id(identity):
+        _reject(
+            "noncanonical ID substitution rejected: experiment_identity_id must be Package-N SHA256"
+        )
+    return identity
+
+
+def _reject_forbidden_keys(payload: Mapping[str, Any], *, surface: str) -> None:
+    keys = {str(key) for key in payload.keys()}
+    forbidden = sorted(keys & _FORBIDDEN_LIVE_KEYS)
+    if forbidden:
+        if forbidden[0] in _CROSS_LANE_KEYS:
+            _reject(f"cross-lane substitution rejected: {forbidden[0]}")
+        if forbidden[0] in _CROSS_PLANE_KEYS:
+            _reject(f"cross-plane substitution rejected: {forbidden[0]}")
+        _reject(f"noncanonical ID substitution rejected: {forbidden[0]}")
+    content = sorted(keys & _FORBIDDEN_LIVE_CONTENT_KEYS)
+    if content:
+        _reject(f"malformed plane data rejected: I56 live surface {surface} carries {content[0]}")
+    allowed = _CAPSULE_KEYS if surface == "capsule" else _ARTIFACT_KEYS
+    extra = sorted(keys - allowed - _FORBIDDEN_LIVE_KEYS - _FORBIDDEN_LIVE_CONTENT_KEYS)
+    if extra:
+        _reject(f"malformed plane data rejected: unknown I56 {surface} field: {extra[0]}")
+
+
+def _unique_artifact_hash(artifacts: list[Mapping[str, Any]]) -> str | None:
+    hashes: list[str] = []
+    for item in artifacts:
+        if not isinstance(item, Mapping):
+            _reject("malformed plane data rejected: I56 artifact is not an object")
+        _reject_forbidden_keys(item, surface="artifact")
+        if "path" not in item or "sha256" not in item:
+            _reject("malformed plane data rejected: I56 artifact missing path or sha256")
+        digest = item["sha256"]
+        if not isinstance(digest, str) or not is_valid_sha256_hex(digest):
+            _reject("malformed plane data rejected: I56 artifact sha256 is invalid")
+        hashes.append(digest)
+    if not hashes:
+        return None
+    unique = set(hashes)
+    if len(unique) > 1:
+        _reject("conflicting identity rejected: CONTENT_HASH values disagree")
+    return hashes[0]
+
+
+def _extract_live_fields(live: Mapping[str, Any], *, surface: str) -> dict[str, Any]:
+    if surface == "artifact":
+        digest = _unique_artifact_hash([live])
+        if digest is None:
+            _reject("implicit absence rejected: I56 CONTENT_HASH is missing")
+        return {"artifact_sha256": digest}
+
+    for required in ("capsule_id", "run_id", "ts_ms"):
+        if required not in live:
+            _reject(f"malformed plane data rejected: I56 capsule missing {required}")
+    artifacts_raw = live.get("artifacts", [])
+    if artifacts_raw is None:
+        artifacts_raw = []
+    if not isinstance(artifacts_raw, list):
+        _reject("malformed plane data rejected: I56 capsule artifacts is not a list")
+    out: dict[str, Any] = {
+        "capsule_id": live["capsule_id"],
+        "run_id": live["run_id"],
+    }
+    digest = _unique_artifact_hash(list(artifacts_raw))
+    if digest is not None:
+        out["artifact_sha256"] = digest
+    return out
+
+
+def join_i56_named_lane_identity_v1(
+    live: object,
+    *,
+    surface: str,
+    experiment_identity_id: str | None = None,
+    run_id: str | None = None,
+    campaign_id: str | None = None,
+    session_id: str | None = None,
+    legacy_alias_md5_12: str | None = None,
+    content_sha256: str | None = None,
+    evidence_ref: str | None = None,
+    historical_provenance: Mapping[str, Any] | None = None,
+) -> CrossLaneIdentityJoinV1:
+    """Join Package-N SHA256 IDENTITY onto a named I56 live contract payload.
+
+    Does not mutate inputs and does not rewrite persisted I56 schemas.
+    """
+    if surface not in LIVE_CONTRACT_SURFACES:
+        _reject(f"malformed plane data rejected: unknown I56 live surface {surface}")
+    if isinstance(live, (list, tuple)):
+        _reject("ambiguous join rejected: I56 live surface has multiple Package-N assignments")
+    if not isinstance(live, Mapping):
+        _reject("malformed plane data rejected: I56 live payload is not an object")
+    snapshot = copy.deepcopy(dict(live))
+    _reject_forbidden_keys(live, surface=surface)
+
+    identity = _require_identity(experiment_identity_id)
+    if run_id is not None:
+        _reject("noncanonical ID substitution rejected: run_id")
+    extracted = _extract_live_fields(live, surface=surface)
+    sidecar_campaign = _optional_sidecar(campaign_id, field="campaign_id")
+    sidecar_session = _optional_sidecar(session_id, field="session_id")
+    sidecar_alias = _optional_sidecar(legacy_alias_md5_12, field="legacy_alias_md5_12")
+    sidecar_hash = _optional_sidecar(content_sha256, field="content_sha256")
+    sidecar_evidence = _optional_sidecar(evidence_ref, field="evidence_ref")
+
+    payload: dict[str, Any] = {"experiment_identity_id": identity}
+    if extracted.get("capsule_id"):
+        payload["capsule_id"] = extracted["capsule_id"]
+    if extracted.get("run_id") is not None:
+        payload["run_id"] = extracted["run_id"]
+    live_hash = extracted.get("artifact_sha256")
+    if sidecar_hash is not None and live_hash and sidecar_hash != live_hash:
+        _reject("conflicting identity rejected: CONTENT_HASH values disagree")
+    if live_hash:
+        payload["artifact_sha256"] = live_hash
+    if sidecar_hash is not None:
+        payload["content_sha256"] = sidecar_hash
+    live_evidence = extracted.get("capsule_id")
+    if sidecar_evidence is not None and live_evidence and sidecar_evidence != live_evidence:
+        _reject("conflicting identity rejected: EVIDENCE values disagree")
+    if sidecar_evidence is not None:
+        payload["evidence_ref"] = sidecar_evidence
+    if sidecar_campaign is not None:
+        payload["campaign_id"] = sidecar_campaign
+    if sidecar_session is not None:
+        payload["session_id"] = sidecar_session
+    if sidecar_alias is not None:
+        payload["legacy_alias_md5_12"] = sidecar_alias
+    if historical_provenance is not None:
+        if not isinstance(historical_provenance, Mapping):
+            _reject("malformed plane data rejected: historical_provenance must be an object")
+        provenance_copy = copy.deepcopy(dict(historical_provenance))
+        nested = provenance_copy.get("experiment_identity_id")
+        if nested is not None and nested != identity:
+            _reject("conflicting identity rejected: historical_provenance.experiment_identity_id")
+        payload["historical_provenance"] = provenance_copy
+
+    try:
+        record = attach_i56_ingress_join_v1(payload)
+    except I56IngressJoinAttachmentError as exc:
+        message = str(exc)
+        if "must not substitute" in message or "cannot fill IDENTITY" in message:
+            _reject(f"cross-plane substitution rejected: {exc}")
+        if "conflicting" in message:
+            _reject(f"conflicting identity rejected: {exc}")
+        if "Package-N SHA256" in message or "must not be UUID" in message:
+            _reject(f"noncanonical ID substitution rejected: {exc}")
+        raise I56IngressNamedLaneIdentityJoinError(
+            f"I56 named-lane IDENTITY join rejected by R7 attachment: {exc}"
+        ) from exc
+
+    if dict(live) != snapshot:
+        _reject("I56 live payload input was mutated")
+    return record
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "I56IngressNamedLaneIdentityJoinError",
+    "I56_NAMED_LANE_IDENTITY_JOIN_REGISTERED",
+    "LIVE_CONTRACT_SURFACES",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "is_i56_named_lane_identity_join_registered",
+    "join_i56_named_lane_identity_v1",
+]

--- a/src/levelup/i52_levelup_join_attachment_v1.py
+++ b/src/levelup/i52_levelup_join_attachment_v1.py
@@ -1,0 +1,227 @@
+"""EG-I82-JOIN U-I82-R6 — dormant I52 Level-Up join attachment.
+
+Attaches Package-N SHA256 IDENTITY onto I52 Level-Up join payloads.
+relative_dir remains an EVIDENCE pointer under out/ops/ and is never IDENTITY.
+Does not rewrite LevelUpManifestV0 / EvidenceBundleRefV0, does not register
+into runtime/execution, and does not import Cap 7.2.
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+from typing import Any, Mapping
+
+from src.experiments.cross_lane_identity_join_record_v1 import (
+    CrossLaneIdentityJoinRecordError,
+    build_cross_lane_identity_join_record_v1,
+)
+from src.experiments.cross_lane_identity_join_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    JOIN_PLANES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    PlanePresence,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+)
+from src.meta.learning_loop.contract_safety_v1 import is_valid_sha256_hex
+
+CONTRACT_ID = "i52_levelup_join_attachment_v1"
+
+_EVIDENCE_PREFIX = "out/ops/"
+_SAFE_SEGMENT = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._\-/]*$")
+
+_KNOWN_KEYS = frozenset(
+    {
+        "experiment_identity_id",
+        "slice_id",
+        "relative_dir",
+        "evidence_ref",
+        "content_sha256",
+        "run_id",
+        "campaign_id",
+        "session_id",
+        "legacy_alias_md5_12",
+        "historical_provenance",
+    }
+)
+_FORBIDDEN_KEYS = frozenset(
+    {
+        "orders",
+        "credentials",
+        "promotion_authority",
+        "apply_authority",
+        "live_arming",
+        "experiment_id",
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "registry_run_id",
+        "mlflow_run_id",
+    }
+)
+_NON_IDENTITY_I52_FIELDS = (
+    "slice_id",
+    "relative_dir",
+    "run_id",
+    "campaign_id",
+    "session_id",
+)
+
+
+class I52LevelUpJoinAttachmentError(ValueError):
+    """Fail-closed I52 Level-Up join attachment error."""
+
+
+def _reject(message: str) -> None:
+    raise I52LevelUpJoinAttachmentError(message)
+
+
+def _optional_str(payload: Mapping[str, Any], key: str) -> str | None:
+    if key not in payload:
+        return None
+    value = payload[key]
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        _reject(f"{key} must be a string when present")
+    if not value.strip() or value != value.strip():
+        _reject(f"{key} is present but empty or whitespace-padded")
+    return value
+
+
+def _present(plane: str, value: str, join_key: str) -> dict[str, str]:
+    return {
+        "plane": plane,
+        "presence": PlanePresence.PRESENT.value,
+        "join_key": join_key,
+        "value": value,
+    }
+
+
+def _absent(plane: str) -> dict[str, str]:
+    return {"plane": plane, "presence": PlanePresence.ABSENT_DECLARED.value}
+
+
+def _resolve_identity(payload: Mapping[str, Any]) -> str:
+    identity = _optional_str(payload, "experiment_identity_id")
+    if identity is None:
+        _reject("I52 IDENTITY missing: experiment_identity_id required")
+    if not is_package_n_sha256_canonical_id(identity):
+        _reject("experiment_identity_id must be Package-N SHA256")
+    return identity
+
+
+def _validate_relative_dir(relative_dir: str) -> str:
+    path = relative_dir.replace("\\", "/")
+    if not path.startswith(_EVIDENCE_PREFIX):
+        _reject(f"relative_dir must start with {_EVIDENCE_PREFIX!r}")
+    if ".." in path or path.startswith("/"):
+        _reject("relative_dir path traversal is not allowed")
+    rest = path[len(_EVIDENCE_PREFIX) :]
+    if not rest or _SAFE_SEGMENT.match(rest) is None:
+        _reject("relative_dir has invalid evidence path segments")
+    return path
+
+
+def _evidence_ref(payload: Mapping[str, Any]) -> str | None:
+    evidence = _optional_str(payload, "evidence_ref")
+    relative_dir = _optional_str(payload, "relative_dir")
+    if relative_dir is not None:
+        relative_dir = _validate_relative_dir(relative_dir)
+    if evidence is not None:
+        evidence = _validate_relative_dir(evidence)
+    if evidence is not None and relative_dir is not None and evidence != relative_dir:
+        _reject("conflicting EVIDENCE values")
+    return relative_dir if relative_dir is not None else evidence
+
+
+def _content_sha256(payload: Mapping[str, Any]) -> str | None:
+    value = _optional_str(payload, "content_sha256")
+    if value is None:
+        return None
+    if not is_valid_sha256_hex(value):
+        _reject("content_sha256 must be 64-char lowercase sha256 hex when CONTENT_HASH is PRESENT")
+    return value
+
+
+def attach_i52_levelup_join_v1(i52_identity: Mapping[str, Any]) -> CrossLaneIdentityJoinV1:
+    """Attach Package-N SHA256 IDENTITY onto an I52 Level-Up join payload."""
+    if not isinstance(i52_identity, Mapping):
+        _reject("I52 identity payload must be an object")
+    forbidden = sorted(str(key) for key in i52_identity.keys() if str(key) in _FORBIDDEN_KEYS)
+    if forbidden:
+        _reject(f"forbidden I52 join field: {forbidden[0]}")
+    extra = sorted(str(key) for key in i52_identity.keys() if str(key) not in _KNOWN_KEYS)
+    if extra:
+        _reject(f"unknown I52 join field: {extra[0]}")
+
+    identity_id = _resolve_identity(i52_identity)
+    slice_id = _optional_str(i52_identity, "slice_id")
+    run_id = _optional_str(i52_identity, "run_id")
+    campaign_id = _optional_str(i52_identity, "campaign_id")
+    session_id = _optional_str(i52_identity, "session_id")
+    alias = _optional_str(i52_identity, "legacy_alias_md5_12")
+    evidence = _evidence_ref(i52_identity)
+    content_hash = _content_sha256(i52_identity)
+    provenance = i52_identity.get("historical_provenance")
+    if provenance is not None and not isinstance(provenance, Mapping):
+        _reject("historical_provenance must be an object")
+    provenance_copy = copy.deepcopy(dict(provenance)) if isinstance(provenance, Mapping) else {}
+
+    if slice_id is not None and slice_id == identity_id:
+        _reject("slice_id must not substitute for Package-N SHA256 IDENTITY")
+    for label in _NON_IDENTITY_I52_FIELDS:
+        value = _optional_str(i52_identity, label)
+        if value is not None and value == identity_id:
+            _reject(f"{label} must not substitute for Package-N SHA256 IDENTITY")
+
+    contributions = {
+        "IDENTITY": _present("IDENTITY", identity_id, identity_id),
+        "ALIAS": _present("ALIAS", alias, identity_id) if alias is not None else _absent("ALIAS"),
+        "RUN": _present("RUN", run_id, identity_id) if run_id is not None else _absent("RUN"),
+        "CAMPAIGN": (
+            _present("CAMPAIGN", campaign_id, identity_id)
+            if campaign_id is not None
+            else _absent("CAMPAIGN")
+        ),
+        "SESSION": (
+            _present("SESSION", session_id, identity_id)
+            if session_id is not None
+            else _absent("SESSION")
+        ),
+        "EVIDENCE": (
+            _present("EVIDENCE", evidence, identity_id)
+            if evidence is not None
+            else _absent("EVIDENCE")
+        ),
+        "CONTENT_HASH": (
+            _present("CONTENT_HASH", content_hash, identity_id)
+            if content_hash is not None
+            else _absent("CONTENT_HASH")
+        ),
+    }
+    ordered = [contributions[plane] for plane in JOIN_PLANES]
+    try:
+        return build_cross_lane_identity_join_record_v1(
+            ordered,
+            package_n_identity_id=identity_id,
+            historical_provenance=provenance_copy or None,
+        )
+    except CrossLaneIdentityJoinRecordError as exc:
+        raise I52LevelUpJoinAttachmentError(
+            f"I52 Level-Up join rejected by R3 primitive: {exc}"
+        ) from exc
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "I52LevelUpJoinAttachmentError",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "attach_i52_levelup_join_v1",
+]

--- a/src/levelup/i52_levelup_live_contract_join_v1.py
+++ b/src/levelup/i52_levelup_live_contract_join_v1.py
@@ -1,0 +1,300 @@
+"""EG-I82-JOIN U-I82-R13 — dormant I52 live-contract join registration.
+
+Binds Package-N SHA256 IDENTITY onto validated I52 manifest/slice/evidence
+payloads without rewriting those live schemas, without hooking Cap 7.2 /
+src.execution, and without persistence, migration, or backfill.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+from pydantic import ValidationError
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+)
+from src.levelup.i52_levelup_join_attachment_v1 import (
+    I52LevelUpJoinAttachmentError,
+    attach_i52_levelup_join_v1,
+)
+from src.levelup.v0_models import EvidenceBundleRefV0, LevelUpManifestV0, SliceContractV0
+
+CONTRACT_ID = "i52_levelup_live_contract_join_v1"
+I52_LIVE_CONTRACT_REGISTERED = True
+
+LIVE_CONTRACT_SURFACES: tuple[str, ...] = (
+    "manifest",
+    "slice",
+    "evidence_bundle",
+)
+
+_KNOWN_ENVELOPE_KEYS = frozenset(
+    {
+        "experiment_identity_id",
+        "manifest",
+        "slice",
+        "evidence_bundle",
+        "run_id",
+        "campaign_id",
+        "session_id",
+        "legacy_alias_md5_12",
+        "evidence_ref",
+        "content_sha256",
+        "historical_provenance",
+    }
+)
+_FORBIDDEN_ENVELOPE_KEYS = frozenset(
+    {
+        "slice_id",
+        "relative_dir",
+        "experiment_id",
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "registry_run_id",
+        "mlflow_run_id",
+        "orders",
+        "credentials",
+        "promotion_authority",
+        "apply_authority",
+        "live_arming",
+        "I16",
+        "I17",
+        "I52",
+        "I56",
+        "I61",
+        "I65",
+        "plane_presence",
+        "join_key",
+    }
+)
+_LIVE_IDENTITY_SUBSTITUTE_KEYS = frozenset(
+    {
+        "experiment_identity_id",
+        "experiment_id",
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "plane_presence",
+        "join_key",
+        "I16",
+        "I17",
+        "I56",
+        "I61",
+        "I65",
+    }
+)
+
+
+class I52LevelUpLiveContractJoinError(ValueError):
+    """Fail-closed I52 live-contract join registration error."""
+
+
+def _reject(message: str) -> None:
+    raise I52LevelUpLiveContractJoinError(message)
+
+
+def is_i52_live_contract_registered() -> bool:
+    """True iff the dormant I52 live-contract join surface is registered."""
+    return I52_LIVE_CONTRACT_REGISTERED is True
+
+
+def _optional_str(payload: Mapping[str, Any], key: str) -> str | None:
+    if key not in payload:
+        return None
+    value = payload[key]
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        _reject(f"{key} must be a string when present")
+    if not value.strip() or value != value.strip():
+        _reject(f"{key} is present but empty or whitespace-padded")
+    return value
+
+
+def _require_identity(envelope: Mapping[str, Any]) -> str:
+    if "experiment_identity_id" not in envelope:
+        _reject("implicit absence rejected: I52 live-contract IDENTITY is missing")
+    identity = envelope.get("experiment_identity_id")
+    if identity is None:
+        _reject("implicit absence rejected: I52 live-contract IDENTITY is missing")
+    if not isinstance(identity, str) or not is_package_n_sha256_canonical_id(identity):
+        _reject(
+            "noncanonical ID substitution rejected: experiment_identity_id must be Package-N SHA256"
+        )
+    return identity
+
+
+def _snapshot_live_payload(raw: object, *, surface: str) -> dict[str, Any]:
+    if raw is None:
+        _reject(f"implicit absence rejected: I52 live surface {surface} is missing")
+    if isinstance(raw, (list, tuple)):
+        if not raw:
+            _reject(f"implicit absence rejected: I52 live surface {surface} is missing")
+        if len(raw) != 1:
+            _reject(
+                f"ambiguous join rejected: I52 live surface {surface} has multiple Package-N assignments"
+            )
+        return _snapshot_live_payload(raw[0], surface=surface)
+    if not isinstance(raw, Mapping):
+        _reject(f"malformed plane data rejected: I52 live surface {surface} is not an object")
+    return copy.deepcopy(dict(raw))
+
+
+def _reject_live_identity_substitution(payload: Mapping[str, Any], *, surface: str) -> None:
+    substitutes = sorted(
+        str(key) for key in payload.keys() if str(key) in _LIVE_IDENTITY_SUBSTITUTE_KEYS
+    )
+    if substitutes:
+        _reject(
+            f"noncanonical ID substitution rejected: live surface {surface} uses {substitutes[0]} "
+            "as Package-N identity"
+        )
+
+
+def _select_live_surface(envelope: Mapping[str, Any]) -> tuple[str, dict[str, Any]]:
+    present = [name for name in LIVE_CONTRACT_SURFACES if name in envelope]
+    if not present:
+        _reject("implicit absence rejected: I52 live contract surface is missing")
+    if len(present) != 1:
+        _reject("ambiguous join rejected: I52 live contract has multiple Package-N assignments")
+    surface = present[0]
+    return surface, _snapshot_live_payload(envelope[surface], surface=surface)
+
+
+def _validate_manifest(payload: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        contract = LevelUpManifestV0.model_validate(payload)
+    except ValidationError as exc:
+        _reject(f"malformed plane data rejected: I52 manifest is invalid: {exc}")
+    if len(contract.slices) > 1:
+        _reject("ambiguous join rejected: I52 manifest has multiple Package-N assignments")
+    dumped = contract.model_dump(mode="python")
+    if contract.slices:
+        slice_dump = dumped["slices"][0]
+        out: dict[str, Any] = {"slice_id": slice_dump["slice_id"]}
+        evidence = slice_dump.get("evidence")
+        if isinstance(evidence, Mapping) and evidence.get("relative_dir"):
+            out["relative_dir"] = evidence["relative_dir"]
+        return out
+    return {}
+
+
+def _validate_slice(payload: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        contract = SliceContractV0.model_validate(payload)
+    except ValidationError as exc:
+        _reject(f"malformed plane data rejected: I52 slice is invalid: {exc}")
+    dumped = contract.model_dump(mode="python")
+    out: dict[str, Any] = {"slice_id": dumped["slice_id"]}
+    evidence = dumped.get("evidence")
+    if isinstance(evidence, Mapping) and evidence.get("relative_dir"):
+        out["relative_dir"] = evidence["relative_dir"]
+    return out
+
+
+def _validate_evidence_bundle(payload: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        contract = EvidenceBundleRefV0.model_validate(payload)
+    except ValidationError as exc:
+        _reject(f"malformed plane data rejected: I52 evidence_bundle is invalid: {exc}")
+    return {"relative_dir": contract.relative_dir}
+
+
+_SURFACE_VALIDATORS = {
+    "manifest": _validate_manifest,
+    "slice": _validate_slice,
+    "evidence_bundle": _validate_evidence_bundle,
+}
+
+
+def _join_payload(
+    *,
+    identity_id: str,
+    live: Mapping[str, Any],
+    envelope: Mapping[str, Any],
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"experiment_identity_id": identity_id}
+    if live.get("slice_id"):
+        payload["slice_id"] = live["slice_id"]
+    live_evidence = live.get("relative_dir")
+    envelope_evidence = _optional_str(envelope, "evidence_ref")
+    if envelope_evidence is not None and live_evidence and envelope_evidence != live_evidence:
+        _reject("conflicting identity rejected: EVIDENCE values disagree")
+    if live_evidence:
+        payload["relative_dir"] = live_evidence
+    if envelope_evidence is not None:
+        payload["evidence_ref"] = envelope_evidence
+
+    content_hash = _optional_str(envelope, "content_sha256")
+    if content_hash is not None:
+        payload["content_sha256"] = content_hash
+    for key in ("run_id", "campaign_id", "session_id", "legacy_alias_md5_12"):
+        value = _optional_str(envelope, key)
+        if value is not None:
+            payload[key] = value
+    provenance = envelope.get("historical_provenance")
+    if provenance is not None:
+        payload["historical_provenance"] = copy.deepcopy(provenance)
+    return payload
+
+
+def register_i52_live_contract_join_v1(
+    live_join: Mapping[str, Any],
+) -> CrossLaneIdentityJoinV1:
+    """Register an I52 live-contract payload onto the Package-N SHA256 join path."""
+    if not isinstance(live_join, Mapping):
+        _reject("malformed plane data rejected: I52 live-contract envelope is not an object")
+    snapshot = copy.deepcopy(dict(live_join))
+    forbidden = sorted(str(key) for key in live_join.keys() if str(key) in _FORBIDDEN_ENVELOPE_KEYS)
+    if forbidden:
+        if forbidden[0] in {"I16", "I17", "I56", "I61", "I65"}:
+            _reject(f"cross-lane substitution rejected: {forbidden[0]}")
+        if forbidden[0] in {"plane_presence", "join_key"}:
+            _reject(f"cross-plane substitution rejected: {forbidden[0]}")
+        _reject(f"noncanonical ID substitution rejected: {forbidden[0]}")
+    extra = sorted(str(key) for key in live_join.keys() if str(key) not in _KNOWN_ENVELOPE_KEYS)
+    if extra:
+        _reject(f"malformed plane data rejected: unknown I52 live-contract field: {extra[0]}")
+
+    identity_id = _require_identity(live_join)
+    surface, live_payload = _select_live_surface(live_join)
+    _reject_live_identity_substitution(live_payload, surface=surface)
+    validated = _SURFACE_VALIDATORS[surface](live_payload)
+    attachment = _join_payload(identity_id=identity_id, live=validated, envelope=live_join)
+    try:
+        record = attach_i52_levelup_join_v1(attachment)
+    except I52LevelUpJoinAttachmentError as exc:
+        message = str(exc)
+        if "must not substitute" in message:
+            _reject(f"cross-plane substitution rejected: {exc}")
+        raise I52LevelUpLiveContractJoinError(
+            f"I52 live-contract join rejected by R6 attachment: {exc}"
+        ) from exc
+
+    if dict(live_join) != snapshot:
+        _reject("I52 live-contract envelope input was mutated")
+    return record
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "I52LevelUpLiveContractJoinError",
+    "I52_LIVE_CONTRACT_REGISTERED",
+    "LIVE_CONTRACT_SURFACES",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "is_i52_live_contract_registered",
+    "register_i52_live_contract_join_v1",
+]

--- a/src/levelup/i52_levelup_named_lane_identity_join_v1.py
+++ b/src/levelup/i52_levelup_named_lane_identity_join_v1.py
@@ -1,0 +1,251 @@
+"""EG-I82-JOIN U-I82-R20 — I52 named-lane IDENTITY join on v0 models.
+
+Attaches Package-N SHA256 IDENTITY onto the named I52 live contract
+surfaces without rewriting LevelUpManifestV0 / SliceContractV0 /
+EvidenceBundleRefV0, without Cap 7.2 / src.execution, and without
+persistence, migration, or backfill. relative_dir remains EVIDENCE.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+)
+from src.levelup.i52_levelup_join_attachment_v1 import (
+    I52LevelUpJoinAttachmentError,
+    attach_i52_levelup_join_v1,
+)
+
+CONTRACT_ID = "i52_levelup_named_lane_identity_join_v1"
+I52_NAMED_LANE_IDENTITY_JOIN_REGISTERED = True
+
+LIVE_CONTRACT_SURFACES: tuple[str, ...] = (
+    "manifest",
+    "slice",
+    "evidence_bundle",
+)
+
+_FORBIDDEN_LIVE_KEYS = frozenset(
+    {
+        "experiment_identity_id",
+        "experiment_id",
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "campaign_id",
+        "run_id",
+        "session_id",
+        "legacy_alias_md5_12",
+        "registry_run_id",
+        "mlflow_run_id",
+        "orders",
+        "credentials",
+        "promotion_authority",
+        "apply_authority",
+        "live_arming",
+        "I16",
+        "I17",
+        "I52",
+        "I56",
+        "I61",
+        "I65",
+        "plane_presence",
+        "join_key",
+    }
+)
+
+
+class I52LevelUpNamedLaneIdentityJoinError(ValueError):
+    """Fail-closed I52 named-lane IDENTITY join error."""
+
+
+def _reject(message: str) -> None:
+    raise I52LevelUpNamedLaneIdentityJoinError(message)
+
+
+def is_i52_named_lane_identity_join_registered() -> bool:
+    """True iff the I52 named-lane IDENTITY join is registered on live I52 surfaces."""
+    return I52_NAMED_LANE_IDENTITY_JOIN_REGISTERED is True
+
+
+def _optional_sidecar(value: str | None, *, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip() or value != value.strip():
+        _reject(f"malformed plane data rejected: sidecar {field} is invalid")
+    return value
+
+
+def _require_identity(identity: object) -> str:
+    if identity is None:
+        _reject("implicit absence rejected: I52 named-lane IDENTITY is missing")
+    if not isinstance(identity, str) or not is_package_n_sha256_canonical_id(identity):
+        _reject(
+            "noncanonical ID substitution rejected: experiment_identity_id must be Package-N SHA256"
+        )
+    return identity
+
+
+def _extract_live_fields(live: Mapping[str, Any], *, surface: str) -> dict[str, Any]:
+    if surface == "evidence_bundle":
+        relative_dir = live.get("relative_dir")
+        if not isinstance(relative_dir, str) or not relative_dir.strip():
+            _reject("implicit absence rejected: I52 EVIDENCE is missing")
+        return {"relative_dir": relative_dir}
+
+    slices = live.get("slices")
+    if surface == "manifest":
+        if slices is None:
+            slices = ()
+        if not isinstance(slices, (list, tuple)):
+            _reject("malformed plane data rejected: I52 manifest slices are invalid")
+        if len(slices) > 1:
+            _reject("ambiguous join rejected: I52 manifest has multiple Package-N assignments")
+        if not slices:
+            return {}
+        item = slices[0]
+        if not isinstance(item, Mapping):
+            _reject("malformed plane data rejected: I52 manifest slice is not an object")
+        return _extract_slice_fields(item)
+
+    return _extract_slice_fields(live)
+
+
+def _extract_slice_fields(payload: Mapping[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    slice_id = payload.get("slice_id")
+    if isinstance(slice_id, str) and slice_id.strip():
+        out["slice_id"] = slice_id
+    evidence = payload.get("evidence")
+    if isinstance(evidence, Mapping) and evidence.get("relative_dir"):
+        out["relative_dir"] = evidence["relative_dir"]
+    elif isinstance(payload.get("relative_dir"), str) and payload["relative_dir"].strip():
+        out["relative_dir"] = payload["relative_dir"]
+    return out
+
+
+def join_i52_named_lane_identity_v1(
+    live: Mapping[str, Any],
+    *,
+    surface: str,
+    experiment_identity_id: str | None = None,
+    run_id: str | None = None,
+    campaign_id: str | None = None,
+    session_id: str | None = None,
+    legacy_alias_md5_12: str | None = None,
+    content_sha256: str | None = None,
+    evidence_ref: str | None = None,
+    historical_provenance: Mapping[str, Any] | None = None,
+) -> CrossLaneIdentityJoinV1:
+    """Join Package-N SHA256 IDENTITY onto a named I52 live contract payload.
+
+    Does not mutate inputs and does not rewrite persisted I52 schemas.
+    """
+    if surface not in LIVE_CONTRACT_SURFACES:
+        _reject(f"malformed plane data rejected: unknown I52 live surface {surface}")
+    if not isinstance(live, Mapping):
+        _reject("malformed plane data rejected: I52 live payload is not an object")
+    snapshot = copy.deepcopy(dict(live))
+    forbidden = sorted(str(key) for key in live.keys() if str(key) in _FORBIDDEN_LIVE_KEYS)
+    if forbidden:
+        if forbidden[0] in {"I16", "I17", "I56", "I61", "I65"}:
+            _reject(f"cross-lane substitution rejected: {forbidden[0]}")
+        if forbidden[0] in {"plane_presence", "join_key"}:
+            _reject(f"cross-plane substitution rejected: {forbidden[0]}")
+        _reject(f"noncanonical ID substitution rejected: {forbidden[0]}")
+
+    nested_candidates: list[Mapping[str, Any]] = []
+    slices = live.get("slices")
+    if isinstance(slices, (list, tuple)):
+        nested_candidates.extend(item for item in slices if isinstance(item, Mapping))
+    evidence = live.get("evidence")
+    if isinstance(evidence, Mapping):
+        nested_candidates.append(evidence)
+    for nested in nested_candidates:
+        nested_forbidden = sorted(
+            str(key) for key in nested.keys() if str(key) in _FORBIDDEN_LIVE_KEYS
+        )
+        if nested_forbidden:
+            if nested_forbidden[0] in {"I16", "I17", "I56", "I61", "I65"}:
+                _reject(f"cross-lane substitution rejected: {nested_forbidden[0]}")
+            if nested_forbidden[0] in {"plane_presence", "join_key"}:
+                _reject(f"cross-plane substitution rejected: {nested_forbidden[0]}")
+            _reject(f"noncanonical ID substitution rejected: {nested_forbidden[0]}")
+
+    identity = _require_identity(experiment_identity_id)
+    extracted = _extract_live_fields(live, surface=surface)
+    sidecar_run = _optional_sidecar(run_id, field="run_id")
+    sidecar_campaign = _optional_sidecar(campaign_id, field="campaign_id")
+    sidecar_session = _optional_sidecar(session_id, field="session_id")
+    sidecar_alias = _optional_sidecar(legacy_alias_md5_12, field="legacy_alias_md5_12")
+    sidecar_hash = _optional_sidecar(content_sha256, field="content_sha256")
+    sidecar_evidence = _optional_sidecar(evidence_ref, field="evidence_ref")
+
+    payload: dict[str, Any] = {"experiment_identity_id": identity}
+    if extracted.get("slice_id"):
+        payload["slice_id"] = extracted["slice_id"]
+    live_evidence = extracted.get("relative_dir")
+    if sidecar_evidence is not None and live_evidence and sidecar_evidence != live_evidence:
+        _reject("conflicting identity rejected: EVIDENCE values disagree")
+    if live_evidence:
+        payload["relative_dir"] = live_evidence
+    if sidecar_evidence is not None:
+        payload["evidence_ref"] = sidecar_evidence
+    if sidecar_run is not None:
+        payload["run_id"] = sidecar_run
+    if sidecar_campaign is not None:
+        payload["campaign_id"] = sidecar_campaign
+    if sidecar_session is not None:
+        payload["session_id"] = sidecar_session
+    if sidecar_alias is not None:
+        payload["legacy_alias_md5_12"] = sidecar_alias
+    if sidecar_hash is not None:
+        payload["content_sha256"] = sidecar_hash
+    if historical_provenance is not None:
+        if not isinstance(historical_provenance, Mapping):
+            _reject("malformed plane data rejected: historical_provenance must be an object")
+        provenance_copy = copy.deepcopy(dict(historical_provenance))
+        nested = provenance_copy.get("experiment_identity_id")
+        if nested is not None and nested != identity:
+            _reject("conflicting identity rejected: historical_provenance.experiment_identity_id")
+        payload["historical_provenance"] = provenance_copy
+
+    try:
+        record = attach_i52_levelup_join_v1(payload)
+    except I52LevelUpJoinAttachmentError as exc:
+        message = str(exc)
+        if "must not substitute" in message:
+            _reject(f"cross-plane substitution rejected: {exc}")
+        if "conflicting" in message:
+            _reject(f"conflicting identity rejected: {exc}")
+        if "Package-N SHA256" in message or "must not be UUID" in message:
+            _reject(f"noncanonical ID substitution rejected: {exc}")
+        raise I52LevelUpNamedLaneIdentityJoinError(
+            f"I52 named-lane IDENTITY join rejected by R6 attachment: {exc}"
+        ) from exc
+
+    if dict(live) != snapshot:
+        _reject("I52 live payload input was mutated")
+    return record
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "I52LevelUpNamedLaneIdentityJoinError",
+    "I52_NAMED_LANE_IDENTITY_JOIN_REGISTERED",
+    "LIVE_CONTRACT_SURFACES",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "is_i52_named_lane_identity_join_registered",
+    "join_i52_named_lane_identity_v1",
+]

--- a/src/levelup/v0_models.py
+++ b/src/levelup/v0_models.py
@@ -7,10 +7,17 @@ slice metadata and pointers to under-repo evidence directories (typically ``out/
 
 from __future__ import annotations
 
+import copy
+from dataclasses import dataclass
 import re
-from typing import Any, Literal, Optional
+from typing import Any, Literal, Mapping, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from src.experiments.cross_lane_identity_join_v1 import CrossLaneIdentityJoinV1
+from src.levelup.i52_levelup_named_lane_identity_join_v1 import (
+    join_i52_named_lane_identity_v1,
+)
 
 _SCHEMA = "levelup/manifest/v0"
 _EVIDENCE_PREFIX = "out/ops/"
@@ -81,6 +88,81 @@ class LevelUpManifestV0(BaseModel):
                 raise ValueError(f"duplicate slice_id in manifest: {sl.slice_id!r}")
             seen.add(sl.slice_id)
         return self
+
+
+@dataclass(frozen=True)
+class LevelUpManifestNamedLaneIdentityJoinResultV0:
+    contract: LevelUpManifestV0
+    join: CrossLaneIdentityJoinV1
+
+
+@dataclass(frozen=True)
+class SliceContractNamedLaneIdentityJoinResultV0:
+    contract: SliceContractV0
+    join: CrossLaneIdentityJoinV1
+
+
+@dataclass(frozen=True)
+class EvidenceBundleNamedLaneIdentityJoinResultV0:
+    contract: EvidenceBundleRefV0
+    join: CrossLaneIdentityJoinV1
+
+
+def parse_levelup_manifest_with_identity_join_v1(
+    raw: Mapping[str, Any],
+    **sidecars: Any,
+) -> LevelUpManifestNamedLaneIdentityJoinResultV0:
+    """Parse a live I52 manifest and fail-closed join Package-N IDENTITY sidecar."""
+    if not isinstance(raw, Mapping):
+        raise ValueError("malformed plane data rejected: I52 manifest is not an object")
+    snapshot = copy.deepcopy(dict(raw))
+    contract = LevelUpManifestV0.model_validate(raw)
+    join = join_i52_named_lane_identity_v1(
+        contract.model_dump(mode="python"),
+        surface="manifest",
+        **sidecars,
+    )
+    if dict(raw) != snapshot:
+        raise ValueError("I52 manifest input was mutated")
+    return LevelUpManifestNamedLaneIdentityJoinResultV0(contract=contract, join=join)
+
+
+def parse_slice_contract_with_identity_join_v1(
+    raw: Mapping[str, Any],
+    **sidecars: Any,
+) -> SliceContractNamedLaneIdentityJoinResultV0:
+    """Parse a live I52 slice and fail-closed join Package-N IDENTITY sidecar."""
+    if not isinstance(raw, Mapping):
+        raise ValueError("malformed plane data rejected: I52 slice is not an object")
+    snapshot = copy.deepcopy(dict(raw))
+    contract = SliceContractV0.model_validate(raw)
+    join = join_i52_named_lane_identity_v1(
+        contract.model_dump(mode="python"),
+        surface="slice",
+        **sidecars,
+    )
+    if dict(raw) != snapshot:
+        raise ValueError("I52 slice input was mutated")
+    return SliceContractNamedLaneIdentityJoinResultV0(contract=contract, join=join)
+
+
+def parse_evidence_bundle_with_identity_join_v1(
+    raw: Mapping[str, Any],
+    **sidecars: Any,
+) -> EvidenceBundleNamedLaneIdentityJoinResultV0:
+    """Parse a live I52 evidence bundle and fail-closed join Package-N IDENTITY sidecar."""
+    if not isinstance(raw, Mapping):
+        raise ValueError("malformed plane data rejected: I52 evidence_bundle is not an object")
+    snapshot = copy.deepcopy(dict(raw))
+    contract = EvidenceBundleRefV0.model_validate(raw)
+    join = join_i52_named_lane_identity_v1(
+        contract.model_dump(mode="python"),
+        surface="evidence_bundle",
+        **sidecars,
+    )
+    if dict(raw) != snapshot:
+        raise ValueError("I52 evidence_bundle input was mutated")
+    return EvidenceBundleNamedLaneIdentityJoinResultV0(contract=contract, join=join)
 
 
 def levelup_manifest_v0_json_schema() -> dict[str, Any]:

--- a/src/live_eval/i61_live_eval_join_attachment_v1.py
+++ b/src/live_eval/i61_live_eval_join_attachment_v1.py
@@ -1,0 +1,220 @@
+"""EG-I82-JOIN U-I82-R8 — dormant I61 live-eval identity envelope.
+
+Attaches Package-N SHA256 IDENTITY onto an I61 eval metadata envelope.
+Fill trade fields stay off the join surface. --session-dir remains a
+filesystem SESSION hint and is never IDENTITY or session_id.
+Does not rewrite Fill, fill CSV IO, or the eval CLI,
+does not register into runtime/execution, and does not import Cap 7.2.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+from src.experiments.cross_lane_identity_join_record_v1 import (
+    CrossLaneIdentityJoinRecordError,
+    build_cross_lane_identity_join_record_v1,
+)
+from src.experiments.cross_lane_identity_join_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    JOIN_PLANES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    PlanePresence,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+)
+from src.meta.learning_loop.contract_safety_v1 import is_valid_sha256_hex
+
+CONTRACT_ID = "live_session_eval_identity_envelope_v1"
+
+_KNOWN_KEYS = frozenset(
+    {
+        "experiment_identity_id",
+        "session_id",
+        "session_dir",
+        "run_id",
+        "campaign_id",
+        "legacy_alias_md5_12",
+        "evidence_ref",
+        "content_sha256",
+        "historical_provenance",
+    }
+)
+_FORBIDDEN_KEYS = frozenset(
+    {
+        "orders",
+        "credentials",
+        "secrets",
+        "payload",
+        "raw",
+        "raw_payload",
+        "transcript",
+        "fills",
+        "ts",
+        "symbol",
+        "side",
+        "qty",
+        "fill_price",
+        "promotion_authority",
+        "apply_authority",
+        "live_arming",
+        "experiment_id",
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "registry_run_id",
+        "mlflow_run_id",
+    }
+)
+_NON_IDENTITY_I61_FIELDS = (
+    "session_id",
+    "session_dir",
+    "run_id",
+    "campaign_id",
+    "evidence_ref",
+)
+
+
+class I61LiveEvalJoinAttachmentError(ValueError):
+    """Fail-closed I61 live-eval identity envelope error."""
+
+
+def _reject(message: str) -> None:
+    raise I61LiveEvalJoinAttachmentError(message)
+
+
+def _looks_like_filesystem_path(value: str) -> bool:
+    return "/" in value or "\\" in value
+
+
+def _optional_str(payload: Mapping[str, Any], key: str) -> str | None:
+    if key not in payload:
+        return None
+    value = payload[key]
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        _reject(f"{key} must be a string when present")
+    if not value.strip() or value != value.strip():
+        _reject(f"{key} is present but empty or whitespace-padded")
+    return value
+
+
+def _present(plane: str, value: str, join_key: str) -> dict[str, str]:
+    return {
+        "plane": plane,
+        "presence": PlanePresence.PRESENT.value,
+        "join_key": join_key,
+        "value": value,
+    }
+
+
+def _absent(plane: str) -> dict[str, str]:
+    return {"plane": plane, "presence": PlanePresence.ABSENT_DECLARED.value}
+
+
+def _resolve_identity(payload: Mapping[str, Any]) -> str:
+    identity = _optional_str(payload, "experiment_identity_id")
+    if identity is None:
+        _reject("I61 IDENTITY missing: experiment_identity_id required")
+    if _looks_like_filesystem_path(identity):
+        _reject("session-dir path is not identity")
+    if not is_package_n_sha256_canonical_id(identity):
+        _reject("experiment_identity_id must be Package-N SHA256")
+    return identity
+
+
+def _content_sha256(payload: Mapping[str, Any]) -> str | None:
+    value = _optional_str(payload, "content_sha256")
+    if value is None:
+        return None
+    if not is_valid_sha256_hex(value):
+        _reject("content_sha256 must be 64-char lowercase sha256 hex when CONTENT_HASH is PRESENT")
+    return value
+
+
+def attach_i61_live_eval_join_v1(i61_identity: Mapping[str, Any]) -> CrossLaneIdentityJoinV1:
+    """Attach Package-N SHA256 IDENTITY onto an I61 eval metadata envelope."""
+    if not isinstance(i61_identity, Mapping):
+        _reject("I61 identity payload must be an object")
+    forbidden = sorted(str(key) for key in i61_identity.keys() if str(key) in _FORBIDDEN_KEYS)
+    if forbidden:
+        _reject(f"forbidden I61 join field: {forbidden[0]}")
+    extra = sorted(str(key) for key in i61_identity.keys() if str(key) not in _KNOWN_KEYS)
+    if extra:
+        _reject(f"unknown I61 join field: {extra[0]}")
+
+    identity_id = _resolve_identity(i61_identity)
+    session_id = _optional_str(i61_identity, "session_id")
+    session_dir = _optional_str(i61_identity, "session_dir")
+    run_id = _optional_str(i61_identity, "run_id")
+    campaign_id = _optional_str(i61_identity, "campaign_id")
+    alias = _optional_str(i61_identity, "legacy_alias_md5_12")
+    evidence = _optional_str(i61_identity, "evidence_ref")
+    content_hash = _content_sha256(i61_identity)
+    provenance = i61_identity.get("historical_provenance")
+    if provenance is not None and not isinstance(provenance, Mapping):
+        _reject("historical_provenance must be an object")
+    provenance_copy = copy.deepcopy(dict(provenance)) if isinstance(provenance, Mapping) else {}
+
+    if session_dir is not None and session_dir == identity_id:
+        _reject("session-dir path is not identity")
+    if session_id is not None and _looks_like_filesystem_path(session_id):
+        _reject("session-dir path is not session_id")
+    if session_id is not None and session_dir is not None and session_id == session_dir:
+        _reject("session-dir path is not session_id")
+    for label in _NON_IDENTITY_I61_FIELDS:
+        value = _optional_str(i61_identity, label)
+        if value is not None and value == identity_id:
+            _reject(f"{label} must not substitute for Package-N SHA256 IDENTITY")
+
+    contributions = {
+        "IDENTITY": _present("IDENTITY", identity_id, identity_id),
+        "ALIAS": _present("ALIAS", alias, identity_id) if alias is not None else _absent("ALIAS"),
+        "RUN": _present("RUN", run_id, identity_id) if run_id is not None else _absent("RUN"),
+        "CAMPAIGN": (
+            _present("CAMPAIGN", campaign_id, identity_id)
+            if campaign_id is not None
+            else _absent("CAMPAIGN")
+        ),
+        "SESSION": (
+            _present("SESSION", session_id, identity_id)
+            if session_id is not None
+            else _absent("SESSION")
+        ),
+        "EVIDENCE": (
+            _present("EVIDENCE", evidence, identity_id)
+            if evidence is not None
+            else _absent("EVIDENCE")
+        ),
+        "CONTENT_HASH": (
+            _present("CONTENT_HASH", content_hash, identity_id)
+            if content_hash is not None
+            else _absent("CONTENT_HASH")
+        ),
+    }
+    ordered = [contributions[plane] for plane in JOIN_PLANES]
+    try:
+        return build_cross_lane_identity_join_record_v1(
+            ordered,
+            package_n_identity_id=identity_id,
+            historical_provenance=provenance_copy or None,
+        )
+    except CrossLaneIdentityJoinRecordError as exc:
+        raise I61LiveEvalJoinAttachmentError(
+            f"I61 live-eval join rejected by R3 primitive: {exc}"
+        ) from exc
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "I61LiveEvalJoinAttachmentError",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "attach_i61_live_eval_join_v1",
+]

--- a/src/live_eval/i61_live_eval_live_contract_join_v1.py
+++ b/src/live_eval/i61_live_eval_live_contract_join_v1.py
@@ -1,0 +1,350 @@
+"""EG-I82-JOIN U-I82-R15 — dormant I61 live-contract join registration.
+
+Binds Package-N SHA256 IDENTITY onto validated I61 eval metrics / session-dir
+payloads without rewriting Fill, CSV IO, or the eval CLI, without hooking
+Cap 7.2 / src.execution, and without persistence, migration, or backfill.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+)
+from src.live_eval.i61_live_eval_join_attachment_v1 import (
+    I61LiveEvalJoinAttachmentError,
+    attach_i61_live_eval_join_v1,
+)
+
+CONTRACT_ID = "i61_live_eval_live_contract_join_v1"
+I61_LIVE_CONTRACT_REGISTERED = True
+
+LIVE_CONTRACT_SURFACES: tuple[str, ...] = (
+    "metrics",
+    "session",
+)
+
+_REQUIRED_METRICS_KEYS = frozenset(
+    {
+        "total_fills",
+        "symbols",
+        "start_ts",
+        "end_ts",
+        "total_notional",
+        "total_qty",
+        "vwap_overall",
+        "side_breakdown",
+        "realized_pnl_total",
+        "realized_pnl_per_symbol",
+    }
+)
+_OPTIONAL_METRICS_KEYS = frozenset({"vwap_per_symbol"})
+_SESSION_KEYS = frozenset({"session_dir"})
+_KNOWN_ENVELOPE_KEYS = frozenset(
+    {
+        "experiment_identity_id",
+        "metrics",
+        "session",
+        "session_id",
+        "session_dir",
+        "run_id",
+        "campaign_id",
+        "legacy_alias_md5_12",
+        "evidence_ref",
+        "content_sha256",
+        "historical_provenance",
+    }
+)
+_FORBIDDEN_ENVELOPE_KEYS = frozenset(
+    {
+        "fills",
+        "ts",
+        "symbol",
+        "side",
+        "qty",
+        "fill_price",
+        "experiment_id",
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "registry_run_id",
+        "mlflow_run_id",
+        "orders",
+        "credentials",
+        "secrets",
+        "payload",
+        "raw",
+        "raw_payload",
+        "transcript",
+        "promotion_authority",
+        "apply_authority",
+        "live_arming",
+        "I16",
+        "I17",
+        "I52",
+        "I56",
+        "I61",
+        "I65",
+        "plane_presence",
+        "join_key",
+    }
+)
+_LIVE_IDENTITY_SUBSTITUTE_KEYS = frozenset(
+    {
+        "experiment_identity_id",
+        "experiment_id",
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "plane_presence",
+        "join_key",
+        "I16",
+        "I17",
+        "I52",
+        "I56",
+        "I65",
+    }
+)
+_FILL_FIELD_KEYS = frozenset({"fills", "ts", "symbol", "side", "qty", "fill_price"})
+
+
+class I61LiveEvalLiveContractJoinError(ValueError):
+    """Fail-closed I61 live-contract join registration error."""
+
+
+def _reject(message: str) -> None:
+    raise I61LiveEvalLiveContractJoinError(message)
+
+
+def is_i61_live_contract_registered() -> bool:
+    """True iff the dormant I61 live-contract join surface is registered."""
+    return I61_LIVE_CONTRACT_REGISTERED is True
+
+
+def _looks_like_filesystem_path(value: str) -> bool:
+    return "/" in value or "\\" in value
+
+
+def _optional_str(payload: Mapping[str, Any], key: str) -> str | None:
+    if key not in payload:
+        return None
+    value = payload[key]
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        _reject(f"{key} must be a string when present")
+    if not value.strip() or value != value.strip():
+        _reject(f"{key} is present but empty or whitespace-padded")
+    return value
+
+
+def _require_identity(envelope: Mapping[str, Any]) -> str:
+    if "experiment_identity_id" not in envelope:
+        _reject("implicit absence rejected: I61 live-contract IDENTITY is missing")
+    identity = envelope.get("experiment_identity_id")
+    if identity is None:
+        _reject("implicit absence rejected: I61 live-contract IDENTITY is missing")
+    if not isinstance(identity, str) or not is_package_n_sha256_canonical_id(identity):
+        _reject(
+            "noncanonical ID substitution rejected: experiment_identity_id must be Package-N SHA256"
+        )
+    return identity
+
+
+def _snapshot_live_payload(raw: object, *, surface: str) -> dict[str, Any]:
+    if raw is None:
+        _reject(f"implicit absence rejected: I61 live surface {surface} is missing")
+    if isinstance(raw, (list, tuple)):
+        if not raw:
+            _reject(f"implicit absence rejected: I61 live surface {surface} is missing")
+        if len(raw) != 1:
+            _reject(
+                f"ambiguous join rejected: I61 live surface {surface} has multiple Package-N assignments"
+            )
+        return _snapshot_live_payload(raw[0], surface=surface)
+    if not isinstance(raw, Mapping):
+        _reject(f"malformed plane data rejected: I61 live surface {surface} is not an object")
+    return copy.deepcopy(dict(raw))
+
+
+def _reject_live_identity_substitution(payload: Mapping[str, Any], *, surface: str) -> None:
+    substitutes = sorted(
+        str(key) for key in payload.keys() if str(key) in _LIVE_IDENTITY_SUBSTITUTE_KEYS
+    )
+    if substitutes:
+        _reject(
+            f"noncanonical ID substitution rejected: live surface {surface} uses {substitutes[0]} "
+            "as Package-N identity"
+        )
+    fill_fields = sorted(str(key) for key in payload.keys() if str(key) in _FILL_FIELD_KEYS)
+    if fill_fields:
+        _reject(
+            f"cross-plane substitution rejected: I61 live surface {surface} carries {fill_fields[0]}"
+        )
+
+
+def _select_live_surface(envelope: Mapping[str, Any]) -> tuple[str, dict[str, Any]]:
+    present = [name for name in LIVE_CONTRACT_SURFACES if name in envelope]
+    if not present:
+        _reject("implicit absence rejected: I61 live contract surface is missing")
+    if len(present) != 1:
+        _reject("ambiguous join rejected: I61 live contract has multiple Package-N assignments")
+    surface = present[0]
+    return surface, _snapshot_live_payload(envelope[surface], surface=surface)
+
+
+def _validate_metrics(payload: Mapping[str, Any]) -> dict[str, Any]:
+    extra = sorted(
+        str(key)
+        for key in payload.keys()
+        if str(key) not in _REQUIRED_METRICS_KEYS | _OPTIONAL_METRICS_KEYS
+    )
+    if extra:
+        _reject(f"malformed plane data rejected: unknown I61 metrics field: {extra[0]}")
+    missing = sorted(key for key in _REQUIRED_METRICS_KEYS if key not in payload)
+    if missing:
+        _reject(f"malformed plane data rejected: I61 metrics missing {missing[0]}")
+    if not isinstance(payload["symbols"], list):
+        _reject("malformed plane data rejected: I61 metrics symbols is not a list")
+    breakdown = payload["side_breakdown"]
+    if not isinstance(breakdown, Mapping):
+        _reject("malformed plane data rejected: I61 metrics side_breakdown is not an object")
+    for side in ("buy", "sell"):
+        if side not in breakdown or not isinstance(breakdown[side], Mapping):
+            _reject(f"malformed plane data rejected: I61 metrics side_breakdown missing {side}")
+        stats = breakdown[side]
+        for field in ("count", "qty", "notional"):
+            if field not in stats:
+                _reject(
+                    f"malformed plane data rejected: I61 metrics side_breakdown.{side} missing {field}"
+                )
+    if not isinstance(payload["realized_pnl_per_symbol"], Mapping):
+        _reject(
+            "malformed plane data rejected: I61 metrics realized_pnl_per_symbol is not an object"
+        )
+    try:
+        total_fills = int(payload["total_fills"])
+    except (TypeError, ValueError) as exc:
+        _reject(f"malformed plane data rejected: I61 metrics total_fills is invalid: {exc}")
+    if total_fills < 0:
+        _reject("malformed plane data rejected: I61 metrics total_fills is invalid")
+    return {}
+
+
+def _validate_session(payload: Mapping[str, Any]) -> dict[str, Any]:
+    extra = sorted(str(key) for key in payload.keys() if str(key) not in _SESSION_KEYS)
+    if extra:
+        _reject(f"malformed plane data rejected: unknown I61 session field: {extra[0]}")
+    if "session_dir" not in payload:
+        _reject("malformed plane data rejected: I61 session missing session_dir")
+    session_dir = payload["session_dir"]
+    if (
+        not isinstance(session_dir, str)
+        or not session_dir.strip()
+        or session_dir != session_dir.strip()
+    ):
+        _reject("malformed plane data rejected: I61 session_dir is invalid")
+    if not _looks_like_filesystem_path(session_dir):
+        _reject("malformed plane data rejected: I61 session_dir is not a filesystem path")
+    return {"session_dir": session_dir}
+
+
+_SURFACE_VALIDATORS = {
+    "metrics": _validate_metrics,
+    "session": _validate_session,
+}
+
+
+def _join_payload(
+    *,
+    identity_id: str,
+    live: Mapping[str, Any],
+    envelope: Mapping[str, Any],
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {"experiment_identity_id": identity_id}
+    live_dir = live.get("session_dir")
+    envelope_dir = _optional_str(envelope, "session_dir")
+    if envelope_dir is not None and live_dir and envelope_dir != live_dir:
+        _reject("conflicting identity rejected: session_dir values disagree")
+    if live_dir:
+        payload["session_dir"] = live_dir
+    elif envelope_dir is not None:
+        payload["session_dir"] = envelope_dir
+    for key in (
+        "session_id",
+        "run_id",
+        "campaign_id",
+        "legacy_alias_md5_12",
+        "evidence_ref",
+        "content_sha256",
+    ):
+        value = _optional_str(envelope, key)
+        if value is not None:
+            payload[key] = value
+    provenance = envelope.get("historical_provenance")
+    if provenance is not None:
+        payload["historical_provenance"] = copy.deepcopy(provenance)
+    return payload
+
+
+def register_i61_live_contract_join_v1(
+    live_join: Mapping[str, Any],
+) -> CrossLaneIdentityJoinV1:
+    """Register an I61 live-contract payload onto the Package-N SHA256 join path."""
+    if not isinstance(live_join, Mapping):
+        _reject("malformed plane data rejected: I61 live-contract envelope is not an object")
+    snapshot = copy.deepcopy(dict(live_join))
+    forbidden = sorted(str(key) for key in live_join.keys() if str(key) in _FORBIDDEN_ENVELOPE_KEYS)
+    if forbidden:
+        if forbidden[0] in {"I16", "I17", "I52", "I56", "I65"}:
+            _reject(f"cross-lane substitution rejected: {forbidden[0]}")
+        if forbidden[0] in {"plane_presence", "join_key"} | _FILL_FIELD_KEYS:
+            _reject(f"cross-plane substitution rejected: {forbidden[0]}")
+        _reject(f"noncanonical ID substitution rejected: {forbidden[0]}")
+    extra = sorted(str(key) for key in live_join.keys() if str(key) not in _KNOWN_ENVELOPE_KEYS)
+    if extra:
+        _reject(f"malformed plane data rejected: unknown I61 live-contract field: {extra[0]}")
+
+    identity_id = _require_identity(live_join)
+    surface, live_payload = _select_live_surface(live_join)
+    _reject_live_identity_substitution(live_payload, surface=surface)
+    validated = _SURFACE_VALIDATORS[surface](live_payload)
+    attachment = _join_payload(identity_id=identity_id, live=validated, envelope=live_join)
+    try:
+        record = attach_i61_live_eval_join_v1(attachment)
+    except I61LiveEvalJoinAttachmentError as exc:
+        message = str(exc)
+        if "must not substitute" in message or "session-dir path is not" in message:
+            _reject(f"cross-plane substitution rejected: {exc}")
+        if "conflicting" in message:
+            _reject(f"conflicting identity rejected: {exc}")
+        raise I61LiveEvalLiveContractJoinError(
+            f"I61 live-contract join rejected by R8 attachment: {exc}"
+        ) from exc
+
+    if dict(live_join) != snapshot:
+        _reject("I61 live-contract envelope input was mutated")
+    return record
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "I61LiveEvalLiveContractJoinError",
+    "I61_LIVE_CONTRACT_REGISTERED",
+    "LIVE_CONTRACT_SURFACES",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "is_i61_live_contract_registered",
+    "register_i61_live_contract_join_v1",
+]

--- a/src/live_eval/i61_live_eval_named_lane_identity_join_v1.py
+++ b/src/live_eval/i61_live_eval_named_lane_identity_join_v1.py
@@ -1,0 +1,320 @@
+"""EG-I82-JOIN U-I82-R22 — I61 named-lane IDENTITY join on live session eval.
+
+Attaches Package-N SHA256 IDENTITY onto the named I61 live contract
+surfaces without rewriting Fill / CSV IO / eval CLI, without Cap 7.2 /
+src.execution, and without persistence, migration, or backfill.
+session_dir remains a filesystem hint and never fills SESSION or IDENTITY.
+Fill trade fields stay off the join surface.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+)
+from src.live_eval.i61_live_eval_join_attachment_v1 import (
+    I61LiveEvalJoinAttachmentError,
+    attach_i61_live_eval_join_v1,
+)
+
+CONTRACT_ID = "i61_live_eval_named_lane_identity_join_v1"
+I61_NAMED_LANE_IDENTITY_JOIN_REGISTERED = True
+
+LIVE_CONTRACT_SURFACES: tuple[str, ...] = (
+    "metrics",
+    "session",
+)
+
+_REQUIRED_METRICS_KEYS = frozenset(
+    {
+        "total_fills",
+        "symbols",
+        "start_ts",
+        "end_ts",
+        "total_notional",
+        "total_qty",
+        "vwap_overall",
+        "side_breakdown",
+        "realized_pnl_total",
+        "realized_pnl_per_symbol",
+    }
+)
+_OPTIONAL_METRICS_KEYS = frozenset({"vwap_per_symbol"})
+_SESSION_KEYS = frozenset({"session_dir"})
+_FORBIDDEN_LIVE_KEYS = frozenset(
+    {
+        "experiment_identity_id",
+        "experiment_id",
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "campaign_id",
+        "run_id",
+        "session_id",
+        "legacy_alias_md5_12",
+        "registry_run_id",
+        "mlflow_run_id",
+        "orders",
+        "credentials",
+        "promotion_authority",
+        "apply_authority",
+        "live_arming",
+        "I16",
+        "I17",
+        "I52",
+        "I56",
+        "I61",
+        "I65",
+        "plane_presence",
+        "join_key",
+    }
+)
+_FORBIDDEN_LIVE_CONTENT_KEYS = frozenset(
+    {
+        "payload",
+        "raw",
+        "raw_payload",
+        "transcript",
+        "secrets",
+        "orders",
+        "credentials",
+        "fills",
+        "ts",
+        "symbol",
+        "side",
+        "qty",
+        "fill_price",
+    }
+)
+_CROSS_LANE_KEYS = frozenset({"I16", "I17", "I52", "I56", "I65"})
+_CROSS_PLANE_KEYS = frozenset(
+    {
+        "plane_presence",
+        "join_key",
+        "fills",
+        "ts",
+        "symbol",
+        "side",
+        "qty",
+        "fill_price",
+    }
+)
+
+
+class I61LiveEvalNamedLaneIdentityJoinError(ValueError):
+    """Fail-closed I61 named-lane IDENTITY join error."""
+
+
+def _reject(message: str) -> None:
+    raise I61LiveEvalNamedLaneIdentityJoinError(message)
+
+
+def is_i61_named_lane_identity_join_registered() -> bool:
+    """True iff the I61 named-lane IDENTITY join is registered on live I61 surfaces."""
+    return I61_NAMED_LANE_IDENTITY_JOIN_REGISTERED is True
+
+
+def _looks_like_filesystem_path(value: str) -> bool:
+    return "/" in value or "\\" in value
+
+
+def _optional_sidecar(value: str | None, *, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip() or value != value.strip():
+        _reject(f"malformed plane data rejected: sidecar {field} is invalid")
+    return value
+
+
+def _require_identity(identity: object) -> str:
+    if identity is None:
+        _reject("implicit absence rejected: I61 named-lane IDENTITY is missing")
+    if not isinstance(identity, str) or not is_package_n_sha256_canonical_id(identity):
+        _reject(
+            "noncanonical ID substitution rejected: experiment_identity_id must be Package-N SHA256"
+        )
+    return identity
+
+
+def _reject_forbidden_keys(payload: Mapping[str, Any], *, surface: str) -> None:
+    keys = {str(key) for key in payload.keys()}
+    forbidden = sorted(keys & _FORBIDDEN_LIVE_KEYS)
+    if forbidden:
+        if forbidden[0] in _CROSS_LANE_KEYS:
+            _reject(f"cross-lane substitution rejected: {forbidden[0]}")
+        if forbidden[0] in _CROSS_PLANE_KEYS:
+            _reject(f"cross-plane substitution rejected: {forbidden[0]}")
+        _reject(f"noncanonical ID substitution rejected: {forbidden[0]}")
+    content = sorted(keys & _FORBIDDEN_LIVE_CONTENT_KEYS)
+    if content:
+        if content[0] in _CROSS_PLANE_KEYS:
+            _reject(f"cross-plane substitution rejected: {content[0]}")
+        _reject(f"malformed plane data rejected: I61 live surface {surface} carries {content[0]}")
+    allowed = (
+        _REQUIRED_METRICS_KEYS | _OPTIONAL_METRICS_KEYS if surface == "metrics" else _SESSION_KEYS
+    )
+    extra = sorted(keys - allowed - _FORBIDDEN_LIVE_KEYS - _FORBIDDEN_LIVE_CONTENT_KEYS)
+    if extra:
+        _reject(f"malformed plane data rejected: unknown I61 {surface} field: {extra[0]}")
+
+
+def _validate_metrics(payload: Mapping[str, Any]) -> dict[str, Any]:
+    missing = sorted(key for key in _REQUIRED_METRICS_KEYS if key not in payload)
+    if missing:
+        _reject(f"malformed plane data rejected: I61 metrics missing {missing[0]}")
+    if not isinstance(payload["symbols"], list):
+        _reject("malformed plane data rejected: I61 metrics symbols is not a list")
+    breakdown = payload["side_breakdown"]
+    if not isinstance(breakdown, Mapping):
+        _reject("malformed plane data rejected: I61 metrics side_breakdown is not an object")
+    for side in ("buy", "sell"):
+        if side not in breakdown or not isinstance(breakdown[side], Mapping):
+            _reject(f"malformed plane data rejected: I61 metrics side_breakdown missing {side}")
+        stats = breakdown[side]
+        for field in ("count", "qty", "notional"):
+            if field not in stats:
+                _reject(
+                    f"malformed plane data rejected: I61 metrics side_breakdown.{side} missing {field}"
+                )
+    if not isinstance(payload["realized_pnl_per_symbol"], Mapping):
+        _reject(
+            "malformed plane data rejected: I61 metrics realized_pnl_per_symbol is not an object"
+        )
+    try:
+        total_fills = int(payload["total_fills"])
+    except (TypeError, ValueError) as exc:
+        _reject(f"malformed plane data rejected: I61 metrics total_fills is invalid: {exc}")
+    if total_fills < 0:
+        _reject("malformed plane data rejected: I61 metrics total_fills is invalid")
+    return {}
+
+
+def _validate_session(payload: Mapping[str, Any]) -> dict[str, Any]:
+    if "session_dir" not in payload:
+        _reject("malformed plane data rejected: I61 session missing session_dir")
+    session_dir = payload["session_dir"]
+    if (
+        not isinstance(session_dir, str)
+        or not session_dir.strip()
+        or session_dir != session_dir.strip()
+    ):
+        _reject("malformed plane data rejected: I61 session_dir is invalid")
+    if not _looks_like_filesystem_path(session_dir):
+        _reject("malformed plane data rejected: I61 session_dir is not a filesystem path")
+    return {"session_dir": session_dir}
+
+
+def _extract_live_fields(live: Mapping[str, Any], *, surface: str) -> dict[str, Any]:
+    if surface == "session":
+        return _validate_session(live)
+    return _validate_metrics(live)
+
+
+def join_i61_named_lane_identity_v1(
+    live: object,
+    *,
+    surface: str,
+    experiment_identity_id: str | None = None,
+    run_id: str | None = None,
+    campaign_id: str | None = None,
+    session_id: str | None = None,
+    session_dir: str | None = None,
+    legacy_alias_md5_12: str | None = None,
+    content_sha256: str | None = None,
+    evidence_ref: str | None = None,
+    historical_provenance: Mapping[str, Any] | None = None,
+) -> CrossLaneIdentityJoinV1:
+    """Join Package-N SHA256 IDENTITY onto a named I61 live contract payload.
+
+    Does not mutate inputs and does not rewrite Fill, CSV IO, or the eval CLI.
+    """
+    if surface not in LIVE_CONTRACT_SURFACES:
+        _reject(f"malformed plane data rejected: unknown I61 live surface {surface}")
+    if isinstance(live, (list, tuple)):
+        _reject("ambiguous join rejected: I61 live surface has multiple Package-N assignments")
+    if not isinstance(live, Mapping):
+        _reject("malformed plane data rejected: I61 live payload is not an object")
+    snapshot = copy.deepcopy(dict(live))
+    _reject_forbidden_keys(live, surface=surface)
+
+    identity = _require_identity(experiment_identity_id)
+    extracted = _extract_live_fields(live, surface=surface)
+    sidecar_run = _optional_sidecar(run_id, field="run_id")
+    sidecar_campaign = _optional_sidecar(campaign_id, field="campaign_id")
+    sidecar_session = _optional_sidecar(session_id, field="session_id")
+    sidecar_dir = _optional_sidecar(session_dir, field="session_dir")
+    sidecar_alias = _optional_sidecar(legacy_alias_md5_12, field="legacy_alias_md5_12")
+    sidecar_hash = _optional_sidecar(content_sha256, field="content_sha256")
+    sidecar_evidence = _optional_sidecar(evidence_ref, field="evidence_ref")
+    if sidecar_dir is not None and not _looks_like_filesystem_path(sidecar_dir):
+        _reject("malformed plane data rejected: I61 session_dir is not a filesystem path")
+
+    live_dir = extracted.get("session_dir")
+    if sidecar_dir is not None and live_dir and sidecar_dir != live_dir:
+        _reject("conflicting identity rejected: session_dir values disagree")
+
+    payload: dict[str, Any] = {"experiment_identity_id": identity}
+    if live_dir:
+        payload["session_dir"] = live_dir
+    elif sidecar_dir is not None:
+        payload["session_dir"] = sidecar_dir
+    if sidecar_run is not None:
+        payload["run_id"] = sidecar_run
+    if sidecar_campaign is not None:
+        payload["campaign_id"] = sidecar_campaign
+    if sidecar_session is not None:
+        payload["session_id"] = sidecar_session
+    if sidecar_alias is not None:
+        payload["legacy_alias_md5_12"] = sidecar_alias
+    if sidecar_hash is not None:
+        payload["content_sha256"] = sidecar_hash
+    if sidecar_evidence is not None:
+        payload["evidence_ref"] = sidecar_evidence
+    if historical_provenance is not None:
+        if not isinstance(historical_provenance, Mapping):
+            _reject("malformed plane data rejected: historical_provenance must be an object")
+        provenance_copy = copy.deepcopy(dict(historical_provenance))
+        nested = provenance_copy.get("experiment_identity_id")
+        if nested is not None and nested != identity:
+            _reject("conflicting identity rejected: historical_provenance.experiment_identity_id")
+        payload["historical_provenance"] = provenance_copy
+
+    try:
+        record = attach_i61_live_eval_join_v1(payload)
+    except I61LiveEvalJoinAttachmentError as exc:
+        message = str(exc)
+        if "must not substitute" in message or "session-dir path is not" in message:
+            _reject(f"cross-plane substitution rejected: {exc}")
+        if "conflicting" in message:
+            _reject(f"conflicting identity rejected: {exc}")
+        if "Package-N SHA256" in message or "must not be UUID" in message:
+            _reject(f"noncanonical ID substitution rejected: {exc}")
+        raise I61LiveEvalNamedLaneIdentityJoinError(
+            f"I61 named-lane IDENTITY join rejected by R8 attachment: {exc}"
+        ) from exc
+
+    if dict(live) != snapshot:
+        _reject("I61 live payload input was mutated")
+    return record
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "I61LiveEvalNamedLaneIdentityJoinError",
+    "I61_NAMED_LANE_IDENTITY_JOIN_REGISTERED",
+    "LIVE_CONTRACT_SURFACES",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "is_i61_named_lane_identity_join_registered",
+    "join_i61_named_lane_identity_v1",
+]

--- a/src/live_eval/live_session_eval.py
+++ b/src/live_eval/live_session_eval.py
@@ -1,9 +1,15 @@
 """Core evaluation logic for live session fills."""
 
+import copy
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, List, Any
+from typing import Any, Dict, List, Mapping
 from collections import defaultdict
+
+from src.experiments.cross_lane_identity_join_v1 import CrossLaneIdentityJoinV1
+from src.live_eval.i61_live_eval_named_lane_identity_join_v1 import (
+    join_i61_named_lane_identity_v1,
+)
 
 
 @dataclass
@@ -160,3 +166,45 @@ def compute_metrics(fills: List[Fill], strict: bool = False) -> Dict[str, Any]:
         "realized_pnl_total": realized_pnl_total,
         "realized_pnl_per_symbol": realized_pnl_per_symbol,
     }
+
+
+@dataclass(frozen=True)
+class LiveSessionMetricsNamedLaneIdentityJoinResultV1:
+    contract: Dict[str, Any]
+    join: CrossLaneIdentityJoinV1
+
+
+@dataclass(frozen=True)
+class LiveSessionDirNamedLaneIdentityJoinResultV1:
+    contract: Dict[str, Any]
+    join: CrossLaneIdentityJoinV1
+
+
+def parse_live_session_metrics_with_identity_join_v1(
+    raw: Mapping[str, Any],
+    **sidecars: Any,
+) -> LiveSessionMetricsNamedLaneIdentityJoinResultV1:
+    """Parse live I61 metrics and fail-closed join Package-N IDENTITY sidecar."""
+    snapshot = copy.deepcopy(dict(raw)) if isinstance(raw, Mapping) else None
+    join = join_i61_named_lane_identity_v1(raw, surface="metrics", **sidecars)
+    if not isinstance(raw, Mapping) or snapshot is None:
+        raise ValueError("malformed plane data rejected: I61 metrics is not an object")
+    contract = copy.deepcopy(dict(raw))
+    if dict(raw) != snapshot:
+        raise ValueError("I61 metrics input was mutated")
+    return LiveSessionMetricsNamedLaneIdentityJoinResultV1(contract=contract, join=join)
+
+
+def parse_live_session_dir_with_identity_join_v1(
+    raw: Mapping[str, Any],
+    **sidecars: Any,
+) -> LiveSessionDirNamedLaneIdentityJoinResultV1:
+    """Parse a live I61 session-dir hint and fail-closed join Package-N IDENTITY sidecar."""
+    snapshot = copy.deepcopy(dict(raw)) if isinstance(raw, Mapping) else None
+    join = join_i61_named_lane_identity_v1(raw, surface="session", **sidecars)
+    if not isinstance(raw, Mapping) or snapshot is None:
+        raise ValueError("malformed plane data rejected: I61 session is not an object")
+    contract = {"session_dir": str(raw["session_dir"])}
+    if dict(raw) != snapshot:
+        raise ValueError("I61 session input was mutated")
+    return LiveSessionDirNamedLaneIdentityJoinResultV1(contract=contract, join=join)

--- a/src/ops/paper_shadow_observation_operator_go_session_preregistration_v1/authorization_artifact_v1.py
+++ b/src/ops/paper_shadow_observation_operator_go_session_preregistration_v1/authorization_artifact_v1.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import copy
 import json
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
+from src.experiments.cross_lane_identity_join_v1 import CrossLaneIdentityJoinV1
 from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.confirm_token_v1 import (
     assert_no_plaintext_token_fields,
     verify_confirm_token_v1,
@@ -18,6 +20,9 @@ from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.con
     CAPABILITY_ID,
     NETWORK_SCOPE_OKX_EEA_FUTURES_PUBLIC_MD_OBSERVE_V1,
     SESSION_EXECUTION_SCOPE_PAPER_SHADOW_OBSERVATION_WALLCLOCK_V1,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.i17_paper_shadow_named_lane_identity_join_v1 import (
+    join_i17_named_lane_identity_v1,
 )
 from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.operator_go_contract_v1 import (
     OperatorGoContractV1,
@@ -129,6 +134,12 @@ class AuthorizationBuildResultV1:
             "artifact": None if self.artifact is None else self.artifact.to_dict(),
             "session_executed": False,
         }
+
+
+@dataclass(frozen=True)
+class AuthorizationArtifactNamedLaneIdentityJoinResultV1:
+    artifact: AuthorizationArtifactV1
+    join: CrossLaneIdentityJoinV1
 
 
 def build_authorization_artifact_v1(
@@ -367,3 +378,31 @@ def validate_authorization_artifact_v1(
         artifact=artifact,
         notes=notes,
     )
+
+
+def parse_authorization_artifact_with_identity_join_v1(
+    raw: Mapping[str, Any],
+    *,
+    experiment_identity_id: str,
+    run_id: Optional[str] = None,
+    legacy_alias_md5_12: Optional[str] = None,
+    content_sha256: Optional[str] = None,
+    historical_provenance: Optional[Mapping[str, Any]] = None,
+) -> AuthorizationArtifactNamedLaneIdentityJoinResultV1:
+    """Parse a live I17 authorization artifact and fail-closed join Package-N IDENTITY."""
+    if not isinstance(raw, Mapping):
+        raise AuthorizationArtifactError("AUTHORIZATION_ARTIFACT_NOT_OBJECT")
+    snapshot = copy.deepcopy(dict(raw))
+    artifact = parse_authorization_artifact_v1(raw)
+    join = join_i17_named_lane_identity_v1(
+        artifact.to_dict(),
+        experiment_identity_id=experiment_identity_id,
+        surface="authorization_artifact",
+        run_id=run_id,
+        legacy_alias_md5_12=legacy_alias_md5_12,
+        content_sha256=content_sha256,
+        historical_provenance=historical_provenance,
+    )
+    if dict(raw) != snapshot:
+        raise AuthorizationArtifactError("AUTH_INPUT_MUTATED")
+    return AuthorizationArtifactNamedLaneIdentityJoinResultV1(artifact=artifact, join=join)

--- a/src/ops/paper_shadow_observation_operator_go_session_preregistration_v1/i17_paper_shadow_join_attachment_v1.py
+++ b/src/ops/paper_shadow_observation_operator_go_session_preregistration_v1/i17_paper_shadow_join_attachment_v1.py
@@ -1,0 +1,219 @@
+"""EG-I82-JOIN U-I82-R5 — dormant I17 paper-shadow join attachment.
+
+Adds Package-N SHA256 IDENTITY onto I17 prereg/GO/artifact join payloads.
+session_id remains SESSION and is required independently of IDENTITY.
+Does not rewrite live preregistration/GO/artifact contracts, does not
+register into runtime/execution, and does not import Cap 7.2.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+from src.experiments.cross_lane_identity_join_record_v1 import (
+    CrossLaneIdentityJoinRecordError,
+    build_cross_lane_identity_join_record_v1,
+)
+from src.experiments.cross_lane_identity_join_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    JOIN_PLANES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    PlanePresence,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+)
+from src.meta.learning_loop.contract_safety_v1 import is_valid_sha256_hex
+
+CONTRACT_ID = "i17_paper_shadow_join_attachment_v1"
+
+_KNOWN_KEYS = frozenset(
+    {
+        "experiment_identity_id",
+        "session_id",
+        "run_id",
+        "legacy_alias_md5_12",
+        "evidence_ref",
+        "evidence_root",
+        "content_sha256",
+        "scope_digest",
+        "config_identity",
+        "code_identity",
+        "expected_repository_sha",
+        "go_id",
+        "authorization_id",
+        "historical_provenance",
+    }
+)
+_FORBIDDEN_KEYS = frozenset(
+    {
+        "orders",
+        "credentials",
+        "promotion_authority",
+        "apply_authority",
+        "live_arming",
+        "campaign_id",
+        "experiment_id",
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "registry_run_id",
+        "mlflow_run_id",
+    }
+)
+_NON_IDENTITY_I17_FIELDS = (
+    "session_id",
+    "run_id",
+    "config_identity",
+    "code_identity",
+    "expected_repository_sha",
+    "go_id",
+    "authorization_id",
+)
+
+
+class I17PaperShadowJoinAttachmentError(ValueError):
+    """Fail-closed I17 paper-shadow join attachment error."""
+
+
+def _reject(message: str) -> None:
+    raise I17PaperShadowJoinAttachmentError(message)
+
+
+def _optional_str(payload: Mapping[str, Any], key: str) -> str | None:
+    if key not in payload:
+        return None
+    value = payload[key]
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        _reject(f"{key} must be a string when present")
+    if not value.strip() or value != value.strip():
+        _reject(f"{key} is present but empty or whitespace-padded")
+    return value
+
+
+def _present(plane: str, value: str, join_key: str) -> dict[str, str]:
+    return {
+        "plane": plane,
+        "presence": PlanePresence.PRESENT.value,
+        "join_key": join_key,
+        "value": value,
+    }
+
+
+def _absent(plane: str) -> dict[str, str]:
+    return {"plane": plane, "presence": PlanePresence.ABSENT_DECLARED.value}
+
+
+def _resolve_identity(payload: Mapping[str, Any]) -> str:
+    identity = _optional_str(payload, "experiment_identity_id")
+    if identity is None:
+        _reject("I17 IDENTITY missing: experiment_identity_id required")
+    if not is_package_n_sha256_canonical_id(identity):
+        _reject("experiment_identity_id must be Package-N SHA256")
+    return identity
+
+
+def _require_session_id(payload: Mapping[str, Any]) -> str:
+    session_id = _optional_str(payload, "session_id")
+    if session_id is None:
+        _reject("I17 SESSION missing: session_id required independently of IDENTITY")
+    return session_id
+
+
+def _evidence_ref(payload: Mapping[str, Any]) -> str | None:
+    evidence = _optional_str(payload, "evidence_ref")
+    evidence_root = _optional_str(payload, "evidence_root")
+    if evidence is not None and evidence_root is not None and evidence != evidence_root:
+        _reject("conflicting EVIDENCE values")
+    return evidence if evidence is not None else evidence_root
+
+
+def _content_sha256(payload: Mapping[str, Any]) -> str | None:
+    direct = _optional_str(payload, "content_sha256")
+    scope_digest = _optional_str(payload, "scope_digest")
+    candidates: list[str] = []
+    for label, value in (("content_sha256", direct), ("scope_digest", scope_digest)):
+        if value is None:
+            continue
+        if not is_valid_sha256_hex(value):
+            _reject(f"{label} must be 64-char lowercase sha256 hex when used as CONTENT_HASH")
+        candidates.append(value)
+    if len(set(candidates)) > 1:
+        _reject("conflicting CONTENT_HASH values")
+    return candidates[0] if candidates else None
+
+
+def attach_i17_paper_shadow_join_v1(
+    i17_identity: Mapping[str, Any],
+) -> CrossLaneIdentityJoinV1:
+    """Attach Package-N SHA256 IDENTITY onto an I17 prereg/GO/artifact join payload."""
+    if not isinstance(i17_identity, Mapping):
+        _reject("I17 identity payload must be an object")
+    forbidden = sorted(str(key) for key in i17_identity.keys() if str(key) in _FORBIDDEN_KEYS)
+    if forbidden:
+        _reject(f"forbidden I17 join field: {forbidden[0]}")
+    extra = sorted(str(key) for key in i17_identity.keys() if str(key) not in _KNOWN_KEYS)
+    if extra:
+        _reject(f"unknown I17 join field: {extra[0]}")
+
+    identity_id = _resolve_identity(i17_identity)
+    session_id = _require_session_id(i17_identity)
+    run_id = _optional_str(i17_identity, "run_id")
+    alias = _optional_str(i17_identity, "legacy_alias_md5_12")
+    evidence = _evidence_ref(i17_identity)
+    content_hash = _content_sha256(i17_identity)
+    provenance = i17_identity.get("historical_provenance")
+    if provenance is not None and not isinstance(provenance, Mapping):
+        _reject("historical_provenance must be an object")
+    provenance_copy = copy.deepcopy(dict(provenance)) if isinstance(provenance, Mapping) else {}
+
+    if session_id == identity_id:
+        _reject("session_id must not substitute for Package-N SHA256 IDENTITY")
+    for label in _NON_IDENTITY_I17_FIELDS:
+        value = _optional_str(i17_identity, label)
+        if value is not None and value == identity_id:
+            _reject(f"{label} must not substitute for Package-N SHA256 IDENTITY")
+
+    contributions = {
+        "IDENTITY": _present("IDENTITY", identity_id, identity_id),
+        "ALIAS": _present("ALIAS", alias, identity_id) if alias is not None else _absent("ALIAS"),
+        "RUN": _present("RUN", run_id, identity_id) if run_id is not None else _absent("RUN"),
+        "CAMPAIGN": _absent("CAMPAIGN"),
+        "SESSION": _present("SESSION", session_id, identity_id),
+        "EVIDENCE": (
+            _present("EVIDENCE", evidence, identity_id)
+            if evidence is not None
+            else _absent("EVIDENCE")
+        ),
+        "CONTENT_HASH": (
+            _present("CONTENT_HASH", content_hash, identity_id)
+            if content_hash is not None
+            else _absent("CONTENT_HASH")
+        ),
+    }
+    ordered = [contributions[plane] for plane in JOIN_PLANES]
+    try:
+        return build_cross_lane_identity_join_record_v1(
+            ordered,
+            package_n_identity_id=identity_id,
+            historical_provenance=provenance_copy or None,
+        )
+    except CrossLaneIdentityJoinRecordError as exc:
+        raise I17PaperShadowJoinAttachmentError(
+            f"I17 paper-shadow join rejected by R3 primitive: {exc}"
+        ) from exc
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "I17PaperShadowJoinAttachmentError",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "attach_i17_paper_shadow_join_v1",
+]

--- a/src/ops/paper_shadow_observation_operator_go_session_preregistration_v1/i17_paper_shadow_live_contract_join_v1.py
+++ b/src/ops/paper_shadow_observation_operator_go_session_preregistration_v1/i17_paper_shadow_live_contract_join_v1.py
@@ -1,0 +1,335 @@
+"""EG-I82-JOIN U-I82-R12 — dormant I17 live-contract join registration.
+
+Binds Package-N SHA256 IDENTITY onto validated I17 prereg/GO/artifact
+payloads without rewriting those live schemas, without hooking Cap 7.2 /
+src.execution, and without persistence, migration, or backfill.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.authorization_artifact_v1 import (
+    AuthorizationArtifactError,
+    parse_authorization_artifact_v1,
+    validate_authorization_artifact_v1,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.i17_paper_shadow_join_attachment_v1 import (
+    I17PaperShadowJoinAttachmentError,
+    attach_i17_paper_shadow_join_v1,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.operator_go_contract_v1 import (
+    OperatorGoContractError,
+    parse_operator_go_contract_v1,
+    validate_operator_go_contract_v1,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.preregistration_contract_v1 import (
+    PreregistrationContractError,
+    parse_preregistration_contract_v1,
+    validate_preregistration_contract_v1,
+)
+
+CONTRACT_ID = "i17_paper_shadow_live_contract_join_v1"
+I17_LIVE_CONTRACT_REGISTERED = True
+
+LIVE_CONTRACT_SURFACES: tuple[str, ...] = (
+    "preregistration",
+    "operator_go",
+    "authorization_artifact",
+)
+
+_KNOWN_ENVELOPE_KEYS = frozenset(
+    {
+        "experiment_identity_id",
+        "preregistration",
+        "operator_go",
+        "authorization_artifact",
+        "run_id",
+        "legacy_alias_md5_12",
+        "evidence_ref",
+        "content_sha256",
+        "historical_provenance",
+    }
+)
+_FORBIDDEN_ENVELOPE_KEYS = frozenset(
+    {
+        "session_id",
+        "campaign_id",
+        "experiment_id",
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "registry_run_id",
+        "mlflow_run_id",
+        "orders",
+        "credentials",
+        "promotion_authority",
+        "apply_authority",
+        "live_arming",
+        "I16",
+        "I17",
+        "I52",
+        "I56",
+        "I61",
+        "I65",
+        "plane_presence",
+        "join_key",
+    }
+)
+_LIVE_IDENTITY_SUBSTITUTE_KEYS = frozenset(
+    {
+        "experiment_identity_id",
+        "experiment_id",
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "plane_presence",
+        "join_key",
+        "I16",
+        "I52",
+        "I56",
+        "I61",
+        "I65",
+    }
+)
+
+
+class I17PaperShadowLiveContractJoinError(ValueError):
+    """Fail-closed I17 live-contract join registration error."""
+
+
+def _reject(message: str) -> None:
+    raise I17PaperShadowLiveContractJoinError(message)
+
+
+def is_i17_live_contract_registered() -> bool:
+    """True iff the dormant I17 live-contract join surface is registered."""
+    return I17_LIVE_CONTRACT_REGISTERED is True
+
+
+def _optional_str(payload: Mapping[str, Any], key: str) -> str | None:
+    if key not in payload:
+        return None
+    value = payload[key]
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        _reject(f"{key} must be a string when present")
+    if not value.strip() or value != value.strip():
+        _reject(f"{key} is present but empty or whitespace-padded")
+    return value
+
+
+def _require_identity(envelope: Mapping[str, Any]) -> str:
+    if "experiment_identity_id" not in envelope:
+        _reject("implicit absence rejected: I17 live-contract IDENTITY is missing")
+    identity = envelope.get("experiment_identity_id")
+    if identity is None:
+        _reject("implicit absence rejected: I17 live-contract IDENTITY is missing")
+    if not isinstance(identity, str) or not is_package_n_sha256_canonical_id(identity):
+        _reject(
+            "noncanonical ID substitution rejected: experiment_identity_id must be Package-N SHA256"
+        )
+    return identity
+
+
+def _snapshot_live_payload(raw: object, *, surface: str) -> dict[str, Any]:
+    if raw is None:
+        _reject(f"implicit absence rejected: I17 live surface {surface} is missing")
+    if isinstance(raw, (list, tuple)):
+        if not raw:
+            _reject(f"implicit absence rejected: I17 live surface {surface} is missing")
+        if len(raw) != 1:
+            _reject(
+                f"ambiguous join rejected: I17 live surface {surface} has multiple Package-N assignments"
+            )
+        return _snapshot_live_payload(raw[0], surface=surface)
+    if not isinstance(raw, Mapping):
+        _reject(f"malformed plane data rejected: I17 live surface {surface} is not an object")
+    return copy.deepcopy(dict(raw))
+
+
+def _reject_live_identity_substitution(payload: Mapping[str, Any], *, surface: str) -> None:
+    substitutes = sorted(
+        str(key) for key in payload.keys() if str(key) in _LIVE_IDENTITY_SUBSTITUTE_KEYS
+    )
+    if substitutes:
+        _reject(
+            f"noncanonical ID substitution rejected: live surface {surface} uses {substitutes[0]} "
+            "as Package-N identity"
+        )
+
+
+def _select_live_surface(envelope: Mapping[str, Any]) -> tuple[str, dict[str, Any]]:
+    present = [name for name in LIVE_CONTRACT_SURFACES if name in envelope]
+    if not present:
+        _reject("implicit absence rejected: I17 live contract surface is missing")
+    if len(present) != 1:
+        _reject("ambiguous join rejected: I17 live contract has multiple Package-N assignments")
+    surface = present[0]
+    return surface, _snapshot_live_payload(envelope[surface], surface=surface)
+
+
+def _validate_preregistration(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    try:
+        contract = parse_preregistration_contract_v1(payload)
+        result = validate_preregistration_contract_v1(contract)
+    except PreregistrationContractError as exc:
+        _reject(f"malformed plane data rejected: I17 preregistration is invalid: {exc}")
+    if not result.ok:
+        _reject(
+            "malformed plane data rejected: I17 preregistration is invalid: "
+            + ",".join(result.blockers)
+        )
+    return contract.to_dict()
+
+
+def _validate_operator_go(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    try:
+        contract = parse_operator_go_contract_v1(payload)
+        result = validate_operator_go_contract_v1(contract)
+    except OperatorGoContractError as exc:
+        _reject(f"malformed plane data rejected: I17 operator_go is invalid: {exc}")
+    if not result.ok:
+        _reject(
+            "malformed plane data rejected: I17 operator_go is invalid: "
+            + ",".join(result.blockers)
+        )
+    return contract.to_dict()
+
+
+def _validate_authorization_artifact(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    try:
+        artifact = parse_authorization_artifact_v1(payload)
+        result = validate_authorization_artifact_v1(artifact)
+    except AuthorizationArtifactError as exc:
+        _reject(f"malformed plane data rejected: I17 authorization_artifact is invalid: {exc}")
+    if not result.ok:
+        _reject(
+            "malformed plane data rejected: I17 authorization_artifact is invalid: "
+            + ",".join(result.blockers)
+        )
+    return artifact.to_dict()
+
+
+_SURFACE_VALIDATORS = {
+    "preregistration": _validate_preregistration,
+    "operator_go": _validate_operator_go,
+    "authorization_artifact": _validate_authorization_artifact,
+}
+
+
+def _join_payload(
+    *,
+    identity_id: str,
+    live: Mapping[str, Any],
+    envelope: Mapping[str, Any],
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "experiment_identity_id": identity_id,
+        "session_id": live["session_id"],
+        "config_identity": live.get("config_identity"),
+        "code_identity": live.get("code_identity"),
+        "expected_repository_sha": live.get("expected_repository_sha"),
+    }
+    if live.get("evidence_root"):
+        payload["evidence_root"] = live["evidence_root"]
+    if live.get("go_id"):
+        payload["go_id"] = live["go_id"]
+    if live.get("authorization_id"):
+        payload["authorization_id"] = live["authorization_id"]
+
+    envelope_evidence = _optional_str(envelope, "evidence_ref")
+    live_evidence = live.get("evidence_root")
+    if envelope_evidence is not None and live_evidence and envelope_evidence != live_evidence:
+        _reject("conflicting identity rejected: EVIDENCE values disagree")
+    if envelope_evidence is not None:
+        payload["evidence_ref"] = envelope_evidence
+
+    envelope_hash = _optional_str(envelope, "content_sha256")
+    live_hash = live.get("scope_digest")
+    if (
+        envelope_hash is not None
+        and isinstance(live_hash, str)
+        and live_hash
+        and envelope_hash != live_hash
+    ):
+        _reject("conflicting identity rejected: CONTENT_HASH values disagree")
+    if envelope_hash is not None:
+        payload["content_sha256"] = envelope_hash
+    elif isinstance(live_hash, str) and live_hash:
+        payload["content_sha256"] = live_hash
+
+    run_id = _optional_str(envelope, "run_id")
+    if run_id is not None:
+        payload["run_id"] = run_id
+    alias = _optional_str(envelope, "legacy_alias_md5_12")
+    if alias is not None:
+        payload["legacy_alias_md5_12"] = alias
+    provenance = envelope.get("historical_provenance")
+    if provenance is not None:
+        payload["historical_provenance"] = copy.deepcopy(provenance)
+    return {key: value for key, value in payload.items() if value is not None}
+
+
+def register_i17_live_contract_join_v1(
+    live_join: Mapping[str, Any],
+) -> CrossLaneIdentityJoinV1:
+    """Register an I17 live-contract payload onto the Package-N SHA256 join path."""
+    if not isinstance(live_join, Mapping):
+        _reject("malformed plane data rejected: I17 live-contract envelope is not an object")
+    snapshot = copy.deepcopy(dict(live_join))
+    forbidden = sorted(str(key) for key in live_join.keys() if str(key) in _FORBIDDEN_ENVELOPE_KEYS)
+    if forbidden:
+        if forbidden[0] in {"I16", "I52", "I56", "I61", "I65"}:
+            _reject(f"cross-lane substitution rejected: {forbidden[0]}")
+        if forbidden[0] in {"plane_presence", "join_key"}:
+            _reject(f"cross-plane substitution rejected: {forbidden[0]}")
+        _reject(f"noncanonical ID substitution rejected: {forbidden[0]}")
+    extra = sorted(str(key) for key in live_join.keys() if str(key) not in _KNOWN_ENVELOPE_KEYS)
+    if extra:
+        _reject(f"malformed plane data rejected: unknown I17 live-contract field: {extra[0]}")
+
+    identity_id = _require_identity(live_join)
+    surface, live_payload = _select_live_surface(live_join)
+    _reject_live_identity_substitution(live_payload, surface=surface)
+    validated = _SURFACE_VALIDATORS[surface](live_payload)
+    attachment = _join_payload(identity_id=identity_id, live=validated, envelope=live_join)
+    try:
+        record = attach_i17_paper_shadow_join_v1(attachment)
+    except I17PaperShadowJoinAttachmentError as exc:
+        message = str(exc)
+        if "must not substitute" in message:
+            _reject(f"cross-plane substitution rejected: {exc}")
+        raise I17PaperShadowLiveContractJoinError(
+            f"I17 live-contract join rejected by R5 attachment: {exc}"
+        ) from exc
+
+    if dict(live_join) != snapshot:
+        _reject("I17 live-contract envelope input was mutated")
+    return record
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "I17PaperShadowLiveContractJoinError",
+    "I17_LIVE_CONTRACT_REGISTERED",
+    "LIVE_CONTRACT_SURFACES",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "is_i17_live_contract_registered",
+    "register_i17_live_contract_join_v1",
+]

--- a/src/ops/paper_shadow_observation_operator_go_session_preregistration_v1/i17_paper_shadow_named_lane_identity_join_v1.py
+++ b/src/ops/paper_shadow_observation_operator_go_session_preregistration_v1/i17_paper_shadow_named_lane_identity_join_v1.py
@@ -1,0 +1,197 @@
+"""EG-I82-JOIN U-I82-R19 — I17 named-lane IDENTITY join on prereg/GO/artifact.
+
+Attaches Package-N SHA256 IDENTITY onto the named I17 live contract
+surfaces without rewriting persisted prereg/GO/artifact schemas, without
+Cap 7.2 / src.execution, and without persistence, migration, or backfill.
+session_id remains SESSION and is required independently of IDENTITY.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Mapping
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.i17_paper_shadow_join_attachment_v1 import (
+    I17PaperShadowJoinAttachmentError,
+    attach_i17_paper_shadow_join_v1,
+)
+
+CONTRACT_ID = "i17_paper_shadow_named_lane_identity_join_v1"
+I17_NAMED_LANE_IDENTITY_JOIN_REGISTERED = True
+
+LIVE_CONTRACT_SURFACES: tuple[str, ...] = (
+    "preregistration",
+    "operator_go",
+    "authorization_artifact",
+)
+
+_FORBIDDEN_LIVE_KEYS = frozenset(
+    {
+        "experiment_identity_id",
+        "experiment_id",
+        "identity_id",
+        "ref_id",
+        "canonical_id",
+        "canonical_identity_id",
+        "package_n_sha256",
+        "campaign_id",
+        "run_id",
+        "legacy_alias_md5_12",
+        "registry_run_id",
+        "mlflow_run_id",
+        "orders",
+        "credentials",
+        "promotion_authority",
+        "apply_authority",
+        "live_arming",
+        "I16",
+        "I17",
+        "I52",
+        "I56",
+        "I61",
+        "I65",
+        "plane_presence",
+        "join_key",
+    }
+)
+
+
+class I17PaperShadowNamedLaneIdentityJoinError(ValueError):
+    """Fail-closed I17 named-lane IDENTITY join error."""
+
+
+def _reject(message: str) -> None:
+    raise I17PaperShadowNamedLaneIdentityJoinError(message)
+
+
+def is_i17_named_lane_identity_join_registered() -> bool:
+    """True iff the I17 named-lane IDENTITY join is registered on live I17 surfaces."""
+    return I17_NAMED_LANE_IDENTITY_JOIN_REGISTERED is True
+
+
+def _optional_sidecar(value: str | None, *, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip() or value != value.strip():
+        _reject(f"malformed plane data rejected: sidecar {field} is invalid")
+    return value
+
+
+def _require_identity(identity: object) -> str:
+    if identity is None:
+        _reject("implicit absence rejected: I17 named-lane IDENTITY is missing")
+    if not isinstance(identity, str) or not is_package_n_sha256_canonical_id(identity):
+        _reject(
+            "noncanonical ID substitution rejected: experiment_identity_id must be Package-N SHA256"
+        )
+    return identity
+
+
+def join_i17_named_lane_identity_v1(
+    live: Mapping[str, Any],
+    *,
+    experiment_identity_id: str,
+    surface: str,
+    run_id: str | None = None,
+    legacy_alias_md5_12: str | None = None,
+    content_sha256: str | None = None,
+    historical_provenance: Mapping[str, Any] | None = None,
+) -> CrossLaneIdentityJoinV1:
+    """Join Package-N SHA256 IDENTITY onto a named I17 live contract payload.
+
+    Does not mutate inputs and does not rewrite persisted I17 schemas.
+    """
+    if surface not in LIVE_CONTRACT_SURFACES:
+        _reject(f"malformed plane data rejected: unknown I17 live surface {surface}")
+    if not isinstance(live, Mapping):
+        _reject("malformed plane data rejected: I17 live payload is not an object")
+    snapshot = copy.deepcopy(dict(live))
+    forbidden = sorted(str(key) for key in live.keys() if str(key) in _FORBIDDEN_LIVE_KEYS)
+    if forbidden:
+        if forbidden[0] in {"I16", "I52", "I56", "I61", "I65"}:
+            _reject(f"cross-lane substitution rejected: {forbidden[0]}")
+        if forbidden[0] in {"plane_presence", "join_key"}:
+            _reject(f"cross-plane substitution rejected: {forbidden[0]}")
+        _reject(f"noncanonical ID substitution rejected: {forbidden[0]}")
+
+    identity = _require_identity(experiment_identity_id)
+    session_id = live.get("session_id")
+    if not isinstance(session_id, str) or not session_id.strip():
+        _reject("implicit absence rejected: I17 SESSION is missing")
+
+    sidecar_run = _optional_sidecar(run_id, field="run_id")
+    sidecar_alias = _optional_sidecar(legacy_alias_md5_12, field="legacy_alias_md5_12")
+    sidecar_hash = _optional_sidecar(content_sha256, field="content_sha256")
+
+    payload: dict[str, Any] = {
+        "experiment_identity_id": identity,
+        "session_id": session_id,
+    }
+    evidence_root = live.get("evidence_root")
+    if isinstance(evidence_root, str) and evidence_root.strip():
+        payload["evidence_root"] = evidence_root
+    for field in ("config_identity", "code_identity", "expected_repository_sha"):
+        value = live.get(field)
+        if isinstance(value, str) and value.strip():
+            payload[field] = value
+    go_id = live.get("go_id")
+    if isinstance(go_id, str) and go_id.strip():
+        payload["go_id"] = go_id
+    authorization_id = live.get("authorization_id")
+    if isinstance(authorization_id, str) and authorization_id.strip():
+        payload["authorization_id"] = authorization_id
+    live_hash = live.get("scope_digest")
+    if sidecar_hash is not None:
+        payload["content_sha256"] = sidecar_hash
+    elif isinstance(live_hash, str) and live_hash.strip():
+        payload["content_sha256"] = live_hash
+    if sidecar_run is not None:
+        payload["run_id"] = sidecar_run
+    if sidecar_alias is not None:
+        payload["legacy_alias_md5_12"] = sidecar_alias
+    if historical_provenance is not None:
+        if not isinstance(historical_provenance, Mapping):
+            _reject("malformed plane data rejected: historical_provenance must be an object")
+        provenance_copy = copy.deepcopy(dict(historical_provenance))
+        nested = provenance_copy.get("experiment_identity_id")
+        if nested is not None and nested != identity:
+            _reject("conflicting identity rejected: historical_provenance.experiment_identity_id")
+        payload["historical_provenance"] = provenance_copy
+
+    try:
+        record = attach_i17_paper_shadow_join_v1(payload)
+    except I17PaperShadowJoinAttachmentError as exc:
+        message = str(exc)
+        if "must not substitute" in message:
+            _reject(f"cross-plane substitution rejected: {exc}")
+        if "conflicting" in message:
+            _reject(f"conflicting identity rejected: {exc}")
+        if "Package-N SHA256" in message or "must not be UUID" in message:
+            _reject(f"noncanonical ID substitution rejected: {exc}")
+        raise I17PaperShadowNamedLaneIdentityJoinError(
+            f"I17 named-lane IDENTITY join rejected by R5 attachment: {exc}"
+        ) from exc
+
+    if dict(live) != snapshot:
+        _reject("I17 live payload input was mutated")
+    return record
+
+
+__all__ = [
+    "CONTRACT_ID",
+    "CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS",
+    "I17PaperShadowNamedLaneIdentityJoinError",
+    "I17_NAMED_LANE_IDENTITY_JOIN_REGISTERED",
+    "LIVE_CONTRACT_SURFACES",
+    "MULTI_FUTURE_RUNTIME_AUTHORIZED",
+    "SECOND_EXECUTION_AUTHORITY_AUTHORIZED",
+    "is_i17_named_lane_identity_join_registered",
+    "join_i17_named_lane_identity_v1",
+]

--- a/src/ops/paper_shadow_observation_operator_go_session_preregistration_v1/operator_go_contract_v1.py
+++ b/src/ops/paper_shadow_observation_operator_go_session_preregistration_v1/operator_go_contract_v1.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
+from src.experiments.cross_lane_identity_join_v1 import CrossLaneIdentityJoinV1
 from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.confirm_token_v1 import (
     assert_no_plaintext_token_fields,
 )
@@ -24,6 +26,9 @@ from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.con
     REQUIRED_MODE,
     SESSION_EXECUTION_SCOPE_PAPER_SHADOW_OBSERVATION_WALLCLOCK_V1,
     VENUE_OKX,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.i17_paper_shadow_named_lane_identity_join_v1 import (
+    join_i17_named_lane_identity_v1,
 )
 from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.preregistration_contract_v1 import (
     SessionPreregistrationContractV1,
@@ -154,6 +159,12 @@ class OperatorGoValidationResultV1:
             "paper_shadow_observation_authorized": False,
             "session_executed": False,
         }
+
+
+@dataclass(frozen=True)
+class OperatorGoNamedLaneIdentityJoinResultV1:
+    contract: OperatorGoContractV1
+    join: CrossLaneIdentityJoinV1
 
 
 def _req(raw: Mapping[str, Any], name: str) -> Any:
@@ -420,3 +431,31 @@ def validate_operator_go_path_v1(
         now_unix=now_unix,
         expected_repository_sha=expected_repository_sha,
     )
+
+
+def parse_operator_go_contract_with_identity_join_v1(
+    raw: Mapping[str, Any],
+    *,
+    experiment_identity_id: str,
+    run_id: Optional[str] = None,
+    legacy_alias_md5_12: Optional[str] = None,
+    content_sha256: Optional[str] = None,
+    historical_provenance: Optional[Mapping[str, Any]] = None,
+) -> OperatorGoNamedLaneIdentityJoinResultV1:
+    """Parse a live I17 Operator-GO and fail-closed join Package-N IDENTITY."""
+    if not isinstance(raw, Mapping):
+        raise OperatorGoContractError("OPERATOR_GO_NOT_OBJECT")
+    snapshot = copy.deepcopy(dict(raw))
+    contract = parse_operator_go_contract_v1(raw)
+    join = join_i17_named_lane_identity_v1(
+        contract.to_dict(),
+        experiment_identity_id=experiment_identity_id,
+        surface="operator_go",
+        run_id=run_id,
+        legacy_alias_md5_12=legacy_alias_md5_12,
+        content_sha256=content_sha256,
+        historical_provenance=historical_provenance,
+    )
+    if dict(raw) != snapshot:
+        raise OperatorGoContractError("GO_INPUT_MUTATED")
+    return OperatorGoNamedLaneIdentityJoinResultV1(contract=contract, join=join)

--- a/src/ops/paper_shadow_observation_operator_go_session_preregistration_v1/preregistration_contract_v1.py
+++ b/src/ops/paper_shadow_observation_operator_go_session_preregistration_v1/preregistration_contract_v1.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import re
@@ -9,6 +10,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Mapping, Optional, Sequence
 
+from src.experiments.cross_lane_identity_join_v1 import CrossLaneIdentityJoinV1
 from src.ops.bounded_futures_testnet_venue_binding_v0 import PRODUCTION_INSTRUMENT_ID
 from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.confirm_token_v1 import (
     assert_no_plaintext_token_fields,
@@ -25,6 +27,9 @@ from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.con
     REQUIRED_MODE,
     SESSION_EXECUTION_SCOPE_PAPER_SHADOW_OBSERVATION_WALLCLOCK_V1,
     VENUE_OKX,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.i17_paper_shadow_named_lane_identity_join_v1 import (
+    join_i17_named_lane_identity_v1,
 )
 from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.state_machine_v1 import (
     AuthorizationArmingState,
@@ -193,6 +198,12 @@ class PreregistrationValidationResultV1:
             "paper_shadow_observation_authorized": False,
             "session_executed": False,
         }
+
+
+@dataclass(frozen=True)
+class PreregistrationNamedLaneIdentityJoinResultV1:
+    contract: SessionPreregistrationContractV1
+    join: CrossLaneIdentityJoinV1
 
 
 def _req(raw: Mapping[str, Any], name: str) -> Any:
@@ -502,3 +513,34 @@ def validate_preregistration_path_v1(
         now_unix=now_unix,
         expected_repository_sha=expected_repository_sha,
     )
+
+
+def parse_preregistration_contract_with_identity_join_v1(
+    raw: Mapping[str, Any],
+    *,
+    experiment_identity_id: str,
+    run_id: Optional[str] = None,
+    legacy_alias_md5_12: Optional[str] = None,
+    content_sha256: Optional[str] = None,
+    historical_provenance: Optional[Mapping[str, Any]] = None,
+) -> PreregistrationNamedLaneIdentityJoinResultV1:
+    """Parse a live I17 preregistration and fail-closed join Package-N IDENTITY.
+
+    Persisted prereg schema is unchanged. IDENTITY is a sidecar, never session_id.
+    """
+    if not isinstance(raw, Mapping):
+        raise PreregistrationContractError("PREREGISTRATION_NOT_OBJECT")
+    snapshot = copy.deepcopy(dict(raw))
+    contract = parse_preregistration_contract_v1(raw)
+    join = join_i17_named_lane_identity_v1(
+        contract.to_dict(),
+        experiment_identity_id=experiment_identity_id,
+        surface="preregistration",
+        run_id=run_id,
+        legacy_alias_md5_12=legacy_alias_md5_12,
+        content_sha256=(content_sha256 if content_sha256 is not None else contract.scope_digest()),
+        historical_provenance=historical_provenance,
+    )
+    if dict(raw) != snapshot:
+        raise PreregistrationContractError("PREREG_INPUT_MUTATED")
+    return PreregistrationNamedLaneIdentityJoinResultV1(contract=contract, join=join)

--- a/tests/analytics/test_i65_explorer_join_attachment_v1.py
+++ b/tests/analytics/test_i65_explorer_join_attachment_v1.py
@@ -1,0 +1,257 @@
+"""U-I82-R9 tests for dormant I65 explorer join attachment."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import uuid
+from pathlib import Path
+
+import pytest
+
+from src.analytics.explorer import ExperimentSummary
+from src.analytics.i65_explorer_join_attachment_v1 import (
+    CONTRACT_ID,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    I65ExplorerJoinAttachmentError,
+    LEGACY_EXPERIMENT_ID_CLASSIFICATION,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    attach_i65_explorer_join_v1,
+)
+from src.experiments.cross_lane_identity_join_v1 import (
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+)
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ATTACHMENT_PATH = REPO_ROOT / "src" / "analytics" / "i65_explorer_join_attachment_v1.py"
+EXPLORER_PATH = REPO_ROOT / "src" / "analytics" / "explorer.py"
+EXPERIMENTS_PATH = REPO_ROOT / "src" / "core" / "experiments.py"
+
+_PACKAGE_N_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r9-package-n").hexdigest()
+_OTHER_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r9-other").hexdigest()
+_CONTENT_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r9-content").hexdigest()
+_MD5_12 = "abcdef012345"
+_MD5_32 = "d41d8cd98f00b204e9800998ecf8427e"
+_RUN_ID = str(uuid.uuid4())
+
+
+def _i65_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "experiment_identity_id": _PACKAGE_N_SHA256,
+        "run_id": _RUN_ID,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_canonical_package_n_sha256_happy_path() -> None:
+    record = attach_i65_explorer_join_v1(_i65_payload())
+    assert CONTRACT_ID == "i65_explorer_join_attachment_v1"
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.run_id == _RUN_ID
+    assert record.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert record.plane_presence["RUN"] == PlanePresence.PRESENT.value
+    assert record.experiment_identity_id != _RUN_ID
+    assert is_package_n_sha256_canonical_id(record.experiment_identity_id) is True
+
+
+def test_alias_campaign_session_absent_declared_by_default() -> None:
+    record = attach_i65_explorer_join_v1(_i65_payload())
+    assert record.plane_presence["ALIAS"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["CAMPAIGN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["SESSION"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["EVIDENCE"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["CONTENT_HASH"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.legacy_alias_md5_12 is None
+    assert record.campaign_id is None
+    assert record.session_id is None
+
+
+def test_declared_absent_without_run_id() -> None:
+    record = attach_i65_explorer_join_v1({"experiment_identity_id": _PACKAGE_N_SHA256})
+    assert record.plane_presence["RUN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.run_id is None
+    assert record.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+
+
+def test_legacy_experiment_id_is_run_provenance_alias_not_identity() -> None:
+    record = attach_i65_explorer_join_v1(_i65_payload(experiment_id=_RUN_ID))
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.run_id == _RUN_ID
+    assert dict(record.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+    assert (
+        dict(record.historical_provenance)["legacy_experiment_id_classification"]
+        == LEGACY_EXPERIMENT_ID_CLASSIFICATION
+    )
+    assert record.experiment_identity_id != _RUN_ID
+
+
+def test_explicit_content_sha256_is_content_hash_not_identity() -> None:
+    record = attach_i65_explorer_join_v1(_i65_payload(content_sha256=_CONTENT_SHA256))
+    assert record.plane_presence["CONTENT_HASH"] == PlanePresence.PRESENT.value
+    assert record.content_sha256 == _CONTENT_SHA256
+    assert record.content_sha256 != record.experiment_identity_id
+
+
+def test_implicit_absence_of_identity_rejected() -> None:
+    with pytest.raises(I65ExplorerJoinAttachmentError, match="IDENTITY missing"):
+        attach_i65_explorer_join_v1({"run_id": _RUN_ID, "experiment_id": _RUN_ID})
+
+
+def test_uuid_run_id_as_identity_rejected() -> None:
+    assert is_package_n_sha256_canonical_id(_RUN_ID) is False
+    with pytest.raises(I65ExplorerJoinAttachmentError, match="Package-N SHA256"):
+        attach_i65_explorer_join_v1(_i65_payload(experiment_identity_id=_RUN_ID))
+
+
+def test_legacy_experiment_id_as_identity_rejected() -> None:
+    with pytest.raises(I65ExplorerJoinAttachmentError, match="Package-N SHA256"):
+        attach_i65_explorer_join_v1(
+            _i65_payload(experiment_identity_id=_RUN_ID, experiment_id=_RUN_ID)
+        )
+
+
+def test_md5_as_identity_rejected() -> None:
+    with pytest.raises(I65ExplorerJoinAttachmentError, match="Package-N SHA256"):
+        attach_i65_explorer_join_v1(_i65_payload(experiment_identity_id=_MD5_12))
+    with pytest.raises(I65ExplorerJoinAttachmentError, match="Package-N SHA256"):
+        attach_i65_explorer_join_v1(_i65_payload(experiment_identity_id=_MD5_32))
+
+
+def test_run_id_must_not_substitute_identity() -> None:
+    with pytest.raises(
+        I65ExplorerJoinAttachmentError,
+        match="must not substitute|equals run_id|field separation rejected",
+    ):
+        attach_i65_explorer_join_v1(_i65_payload(run_id=_PACKAGE_N_SHA256))
+
+
+def test_legacy_experiment_id_must_not_substitute_identity() -> None:
+    with pytest.raises(I65ExplorerJoinAttachmentError, match="field separation rejected"):
+        attach_i65_explorer_join_v1(_i65_payload(experiment_id=_PACKAGE_N_SHA256))
+
+
+def test_registry_and_mlflow_ids_cannot_replace_identity() -> None:
+    with pytest.raises(I65ExplorerJoinAttachmentError, match="forbidden I65 join field"):
+        attach_i65_explorer_join_v1(_i65_payload(registry_run_id=_RUN_ID))
+    with pytest.raises(I65ExplorerJoinAttachmentError, match="forbidden I65 join field"):
+        attach_i65_explorer_join_v1(_i65_payload(mlflow_run_id=_RUN_ID))
+    with pytest.raises(I65ExplorerJoinAttachmentError, match="forbidden I65 join field"):
+        attach_i65_explorer_join_v1(_i65_payload(git_sha="abc123"))
+
+
+def test_conflicting_identity_values_rejected() -> None:
+    with pytest.raises(I65ExplorerJoinAttachmentError, match="forbidden I65 join field"):
+        attach_i65_explorer_join_v1(_i65_payload(ref_id=_OTHER_SHA256))
+    with pytest.raises(I65ExplorerJoinAttachmentError, match="conflicting identities"):
+        attach_i65_explorer_join_v1(
+            _i65_payload(historical_provenance={"experiment_identity_id": _OTHER_SHA256})
+        )
+
+
+def test_legacy_experiment_id_run_id_conflation_rejected() -> None:
+    other_uuid = str(uuid.uuid4())
+    with pytest.raises(I65ExplorerJoinAttachmentError, match="field separation rejected"):
+        attach_i65_explorer_join_v1(_i65_payload(experiment_id=other_uuid, run_id=_RUN_ID))
+
+
+def test_malformed_and_ambiguous_join_rejected() -> None:
+    with pytest.raises(I65ExplorerJoinAttachmentError, match="must be an object"):
+        attach_i65_explorer_join_v1("not-an-object")  # type: ignore[arg-type]
+    with pytest.raises(I65ExplorerJoinAttachmentError, match="unknown I65 join field"):
+        attach_i65_explorer_join_v1(_i65_payload(authorization_id="not-in-i65-join"))
+    with pytest.raises(I65ExplorerJoinAttachmentError, match="empty or whitespace-padded"):
+        attach_i65_explorer_join_v1(_i65_payload(experiment_identity_id="   "))
+    with pytest.raises(I65ExplorerJoinAttachmentError, match="must be a string when present"):
+        attach_i65_explorer_join_v1(_i65_payload(run_id=123))
+
+
+def test_join_is_deterministic() -> None:
+    payload = _i65_payload(experiment_id=_RUN_ID, content_sha256=_CONTENT_SHA256)
+    first = attach_i65_explorer_join_v1(payload).to_canonical_mapping()
+    second = attach_i65_explorer_join_v1(copy.deepcopy(payload)).to_canonical_mapping()
+    assert first == second
+
+
+def test_attachment_does_not_mutate_inputs() -> None:
+    payload = _i65_payload(
+        experiment_id=_RUN_ID,
+        historical_provenance={"legacy_experiment_id": _RUN_ID},
+    )
+    snapshot = copy.deepcopy(payload)
+    record = attach_i65_explorer_join_v1(payload)
+    payload["run_id"] = "MUTATED"
+    payload["historical_provenance"]["legacy_experiment_id"] = "MUTATED"  # type: ignore[index]
+    assert dict(record.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+    assert record.run_id == _RUN_ID
+    assert payload != snapshot
+
+
+def test_historical_provenance_non_authoritative() -> None:
+    payload = _i65_payload(
+        experiment_id=_RUN_ID,
+        historical_provenance={"legacy_experiment_id": _RUN_ID},
+    )
+    record = attach_i65_explorer_join_v1(payload)
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.experiment_identity_id != _RUN_ID
+    assert dict(record.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+    assert (
+        dict(record.historical_provenance)["legacy_experiment_id_classification"]
+        == LEGACY_EXPERIMENT_ID_CLASSIFICATION
+    )
+
+
+def test_live_explorer_contract_unregistered() -> None:
+    summary = ExperimentSummary(
+        experiment_id=_RUN_ID,
+        run_type="backtest",
+        run_name="hist",
+    )
+    assert summary.experiment_id == _RUN_ID
+    assert not hasattr(summary, "experiment_identity_id")
+    source = EXPLORER_PATH.read_text(encoding="utf-8")
+    assert 'experiment_id=str(row.get("run_id", ""))' in source
+    assert "uuid.uuid4()" in EXPERIMENTS_PATH.read_text(encoding="utf-8")
+
+
+def test_runtime_invariants_remain_unauthorized() -> None:
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_no_runtime_registration_or_forbidden_imports() -> None:
+    modules = _imported_modules(ATTACHMENT_PATH)
+    assert not any(mod == "src.execution" or mod.startswith("src.execution.") for mod in modules)
+    assert not any(
+        "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in modules
+    )
+    assert "src.analytics.explorer" not in modules
+    assert "src.core.experiments" not in modules
+    assert "src.analytics.legacy_identity_row_interpretation_v1" in modules
+    source = ATTACHMENT_PATH.read_text(encoding="utf-8")
+    assert "open(" not in source
+    assert "_row_to_summary" not in source
+    assert "get_experiment_details" not in source
+    assert "uuid.uuid4()" not in source
+    explorer_source = EXPLORER_PATH.read_text(encoding="utf-8")
+    assert "attach_i65_explorer_join_v1" not in explorer_source

--- a/tests/analytics/test_i65_explorer_live_contract_join_v1.py
+++ b/tests/analytics/test_i65_explorer_live_contract_join_v1.py
@@ -1,0 +1,402 @@
+"""U-I82-R16 tests for dormant I65 live-contract join registration."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import uuid
+from pathlib import Path
+
+import pytest
+
+from src.analytics.explorer import ExperimentSummary
+from src.analytics.i65_explorer_join_attachment_v1 import CONTRACT_ID as R9_CONTRACT_ID
+from src.analytics.i65_explorer_live_contract_join_v1 import (
+    CONTRACT_ID,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    I65_LIVE_CONTRACT_REGISTERED,
+    I65ExplorerLiveContractJoinError,
+    LIVE_CONTRACT_SURFACES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    is_i65_live_contract_registered,
+    register_i65_live_contract_join_v1,
+)
+from src.analytics.legacy_identity_row_interpretation_v1 import (
+    LEGACY_EXPERIMENT_ID_CLASSIFICATION,
+    interpret_legacy_identity_row_v1,
+)
+from src.experiments.cross_lane_identity_join_v1 import (
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+)
+from src.ingress.capsules.i56_ingress_live_contract_join_v1 import (
+    I56_LIVE_CONTRACT_REGISTERED,
+    is_i56_live_contract_registered,
+)
+from src.levelup.i52_levelup_live_contract_join_v1 import (
+    I52_LIVE_CONTRACT_REGISTERED,
+    is_i52_live_contract_registered,
+)
+from src.live_eval.i61_live_eval_live_contract_join_v1 import (
+    I61_LIVE_CONTRACT_REGISTERED,
+    is_i61_live_contract_registered,
+)
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.i17_paper_shadow_live_contract_join_v1 import (
+    I17_LIVE_CONTRACT_REGISTERED,
+    is_i17_live_contract_registered,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REGISTRATION_PATH = REPO_ROOT / "src" / "analytics" / "i65_explorer_live_contract_join_v1.py"
+ATTACHMENT_PATH = REPO_ROOT / "src" / "analytics" / "i65_explorer_join_attachment_v1.py"
+READER_PATH = REPO_ROOT / "src" / "analytics" / "legacy_identity_row_interpretation_v1.py"
+EXPLORER_PATH = REPO_ROOT / "src" / "analytics" / "explorer.py"
+INIT_PATH = REPO_ROOT / "src" / "analytics" / "__init__.py"
+EXPERIMENTS_PATH = REPO_ROOT / "src" / "core" / "experiments.py"
+I17_REGISTRATION_PATH = (
+    REPO_ROOT
+    / "src"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+    / "i17_paper_shadow_live_contract_join_v1.py"
+)
+I52_REGISTRATION_PATH = REPO_ROOT / "src" / "levelup" / "i52_levelup_live_contract_join_v1.py"
+I56_REGISTRATION_PATH = (
+    REPO_ROOT / "src" / "ingress" / "capsules" / "i56_ingress_live_contract_join_v1.py"
+)
+I61_REGISTRATION_PATH = REPO_ROOT / "src" / "live_eval" / "i61_live_eval_live_contract_join_v1.py"
+_LIVE_CONTRACT_FILES = (EXPLORER_PATH, INIT_PATH, ATTACHMENT_PATH, READER_PATH, EXPERIMENTS_PATH)
+
+_PACKAGE_N_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r16-package-n").hexdigest()
+_OTHER_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r16-other").hexdigest()
+_CONTENT_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r16-content").hexdigest()
+_MD5_12 = "abcdef012345"
+_MD5_32 = "d41d8cd98f00b204e9800998ecf8427e"
+_RUN_ID = str(uuid.uuid4())
+
+
+def _summary(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "experiment_id": _RUN_ID,
+        "run_type": "backtest",
+        "run_name": "backtest_ma_crossover_r16",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _row(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "run_id": _RUN_ID,
+        "run_type": "backtest",
+        "run_name": "backtest_ma_crossover_hist",
+        "strategy_key": "ma_crossover",
+        "symbol": "BTC/EUR",
+        "sharpe": 1.5,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _envelope(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "experiment_identity_id": _PACKAGE_N_SHA256,
+        "summary": _summary(),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_live_contract_registration_flag_is_reachable() -> None:
+    assert CONTRACT_ID == "i65_explorer_live_contract_join_v1"
+    assert R9_CONTRACT_ID == "i65_explorer_join_attachment_v1"
+    assert I65_LIVE_CONTRACT_REGISTERED is True
+    assert is_i65_live_contract_registered() is True
+    assert LIVE_CONTRACT_SURFACES == ("summary", "row")
+    assert I17_LIVE_CONTRACT_REGISTERED is True
+    assert is_i17_live_contract_registered() is True
+    assert I52_LIVE_CONTRACT_REGISTERED is True
+    assert is_i52_live_contract_registered() is True
+    assert I56_LIVE_CONTRACT_REGISTERED is True
+    assert is_i56_live_contract_registered() is True
+    assert I61_LIVE_CONTRACT_REGISTERED is True
+    assert is_i61_live_contract_registered() is True
+
+
+def test_canonical_package_n_sha256_present_join_from_summary() -> None:
+    record = register_i65_live_contract_join_v1(_envelope())
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert is_package_n_sha256_canonical_id(record.experiment_identity_id) is True
+    assert record.run_id == _RUN_ID
+    assert record.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert record.plane_presence["RUN"] == PlanePresence.PRESENT.value
+    assert record.experiment_identity_id != _RUN_ID
+
+
+def test_declared_absence_for_alias_campaign_session_evidence_content_hash() -> None:
+    record = register_i65_live_contract_join_v1(_envelope())
+    assert record.plane_presence["ALIAS"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["CAMPAIGN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["SESSION"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["EVIDENCE"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["CONTENT_HASH"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.legacy_alias_md5_12 is None
+    assert record.campaign_id is None
+    assert record.session_id is None
+    assert record.content_sha256 is None
+
+
+def test_row_surface_joins_without_rewriting_historical_record() -> None:
+    historical = _row(experiment_id=_RUN_ID)
+    snapshot = copy.deepcopy(historical)
+    record = register_i65_live_contract_join_v1(
+        {"experiment_identity_id": _PACKAGE_N_SHA256, "row": historical}
+    )
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.run_id == _RUN_ID
+    assert historical == snapshot
+    parsed = interpret_legacy_identity_row_v1(historical)
+    assert parsed.run_id == _RUN_ID
+    assert parsed.legacy_experiment_id == _RUN_ID
+    assert parsed.experiment_identity_id is None
+    assert parsed.identity_canonical is False
+
+
+def test_explicit_content_sha256_is_content_hash_not_identity() -> None:
+    record = register_i65_live_contract_join_v1(_envelope(content_sha256=_CONTENT_SHA256))
+    assert record.plane_presence["CONTENT_HASH"] == PlanePresence.PRESENT.value
+    assert record.content_sha256 == _CONTENT_SHA256
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.content_sha256 != record.experiment_identity_id
+
+
+def test_live_experiment_summary_remains_identity_free() -> None:
+    summary = ExperimentSummary(
+        experiment_id=_RUN_ID,
+        run_type="backtest",
+        run_name="hist",
+    )
+    assert summary.experiment_id == _RUN_ID
+    assert not hasattr(summary, "experiment_identity_id")
+    record = register_i65_live_contract_join_v1(
+        {
+            "experiment_identity_id": _PACKAGE_N_SHA256,
+            "summary": {
+                "experiment_id": summary.experiment_id,
+                "run_type": summary.run_type,
+                "run_name": summary.run_name,
+            },
+        }
+    )
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert summary.experiment_id == _RUN_ID
+
+
+def test_implicit_absence_of_identity_rejected() -> None:
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="implicit absence rejected"):
+        register_i65_live_contract_join_v1({"summary": _summary()})
+
+
+def test_implicit_absence_of_live_surface_rejected() -> None:
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="implicit absence rejected"):
+        register_i65_live_contract_join_v1({"experiment_identity_id": _PACKAGE_N_SHA256})
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="implicit absence rejected"):
+        register_i65_live_contract_join_v1(
+            {"experiment_identity_id": _PACKAGE_N_SHA256, "row": {"run_type": "backtest"}}
+        )
+
+
+def test_noncanonical_id_substitution_rejected() -> None:
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i65_live_contract_join_v1(_envelope(experiment_identity_id=_RUN_ID))
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i65_live_contract_join_v1(_envelope(experiment_identity_id=_MD5_12))
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i65_live_contract_join_v1(_envelope(experiment_identity_id=_MD5_32))
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i65_live_contract_join_v1(
+            _envelope(summary=_summary(experiment_id=_PACKAGE_N_SHA256))
+        )
+
+
+def test_conflicting_identity_rejected() -> None:
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="conflicting"):
+        register_i65_live_contract_join_v1(
+            _envelope(historical_provenance={"experiment_identity_id": _OTHER_SHA256})
+        )
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="conflicting"):
+        register_i65_live_contract_join_v1(_envelope(run_id=str(uuid.uuid4())))
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="conflicting"):
+        register_i65_live_contract_join_v1(
+            {
+                "experiment_identity_id": _PACKAGE_N_SHA256,
+                "row": _row(experiment_id=str(uuid.uuid4())),
+            }
+        )
+
+
+def test_ambiguous_join_rejected() -> None:
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="ambiguous join rejected"):
+        register_i65_live_contract_join_v1(
+            {
+                "experiment_identity_id": _PACKAGE_N_SHA256,
+                "summary": _summary(),
+                "row": _row(),
+            }
+        )
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="ambiguous join rejected"):
+        register_i65_live_contract_join_v1(
+            {
+                "experiment_identity_id": _PACKAGE_N_SHA256,
+                "summary": [_summary(), copy.deepcopy(_summary())],
+            }
+        )
+
+
+def test_malformed_plane_data_rejected() -> None:
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="malformed plane data"):
+        register_i65_live_contract_join_v1("not-an-object")  # type: ignore[arg-type]
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="malformed plane data"):
+        register_i65_live_contract_join_v1(
+            {"experiment_identity_id": _PACKAGE_N_SHA256, "summary": "bad"}
+        )
+    mutated = _summary()
+    mutated.pop("run_name")
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="malformed plane data"):
+        register_i65_live_contract_join_v1(_envelope(summary=mutated))
+
+
+def test_cross_plane_substitution_rejected() -> None:
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="cross-plane substitution"):
+        register_i65_live_contract_join_v1(_envelope(plane_presence={"IDENTITY": "PRESENT"}))
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="cross-plane substitution"):
+        register_i65_live_contract_join_v1(_envelope(fill_price=50000.0))
+    live = _summary()
+    live["total_fills"] = 1
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="cross-plane substitution"):
+        register_i65_live_contract_join_v1(_envelope(summary=live))
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="cross-plane substitution"):
+        register_i65_live_contract_join_v1(_envelope(session_id=_PACKAGE_N_SHA256))
+
+
+def test_cross_lane_substitution_rejected() -> None:
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="cross-lane substitution"):
+        register_i65_live_contract_join_v1(_envelope(I61={"metrics": {}}))
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="malformed plane data"):
+        register_i65_live_contract_join_v1(
+            {
+                "experiment_identity_id": _PACKAGE_N_SHA256,
+                "summary": {
+                    "run_id": "default",
+                    "ts_ms": 1000,
+                },
+            }
+        )
+
+
+def test_identity_inside_live_payload_rejected() -> None:
+    live = _summary()
+    live["experiment_identity_id"] = _PACKAGE_N_SHA256
+    with pytest.raises(I65ExplorerLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i65_live_contract_join_v1(_envelope(summary=live))
+
+
+def test_join_is_deterministic() -> None:
+    payload = _envelope(content_sha256=_CONTENT_SHA256)
+    first = register_i65_live_contract_join_v1(payload).to_canonical_mapping()
+    second = register_i65_live_contract_join_v1(copy.deepcopy(payload)).to_canonical_mapping()
+    assert first == second
+
+
+def test_registration_does_not_mutate_inputs() -> None:
+    payload = _envelope(historical_provenance={"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID})
+    snapshot = copy.deepcopy(payload)
+    record = register_i65_live_contract_join_v1(payload)
+    payload["experiment_identity_id"] = "MUTATED"
+    payload["summary"]["experiment_id"] = "MUTATED"  # type: ignore[index]
+    payload["historical_provenance"]["legacy_experiment_id"] = "MUTATED"  # type: ignore[index]
+    assert record.experiment_identity_id == snapshot["experiment_identity_id"]
+    assert record.run_id == _RUN_ID
+    assert dict(record.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+    assert payload != snapshot
+
+
+def test_legacy_experiment_id_and_run_id_remain_non_authoritative() -> None:
+    payload = _envelope()
+    record = register_i65_live_contract_join_v1(payload)
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.experiment_identity_id != _RUN_ID
+    assert record.run_id == _RUN_ID
+    assert dict(record.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+    assert (
+        dict(record.historical_provenance)["legacy_experiment_id_classification"]
+        == LEGACY_EXPERIMENT_ID_CLASSIFICATION
+    )
+    assert is_package_n_sha256_canonical_id(record.run_id) is False
+
+
+def test_no_synthetic_package_n_identity() -> None:
+    source = REGISTRATION_PATH.read_text(encoding="utf-8")
+    assert "hashlib" not in source
+    assert "uuid.uuid4" not in source
+    assert "sha256(" not in source
+
+
+def test_runtime_invariants_remain_unauthorized() -> None:
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_no_cap72_execution_explorer_or_persistence_hook() -> None:
+    modules = _imported_modules(REGISTRATION_PATH)
+    assert not any(mod == "src.execution" or mod.startswith("src.execution.") for mod in modules)
+    assert not any(
+        "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in modules
+    )
+    assert "src.analytics.explorer" not in modules
+    assert "src.core.experiments" not in modules
+    assert "src.analytics.i65_explorer_join_attachment_v1" in modules
+    source = REGISTRATION_PATH.read_text(encoding="utf-8")
+    assert "open(" not in source
+    assert "write_text" not in source
+    assert "Path(" not in source
+    assert "_row_to_summary" not in source
+    assert "get_experiment_details" not in source
+    assert "append_experiment_record" not in source
+
+
+def test_live_contracts_and_prior_registrations_remain_unhooked() -> None:
+    for path in _LIVE_CONTRACT_FILES:
+        source = path.read_text(encoding="utf-8")
+        assert "register_i65_live_contract_join_v1" not in source
+        assert "i65_explorer_live_contract_join_v1" not in source
+    explorer_src = EXPLORER_PATH.read_text(encoding="utf-8")
+    assert 'experiment_id=str(row.get("run_id", ""))' in explorer_src
+    assert "uuid.uuid4()" in EXPERIMENTS_PATH.read_text(encoding="utf-8")
+    for prior in (
+        I17_REGISTRATION_PATH,
+        I52_REGISTRATION_PATH,
+        I56_REGISTRATION_PATH,
+        I61_REGISTRATION_PATH,
+    ):
+        source = prior.read_text(encoding="utf-8")
+        assert "i65_explorer_live_contract_join_v1" not in source
+        assert "I65_LIVE_CONTRACT_REGISTERED = True" not in source

--- a/tests/analytics/test_i65_explorer_named_lane_identity_join_v1.py
+++ b/tests/analytics/test_i65_explorer_named_lane_identity_join_v1.py
@@ -1,0 +1,447 @@
+"""U-I82-R23 tests for I65 named-lane IDENTITY join on explorer."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import uuid
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from src.analytics.explorer import (
+    ExperimentSummary,
+    _row_to_summary,
+    parse_experiment_row_with_identity_join_v1,
+    parse_experiment_summary_with_identity_join_v1,
+)
+from src.analytics.i65_explorer_join_attachment_v1 import CONTRACT_ID as R9_CONTRACT_ID
+from src.analytics.i65_explorer_named_lane_identity_join_v1 import (
+    CONTRACT_ID,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    I65_NAMED_LANE_IDENTITY_JOIN_REGISTERED,
+    I65ExplorerNamedLaneIdentityJoinError,
+    LIVE_CONTRACT_SURFACES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    is_i65_named_lane_identity_join_registered,
+    join_i65_named_lane_identity_v1,
+)
+from src.analytics.legacy_identity_row_interpretation_v1 import (
+    LEGACY_EXPERIMENT_ID_CLASSIFICATION,
+    IdentityRequestMode,
+    interpret_legacy_identity_row_v1,
+)
+from src.experiments.cross_lane_identity_join_v1 import (
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+)
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+JOIN_PATH = REPO_ROOT / "src" / "analytics" / "i65_explorer_named_lane_identity_join_v1.py"
+ATTACHMENT_PATH = REPO_ROOT / "src" / "analytics" / "i65_explorer_join_attachment_v1.py"
+READER_PATH = REPO_ROOT / "src" / "analytics" / "legacy_identity_row_interpretation_v1.py"
+EXPLORER_PATH = REPO_ROOT / "src" / "analytics" / "explorer.py"
+INIT_PATH = REPO_ROOT / "src" / "analytics" / "__init__.py"
+R16_PATH = REPO_ROOT / "src" / "analytics" / "i65_explorer_live_contract_join_v1.py"
+EXPERIMENTS_PATH = REPO_ROOT / "src" / "core" / "experiments.py"
+_JOIN_MODULE = "src.analytics.i65_explorer_named_lane_identity_join_v1"
+
+_PACKAGE_N_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r23-package-n").hexdigest()
+_OTHER_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r23-other").hexdigest()
+_CONTENT_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r23-content").hexdigest()
+_MD5_12 = "abcdef012345"
+_MD5_32 = "d41d8cd98f00b204e9800998ecf8427e"
+_RUN_ID = str(uuid.uuid4())
+_CAMPAIGN_ID = "campaign-i65-r23"
+_SESSION_ID = "session-i65-r23"
+_EVIDENCE_REF = "explorer-evidence-i65-r23"
+
+
+def _summary(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "experiment_id": _RUN_ID,
+        "run_type": "backtest",
+        "run_name": "hist-run",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _row(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "run_id": _RUN_ID,
+        "run_type": "backtest",
+        "run_name": "hist-run",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_named_lane_identity_join_is_registered_and_reachable() -> None:
+    assert CONTRACT_ID == "i65_explorer_named_lane_identity_join_v1"
+    assert R9_CONTRACT_ID == "i65_explorer_join_attachment_v1"
+    assert I65_NAMED_LANE_IDENTITY_JOIN_REGISTERED is True
+    assert is_i65_named_lane_identity_join_registered() is True
+    assert LIVE_CONTRACT_SURFACES == ("summary", "row")
+
+
+def test_named_summary_producer_attaches_package_n_identity() -> None:
+    result = parse_experiment_summary_with_identity_join_v1(
+        _summary(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.experiment_identity_id == _PACKAGE_N_SHA256
+    assert is_package_n_sha256_canonical_id(result.join.experiment_identity_id) is True
+    assert result.join.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["RUN"] == PlanePresence.PRESENT.value
+    assert result.join.run_id == _RUN_ID
+    assert result.join.experiment_identity_id != _RUN_ID
+    assert result.contract.experiment_id == _RUN_ID
+    assert not hasattr(result.contract, "experiment_identity_id")
+
+
+def test_declared_absence_for_alias_campaign_session_evidence_content_hash() -> None:
+    result = parse_experiment_summary_with_identity_join_v1(
+        _summary(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.plane_presence["ALIAS"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["CAMPAIGN"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["SESSION"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["EVIDENCE"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["CONTENT_HASH"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.legacy_alias_md5_12 is None
+    assert result.join.campaign_id is None
+    assert result.join.session_id is None
+    assert result.join.content_sha256 is None
+
+
+def test_present_sidecars_are_joined_and_not_identity() -> None:
+    result = parse_experiment_summary_with_identity_join_v1(
+        _summary(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        campaign_id=_CAMPAIGN_ID,
+        session_id=_SESSION_ID,
+        legacy_alias_md5_12=_MD5_12,
+        content_sha256=_CONTENT_SHA256,
+        evidence_ref=_EVIDENCE_REF,
+    )
+    assert result.join.plane_presence["CAMPAIGN"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["SESSION"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["ALIAS"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["CONTENT_HASH"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["EVIDENCE"] == PlanePresence.PRESENT.value
+    assert result.join.campaign_id == _CAMPAIGN_ID
+    assert result.join.session_id == _SESSION_ID
+    assert result.join.legacy_alias_md5_12 == _MD5_12
+    assert result.join.content_sha256 == _CONTENT_SHA256
+    assert result.join.evidence_ref == _EVIDENCE_REF
+    assert result.join.experiment_identity_id != _CAMPAIGN_ID
+    assert result.join.experiment_identity_id != _SESSION_ID
+    assert result.join.experiment_identity_id != _MD5_12
+    assert result.join.experiment_identity_id != _CONTENT_SHA256
+    assert result.join.experiment_identity_id != _EVIDENCE_REF
+    assert result.join.run_id == _RUN_ID
+
+
+def test_named_row_producer_attaches_identity_and_keeps_run_plane() -> None:
+    result = parse_experiment_row_with_identity_join_v1(
+        _row(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.experiment_identity_id == _PACKAGE_N_SHA256
+    assert result.join.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["RUN"] == PlanePresence.PRESENT.value
+    assert result.join.run_id == _RUN_ID
+    assert result.join.experiment_identity_id != result.contract["run_id"]
+    assert result.contract["run_id"] == _RUN_ID
+
+
+def test_legacy_experiment_id_is_run_provenance_not_identity() -> None:
+    result = parse_experiment_row_with_identity_join_v1(
+        _row(experiment_id=_RUN_ID),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.experiment_identity_id == _PACKAGE_N_SHA256
+    assert result.join.run_id == _RUN_ID
+    assert dict(result.join.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+    assert (
+        dict(result.join.historical_provenance)["legacy_experiment_id_classification"]
+        == LEGACY_EXPERIMENT_ID_CLASSIFICATION
+    )
+    assert result.join.experiment_identity_id != _RUN_ID
+
+
+def test_implicit_absence_of_identity_rejected() -> None:
+    with pytest.raises(I65ExplorerNamedLaneIdentityJoinError, match="implicit absence rejected"):
+        parse_experiment_summary_with_identity_join_v1(_summary())
+
+
+def test_noncanonical_id_substitution_rejected() -> None:
+    with pytest.raises(I65ExplorerNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        parse_experiment_summary_with_identity_join_v1(
+            _summary(),
+            experiment_identity_id=_RUN_ID,
+        )
+    with pytest.raises(I65ExplorerNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        parse_experiment_summary_with_identity_join_v1(
+            _summary(),
+            experiment_identity_id=_MD5_12,
+        )
+    with pytest.raises(I65ExplorerNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        parse_experiment_summary_with_identity_join_v1(
+            _summary(),
+            experiment_identity_id=_MD5_32,
+        )
+
+
+def test_synthetic_package_n_identity_from_run_id_forbidden() -> None:
+    with pytest.raises(I65ExplorerNamedLaneIdentityJoinError, match="implicit absence rejected"):
+        parse_experiment_row_with_identity_join_v1(_row())
+    with pytest.raises(I65ExplorerNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        parse_experiment_summary_with_identity_join_v1(
+            _summary(),
+            experiment_identity_id=_RUN_ID,
+        )
+    with pytest.raises(I65ExplorerNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        parse_experiment_summary_with_identity_join_v1(
+            _summary(experiment_id=_PACKAGE_N_SHA256),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_run_id_sidecar_cannot_fill_identity() -> None:
+    with pytest.raises(I65ExplorerNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        parse_experiment_summary_with_identity_join_v1(
+            _summary(),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            run_id=_RUN_ID,
+        )
+
+
+def test_identity_inside_live_payload_rejected() -> None:
+    live = _summary()
+    live["experiment_identity_id"] = _PACKAGE_N_SHA256
+    with pytest.raises(I65ExplorerNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        join_i65_named_lane_identity_v1(
+            live,
+            surface="summary",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_conflicting_identity_rejected() -> None:
+    with pytest.raises(I65ExplorerNamedLaneIdentityJoinError, match="conflicting"):
+        parse_experiment_summary_with_identity_join_v1(
+            _summary(),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            historical_provenance={"experiment_identity_id": _OTHER_SHA256},
+        )
+    with pytest.raises(I65ExplorerNamedLaneIdentityJoinError, match="conflicting"):
+        parse_experiment_row_with_identity_join_v1(
+            _row(experiment_id=str(uuid.uuid4())),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_ambiguous_join_rejected() -> None:
+    with pytest.raises(I65ExplorerNamedLaneIdentityJoinError, match="ambiguous join rejected"):
+        join_i65_named_lane_identity_v1(
+            [_summary(), _summary(run_name="other")],
+            surface="summary",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_malformed_plane_data_rejected() -> None:
+    with pytest.raises(I65ExplorerNamedLaneIdentityJoinError, match="malformed plane data"):
+        join_i65_named_lane_identity_v1(
+            "not-an-object",  # type: ignore[arg-type]
+            surface="summary",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+    with pytest.raises(I65ExplorerNamedLaneIdentityJoinError, match="malformed plane data"):
+        parse_experiment_summary_with_identity_join_v1(
+            _summary(),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            session_id="   ",
+        )
+    mutated = _summary()
+    mutated.pop("run_type")
+    with pytest.raises(I65ExplorerNamedLaneIdentityJoinError, match="malformed plane data"):
+        parse_experiment_summary_with_identity_join_v1(
+            mutated,
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_cross_lane_substitution_rejected() -> None:
+    live = _summary()
+    live["I61"] = {"session_dir": "/tmp/eval"}
+    with pytest.raises(I65ExplorerNamedLaneIdentityJoinError, match="cross-lane substitution"):
+        join_i65_named_lane_identity_v1(
+            live,
+            surface="summary",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_cross_plane_substitution_rejected() -> None:
+    live = _summary()
+    live["plane_presence"] = {"IDENTITY": "PRESENT"}
+    with pytest.raises(I65ExplorerNamedLaneIdentityJoinError, match="cross-plane substitution"):
+        join_i65_named_lane_identity_v1(
+            live,
+            surface="summary",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+    live_fill = _summary()
+    live_fill["session_dir"] = "evidence/fixtures/live_eval/session_dir"
+    with pytest.raises(I65ExplorerNamedLaneIdentityJoinError, match="cross-plane substitution"):
+        join_i65_named_lane_identity_v1(
+            live_fill,
+            surface="summary",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+    with pytest.raises(I65ExplorerNamedLaneIdentityJoinError, match="cross-plane substitution"):
+        parse_experiment_summary_with_identity_join_v1(
+            _summary(),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            session_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_join_is_deterministic() -> None:
+    first = parse_experiment_summary_with_identity_join_v1(
+        _summary(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        content_sha256=_CONTENT_SHA256,
+    ).join.to_canonical_mapping()
+    second = parse_experiment_summary_with_identity_join_v1(
+        _summary(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        content_sha256=_CONTENT_SHA256,
+    ).join.to_canonical_mapping()
+    assert first == second
+
+
+def test_named_lane_does_not_mutate_inputs() -> None:
+    raw = _summary()
+    snapshot = copy.deepcopy(raw)
+    result = parse_experiment_summary_with_identity_join_v1(
+        raw,
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        historical_provenance={"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID},
+    )
+    raw["experiment_id"] = "MUTATED"
+    assert result.contract.experiment_id == snapshot["experiment_id"]
+    assert dict(raw) != snapshot
+
+
+def test_historical_i65_row_readability_preserved() -> None:
+    row = pd.Series(
+        {
+            "run_id": _RUN_ID,
+            "run_type": "backtest",
+            "run_name": "hist-run",
+            "strategy_key": "ma_crossover",
+            "sweep_name": None,
+            "scan_name": None,
+            "portfolio_name": None,
+            "symbol": "BTC-USDT",
+            "metadata_json": "{}",
+            "timestamp": "2026-01-01T00:00:00",
+            "params_json": "{}",
+            "sharpe": 1.2,
+            "total_return": 0.1,
+            "max_drawdown": -0.05,
+            "cagr": 0.08,
+            "stats_json": "{}",
+        }
+    )
+    summary = _row_to_summary(row)
+    assert summary.experiment_id == _RUN_ID
+    assert not hasattr(summary, "experiment_identity_id")
+    interpreted = interpret_legacy_identity_row_v1(
+        {"run_id": _RUN_ID, "experiment_id": _RUN_ID},
+        identity_request=IdentityRequestMode.PROVENANCE,
+    )
+    assert interpreted.identity_canonical is False
+    assert interpreted.identity_status == PlanePresence.ABSENT_DECLARED.value
+    assert interpreted.run_id == _RUN_ID
+    assert interpreted.legacy_experiment_id_classification == LEGACY_EXPERIMENT_ID_CLASSIFICATION
+    source = EXPLORER_PATH.read_text(encoding="utf-8")
+    assert 'experiment_id=str(row.get("run_id", ""))' in source
+    constructed = ExperimentSummary(
+        experiment_id=_RUN_ID,
+        run_type="backtest",
+        run_name="hist-run",
+    )
+    assert constructed.experiment_id == _RUN_ID
+
+
+def test_runtime_invariants_remain_unauthorized() -> None:
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+
+
+def test_named_lane_producer_is_hooked_and_forbidden_surfaces_are_not() -> None:
+    join_modules = _imported_modules(JOIN_PATH)
+    assert "src.analytics.i65_explorer_join_attachment_v1" in join_modules
+    assert "src.analytics.explorer" not in join_modules
+    assert "src.core.experiments" not in join_modules
+    explorer_modules = _imported_modules(EXPLORER_PATH)
+    assert _JOIN_MODULE in explorer_modules
+    assert not any(
+        mod == "src.execution" or mod.startswith("src.execution.") for mod in explorer_modules
+    )
+    assert not any(
+        "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in explorer_modules
+    )
+    assert "src.ingress.capsules.evidence_capsule" not in explorer_modules
+    assert "src.live_eval.live_session_eval" not in explorer_modules
+    assert not any(
+        mod == "src.execution" or mod.startswith("src.execution.") for mod in join_modules
+    )
+    join_source = JOIN_PATH.read_text(encoding="utf-8")
+    assert "write_text" not in join_source
+    assert "open(" not in join_source
+    assert "Path(" not in join_source
+    assert "_row_to_summary" not in join_source
+    assert "get_experiment_details" not in join_source
+    assert "append_experiment_record" not in join_source
+    explorer_source = EXPLORER_PATH.read_text(encoding="utf-8")
+    assert "experiment_identity_id" not in explorer_source
+    assert "i65_explorer_live_contract_join_v1" not in explorer_source
+    assert 'experiment_id=str(row.get("run_id", ""))' in explorer_source
+    init_source = INIT_PATH.read_text(encoding="utf-8")
+    attachment_source = ATTACHMENT_PATH.read_text(encoding="utf-8")
+    reader_source = READER_PATH.read_text(encoding="utf-8")
+    r16_source = R16_PATH.read_text(encoding="utf-8")
+    experiments_source = EXPERIMENTS_PATH.read_text(encoding="utf-8")
+    assert "i65_explorer_named_lane_identity_join_v1" not in init_source
+    assert "i65_explorer_named_lane_identity_join_v1" not in attachment_source
+    assert "i65_explorer_named_lane_identity_join_v1" not in reader_source
+    assert "i65_explorer_named_lane_identity_join_v1" not in r16_source
+    assert "i65_explorer_named_lane_identity_join_v1" not in experiments_source
+    assert "uuid.uuid4()" in experiments_source
+    assert _PACKAGE_N_SHA256 not in explorer_source

--- a/tests/analytics/test_legacy_identity_row_interpretation_v1.py
+++ b/tests/analytics/test_legacy_identity_row_interpretation_v1.py
@@ -1,0 +1,196 @@
+"""U-I82-R2 tests for dormant historical I65 identity-row interpretation."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import uuid
+from pathlib import Path
+
+import pytest
+
+from src.analytics.legacy_identity_row_interpretation_v1 import (
+    CONTRACT_ID,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    IdentityRequestMode,
+    LEGACY_EXPERIMENT_ID_CLASSIFICATION,
+    LegacyIdentityRowInterpretationError,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    interpret_legacy_identity_row_v1,
+)
+from src.experiments.cross_lane_identity_join_v1 import (
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+)
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+READER_PATH = REPO_ROOT / "src" / "analytics" / "legacy_identity_row_interpretation_v1.py"
+
+_PACKAGE_N_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r2-package-n").hexdigest()
+_OTHER_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r2-other").hexdigest()
+_MD5_12 = "abcdef012345"
+
+
+def _historical_i65_row(**overrides: object) -> dict[str, object]:
+    run_id = str(uuid.uuid4())
+    payload: dict[str, object] = {
+        "run_id": run_id,
+        "run_type": "backtest",
+        "run_name": "backtest_ma_crossover_hist",
+        "strategy_key": "ma_crossover",
+        "symbol": "BTC/EUR",
+        "sharpe": 1.5,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_historical_uuid_run_id_remains_readable() -> None:
+    row = _historical_i65_row()
+    parsed = interpret_legacy_identity_row_v1(row)
+    assert parsed.run_id == row["run_id"]
+    assert parsed.contract_id == CONTRACT_ID
+    assert parsed.join_record.run_id == row["run_id"]
+
+
+def test_run_id_preserved_as_run_provenance() -> None:
+    row = _historical_i65_row()
+    parsed = interpret_legacy_identity_row_v1(row)
+    assert parsed.join_record.plane_presence["RUN"] == PlanePresence.PRESENT.value
+    assert parsed.run_id == row["run_id"]
+    assert parsed.identity_canonical is False
+
+
+def test_legacy_experiment_id_equal_run_id_is_not_package_n_sha256() -> None:
+    run_id = str(uuid.uuid4())
+    row = _historical_i65_row(run_id=run_id, experiment_id=run_id)
+    parsed = interpret_legacy_identity_row_v1(row)
+    assert parsed.legacy_experiment_id == run_id
+    assert parsed.legacy_experiment_id_classification == LEGACY_EXPERIMENT_ID_CLASSIFICATION
+    assert parsed.experiment_identity_id is None
+    assert is_package_n_sha256_canonical_id(parsed.legacy_experiment_id) is False
+    assert parsed.join_record.experiment_identity_id is None
+
+
+def test_missing_package_n_identity_does_not_synthesize() -> None:
+    row = _historical_i65_row()
+    parsed = interpret_legacy_identity_row_v1(row)
+    assert parsed.experiment_identity_id is None
+    assert parsed.identity_canonical is False
+    assert "experiment_identity_id" not in parsed.to_canonical_mapping()["join_record"]
+    with pytest.raises(LegacyIdentityRowInterpretationError, match="IDENTITY_CANONICAL"):
+        interpret_legacy_identity_row_v1(
+            row, identity_request=IdentityRequestMode.IDENTITY_CANONICAL
+        )
+
+
+def test_absent_declared_semantics_match_r1_contract() -> None:
+    row = _historical_i65_row()
+    parsed = interpret_legacy_identity_row_v1(row)
+    assert parsed.identity_status == PlanePresence.ABSENT_DECLARED.value
+    assert parsed.join_record.plane_presence["IDENTITY"] == PlanePresence.ABSENT_DECLARED.value
+    assert parsed.join_record.plane_presence["CAMPAIGN"] == PlanePresence.ABSENT_DECLARED.value
+    assert parsed.join_record.plane_presence["SESSION"] == PlanePresence.ABSENT_DECLARED.value
+    assert parsed.join_record.experiment_identity_id is None
+
+
+def test_present_valid_package_n_sha256_is_recognized() -> None:
+    row = _historical_i65_row(experiment_identity_id=_PACKAGE_N_SHA256)
+    parsed = interpret_legacy_identity_row_v1(
+        row, identity_request=IdentityRequestMode.IDENTITY_CANONICAL
+    )
+    assert parsed.identity_canonical is True
+    assert parsed.experiment_identity_id == _PACKAGE_N_SHA256
+    assert parsed.identity_status == PlanePresence.PRESENT.value
+    assert parsed.join_record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert parsed.run_id == row["run_id"]
+    assert parsed.join_record.plane_presence["RUN"] == PlanePresence.PRESENT.value
+
+
+def test_conflicting_identity_data_fail_closed() -> None:
+    run_id = str(uuid.uuid4())
+    other = str(uuid.uuid4())
+    row = _historical_i65_row(run_id=run_id, experiment_id=other)
+    with pytest.raises(LegacyIdentityRowInterpretationError, match="conflicting identities"):
+        interpret_legacy_identity_row_v1(row)
+
+    row = _historical_i65_row()
+    row["experiment_identity_id"] = row["run_id"]
+    with pytest.raises(LegacyIdentityRowInterpretationError, match="not a Package-N SHA256"):
+        interpret_legacy_identity_row_v1(row)
+
+    row = {"experiment_id": _OTHER_SHA256}
+    with pytest.raises(LegacyIdentityRowInterpretationError, match="must not be treated"):
+        interpret_legacy_identity_row_v1(row)
+
+
+def test_reader_does_not_mutate_historical_record() -> None:
+    run_id = str(uuid.uuid4())
+    row: dict[str, object] = _historical_i65_row(run_id=run_id, experiment_id=run_id)
+    snapshot = copy.deepcopy(row)
+    parsed = interpret_legacy_identity_row_v1(row)
+    row["run_id"] = "MUTATED"
+    row["experiment_id"] = "MUTATED"
+    assert parsed.run_id == snapshot["run_id"]
+    assert parsed.legacy_experiment_id == snapshot["experiment_id"]
+    assert dict(parsed.historical_provenance)["run_id"] == snapshot["run_id"]
+    assert row["run_id"] == "MUTATED"
+    assert snapshot["run_id"] != "MUTATED"
+
+
+def test_repeated_read_is_deterministic() -> None:
+    run_id = str(uuid.uuid4())
+    row = _historical_i65_row(run_id=run_id, experiment_id=run_id)
+    first = interpret_legacy_identity_row_v1(row).to_canonical_mapping()
+    second = interpret_legacy_identity_row_v1(row).to_canonical_mapping()
+    third = interpret_legacy_identity_row_v1(copy.deepcopy(row)).to_canonical_mapping()
+    assert first == second == third
+
+
+def test_uuid_run_id_cannot_bypass_r1_sha256_validator() -> None:
+    run_id = str(uuid.uuid4())
+    assert is_package_n_sha256_canonical_id(run_id) is False
+    row = _historical_i65_row(run_id=run_id, experiment_identity_id=run_id)
+    with pytest.raises(LegacyIdentityRowInterpretationError, match="Package-N SHA256"):
+        interpret_legacy_identity_row_v1(row)
+    row = _historical_i65_row(experiment_identity_id=_MD5_12)
+    with pytest.raises(LegacyIdentityRowInterpretationError, match="Package-N SHA256"):
+        interpret_legacy_identity_row_v1(row)
+
+
+def test_runtime_invariants_remain_unauthorized() -> None:
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_no_cap72_or_src_execution_or_writer_imports() -> None:
+    modules = _imported_modules(READER_PATH)
+    assert not any(mod == "src.execution" or mod.startswith("src.execution.") for mod in modules)
+    assert not any(
+        "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in modules
+    )
+    assert "src.core.experiments" not in modules
+    assert "src.analytics.explorer" not in modules
+    assert "src.experiments.base" not in modules
+    source = READER_PATH.read_text(encoding="utf-8")
+    assert "open(" not in source
+    assert "to_csv" not in source
+    assert "append_experiment_record" not in source

--- a/tests/experiments/test_cross_lane_identity_join_record_v1.py
+++ b/tests/experiments/test_cross_lane_identity_join_record_v1.py
@@ -1,0 +1,272 @@
+"""U-I82-R3 tests for dormant cross_lane_identity_join_record_v1 primitive."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import uuid
+from pathlib import Path
+
+import pytest
+
+from src.experiments.cross_lane_identity_join_record_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    CrossLaneIdentityJoinRecordError,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    build_cross_lane_identity_join_record_v1,
+)
+from src.experiments.cross_lane_identity_join_v1 import (
+    JOIN_PLANES,
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+    validate_cross_lane_identity_join_v1,
+)
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PRIMITIVE_PATH = REPO_ROOT / "src" / "experiments" / "cross_lane_identity_join_record_v1.py"
+
+_PACKAGE_N_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r3-package-n").hexdigest()
+_OTHER_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r3-other").hexdigest()
+_MD5_12 = "abcdef012345"
+_RUN_ID = str(uuid.uuid4())
+
+
+def _absent(plane: str) -> dict[str, str]:
+    return {"plane": plane, "presence": PlanePresence.ABSENT_DECLARED.value}
+
+
+def _present(plane: str, value: str, join_key: str = _PACKAGE_N_SHA256) -> dict[str, str]:
+    return {
+        "plane": plane,
+        "presence": PlanePresence.PRESENT.value,
+        "join_key": join_key,
+        "value": value,
+    }
+
+
+def _complete(*overrides: dict[str, str]) -> list[dict[str, str]]:
+    by_plane = {plane: _absent(plane) for plane in JOIN_PLANES}
+    for item in overrides:
+        by_plane[item["plane"]] = item
+    return [by_plane[plane] for plane in JOIN_PLANES]
+
+
+def test_two_present_planes_same_package_n_sha256_join() -> None:
+    contributions = _complete(
+        _present("IDENTITY", _PACKAGE_N_SHA256),
+        _present("RUN", _RUN_ID),
+    )
+    record = build_cross_lane_identity_join_record_v1(contributions)
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.run_id == _RUN_ID
+    assert record.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert record.plane_presence["RUN"] == PlanePresence.PRESENT.value
+
+
+def test_present_plus_absent_declared_explicit_join() -> None:
+    record = build_cross_lane_identity_join_record_v1(
+        _complete(_present("IDENTITY", _PACKAGE_N_SHA256))
+    )
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.plane_presence["RUN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.run_id is None
+
+
+def test_conflicting_package_n_sha256_rejected() -> None:
+    contributions = _complete(
+        _present("IDENTITY", _PACKAGE_N_SHA256, join_key=_PACKAGE_N_SHA256),
+        _present("RUN", _RUN_ID, join_key=_OTHER_SHA256),
+    )
+    with pytest.raises(CrossLaneIdentityJoinRecordError, match="conflicting Package-N SHA256"):
+        build_cross_lane_identity_join_record_v1(contributions)
+
+
+def test_missing_plane_status_rejected() -> None:
+    contributions = _complete(_present("IDENTITY", _PACKAGE_N_SHA256))
+    contributions[1] = {"plane": "ALIAS"}
+    with pytest.raises(CrossLaneIdentityJoinRecordError, match="status is missing"):
+        build_cross_lane_identity_join_record_v1(contributions)
+
+
+def test_unknown_status_rejected() -> None:
+    contributions = _complete(_present("IDENTITY", _PACKAGE_N_SHA256))
+    contributions[1] = {"plane": "ALIAS", "presence": "ABSENT"}
+    with pytest.raises(CrossLaneIdentityJoinRecordError, match="unknown plane presence status"):
+        build_cross_lane_identity_join_record_v1(contributions)
+
+
+def test_present_without_package_n_sha256_rejected() -> None:
+    contributions = _complete(
+        {
+            "plane": "IDENTITY",
+            "presence": PlanePresence.PRESENT.value,
+            "value": _PACKAGE_N_SHA256,
+        }
+    )
+    with pytest.raises(CrossLaneIdentityJoinRecordError, match="missing Package-N SHA256 join_key"):
+        build_cross_lane_identity_join_record_v1(contributions)
+
+
+def test_uuid_run_id_as_identity_rejected() -> None:
+    assert is_package_n_sha256_canonical_id(_RUN_ID) is False
+    contributions = _complete(_present("IDENTITY", _RUN_ID, join_key=_RUN_ID))
+    with pytest.raises(CrossLaneIdentityJoinRecordError, match="Package-N SHA256"):
+        build_cross_lane_identity_join_record_v1(contributions)
+
+
+def test_legacy_experiment_id_as_identity_rejected() -> None:
+    contributions = _complete(_present("IDENTITY", _PACKAGE_N_SHA256))
+    contributions[0] = {
+        "plane": "IDENTITY",
+        "presence": PlanePresence.PRESENT.value,
+        "join_key": _PACKAGE_N_SHA256,
+        "value": _PACKAGE_N_SHA256,
+        "experiment_id": _RUN_ID,
+    }
+    with pytest.raises(CrossLaneIdentityJoinRecordError, match="forbidden join contribution key"):
+        build_cross_lane_identity_join_record_v1(contributions)
+
+
+def test_md5_as_identity_rejected() -> None:
+    contributions = _complete(_present("IDENTITY", _MD5_12, join_key=_MD5_12))
+    with pytest.raises(CrossLaneIdentityJoinRecordError, match="Package-N SHA256"):
+        build_cross_lane_identity_join_record_v1(contributions)
+
+
+def test_absent_declared_with_synthetic_identity_rejected() -> None:
+    contributions = _complete(
+        {
+            "plane": "IDENTITY",
+            "presence": PlanePresence.ABSENT_DECLARED.value,
+            "join_key": _PACKAGE_N_SHA256,
+            "value": _PACKAGE_N_SHA256,
+        }
+    )
+    with pytest.raises(CrossLaneIdentityJoinRecordError, match="synthetic identity forbidden"):
+        build_cross_lane_identity_join_record_v1(contributions)
+
+
+def test_join_is_deterministic_for_identical_input() -> None:
+    contributions = _complete(
+        _present("IDENTITY", _PACKAGE_N_SHA256),
+        _present("RUN", _RUN_ID),
+    )
+    first = build_cross_lane_identity_join_record_v1(contributions).to_canonical_mapping()
+    second = build_cross_lane_identity_join_record_v1(
+        list(reversed(contributions))
+    ).to_canonical_mapping()
+    third = build_cross_lane_identity_join_record_v1(
+        copy.deepcopy(contributions)
+    ).to_canonical_mapping()
+    assert first == second == third
+    validate_cross_lane_identity_join_v1(first)
+
+
+def test_join_does_not_mutate_inputs() -> None:
+    contributions = _complete(
+        _present("IDENTITY", _PACKAGE_N_SHA256),
+        _present("RUN", _RUN_ID),
+    )
+    snapshot = copy.deepcopy(contributions)
+    provenance = {"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID}
+    provenance_snapshot = copy.deepcopy(provenance)
+    build_cross_lane_identity_join_record_v1(contributions, historical_provenance=provenance)
+    assert contributions == snapshot
+    assert provenance == provenance_snapshot
+
+
+def test_historical_provenance_non_authoritative() -> None:
+    provenance = {
+        "legacy_experiment_id": _RUN_ID,
+        "run_id": _RUN_ID,
+        "note": "historical I65 row",
+    }
+    record = build_cross_lane_identity_join_record_v1(
+        _complete(_present("IDENTITY", _PACKAGE_N_SHA256)),
+        historical_provenance=provenance,
+    )
+    provenance["legacy_experiment_id"] = "MUTATED"
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert dict(record.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+    assert record.experiment_identity_id != _RUN_ID
+
+
+def test_duplicate_plane_rejected() -> None:
+    contributions = _complete(_present("IDENTITY", _PACKAGE_N_SHA256))
+    contributions.append(_present("IDENTITY", _PACKAGE_N_SHA256))
+    with pytest.raises(CrossLaneIdentityJoinRecordError, match="duplicate plane"):
+        build_cross_lane_identity_join_record_v1(contributions)
+
+
+def test_incomplete_join_record_rejected() -> None:
+    contributions = [
+        item
+        for item in _complete(_present("IDENTITY", _PACKAGE_N_SHA256))
+        if item["plane"] != "SESSION"
+    ]
+    with pytest.raises(CrossLaneIdentityJoinRecordError, match="incomplete join record"):
+        build_cross_lane_identity_join_record_v1(contributions)
+
+
+def test_package_n_manifest_id_match_and_mismatch() -> None:
+    manifest = {"experiment_identity_id": _PACKAGE_N_SHA256}
+    record = build_cross_lane_identity_join_record_v1(
+        _complete(_present("IDENTITY", _PACKAGE_N_SHA256)),
+        package_n_manifest=manifest,
+    )
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    with pytest.raises(CrossLaneIdentityJoinRecordError, match="conflicting Package-N SHA256"):
+        build_cross_lane_identity_join_record_v1(
+            _complete(_present("IDENTITY", _PACKAGE_N_SHA256)),
+            package_n_manifest={"experiment_identity_id": _OTHER_SHA256},
+        )
+
+
+def test_forbidden_runtime_keys_rejected() -> None:
+    for key in ("orders", "credentials", "promotion_authority"):
+        contributions = _complete(_present("IDENTITY", _PACKAGE_N_SHA256))
+        item = dict(contributions[0])
+        item[key] = True
+        contributions[0] = item
+        with pytest.raises(
+            CrossLaneIdentityJoinRecordError, match="forbidden join contribution key"
+        ):
+            build_cross_lane_identity_join_record_v1(contributions)
+
+
+def test_runtime_invariants_remain_unauthorized() -> None:
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_no_cap72_execution_or_runtime_registration_imports() -> None:
+    modules = _imported_modules(PRIMITIVE_PATH)
+    assert not any(mod == "src.execution" or mod.startswith("src.execution.") for mod in modules)
+    assert not any(
+        "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in modules
+    )
+    assert "src.experiments.base" not in modules
+    assert "src.experiments.experiment_identity_manifest_v1" not in modules
+    assert "src.analytics.explorer" not in modules
+    assert "src.core.experiments" not in modules
+    source = PRIMITIVE_PATH.read_text(encoding="utf-8")
+    assert "open(" not in source
+    assert "append_experiment_record" not in source

--- a/tests/experiments/test_cross_lane_identity_join_v1.py
+++ b/tests/experiments/test_cross_lane_identity_join_v1.py
@@ -1,0 +1,244 @@
+"""U-I82-R1 tests for dormant cross_lane_identity_join_v1 contract."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import uuid
+from pathlib import Path
+from types import MappingProxyType
+
+import pytest
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    CONTRACT_ID,
+    CONTRACT_VERSION,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    JOIN_PLANES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    CrossLaneIdentityJoinError,
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+    read_historical_provenance,
+    validate_cross_lane_identity_join_v1,
+)
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_PATH = REPO_ROOT / "src" / "experiments" / "cross_lane_identity_join_v1.py"
+
+_PACKAGE_N_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r1-package-n").hexdigest()
+_OTHER_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r1-other").hexdigest()
+_MD5_12 = "abcdef012345"
+
+
+def _absent_planes(**overrides: str) -> dict[str, str]:
+    planes = {plane: PlanePresence.ABSENT_DECLARED.value for plane in JOIN_PLANES}
+    planes.update(overrides)
+    return planes
+
+
+def _base_record(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schema_version": CONTRACT_VERSION,
+        "contract_version": CONTRACT_VERSION,
+        "contract_id": CONTRACT_ID,
+        "plane_presence": _absent_planes(IDENTITY=PlanePresence.PRESENT.value),
+        "experiment_identity_id": _PACKAGE_N_SHA256,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_valid_package_n_sha256_id_accepted() -> None:
+    assert is_package_n_sha256_canonical_id(_PACKAGE_N_SHA256)
+    record = validate_cross_lane_identity_join_v1(_base_record())
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert len(record.experiment_identity_id or "") == 64
+
+
+def test_present_state_supported() -> None:
+    payload = _base_record(
+        plane_presence=_absent_planes(
+            IDENTITY=PlanePresence.PRESENT.value,
+            RUN=PlanePresence.PRESENT.value,
+        ),
+        run_id="run-opaque-1",
+    )
+    record = validate_cross_lane_identity_join_v1(payload)
+    assert record.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert record.plane_presence["RUN"] == PlanePresence.PRESENT.value
+    assert record.run_id == "run-opaque-1"
+
+
+def test_absent_declared_state_supported() -> None:
+    payload = _base_record(
+        plane_presence=_absent_planes(),
+    )
+    del payload["experiment_identity_id"]
+    record = validate_cross_lane_identity_join_v1(payload)
+    assert record.plane_presence["IDENTITY"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.experiment_identity_id is None
+    for plane in JOIN_PLANES:
+        assert record.plane_presence[plane] == PlanePresence.ABSENT_DECLARED.value
+
+
+def test_missing_status_rejected() -> None:
+    payload = _base_record()
+    planes = _absent_planes(IDENTITY=PlanePresence.PRESENT.value)
+    del planes["RUN"]
+    payload["plane_presence"] = planes
+    with pytest.raises(CrossLaneIdentityJoinError, match="missing required plane status"):
+        validate_cross_lane_identity_join_v1(payload)
+
+    payload = _base_record()
+    payload["plane_presence"] = _absent_planes(IDENTITY=PlanePresence.PRESENT.value, RUN="")
+    with pytest.raises(CrossLaneIdentityJoinError, match="status is missing"):
+        validate_cross_lane_identity_join_v1(payload)
+
+    payload = _base_record()
+    payload["plane_presence"] = _absent_planes(
+        IDENTITY=PlanePresence.PRESENT.value, SESSION="ABSENT"
+    )
+    with pytest.raises(CrossLaneIdentityJoinError, match="PRESENT or ABSENT_DECLARED"):
+        validate_cross_lane_identity_join_v1(payload)
+
+
+def test_missing_canonical_id_when_present_rejected() -> None:
+    payload = _base_record()
+    del payload["experiment_identity_id"]
+    with pytest.raises(CrossLaneIdentityJoinError, match="canonical Package-N SHA256 id missing"):
+        validate_cross_lane_identity_join_v1(payload)
+
+    payload = _base_record(experiment_identity_id=None)
+    with pytest.raises(CrossLaneIdentityJoinError, match="canonical Package-N SHA256 id missing"):
+        validate_cross_lane_identity_join_v1(payload)
+
+
+def test_uuid_and_run_id_not_accepted_as_package_n_sha256() -> None:
+    run_id = str(uuid.uuid4())
+    assert is_package_n_sha256_canonical_id(run_id) is False
+    payload = _base_record(experiment_identity_id=run_id)
+    with pytest.raises(CrossLaneIdentityJoinError, match="UUID/run_id"):
+        validate_cross_lane_identity_join_v1(payload)
+
+    payload = _base_record(
+        plane_presence=_absent_planes(
+            IDENTITY=PlanePresence.PRESENT.value,
+            RUN=PlanePresence.PRESENT.value,
+        ),
+        experiment_identity_id=run_id,
+        run_id=run_id,
+    )
+    with pytest.raises(CrossLaneIdentityJoinError, match="UUID/run_id"):
+        validate_cross_lane_identity_join_v1(payload)
+
+    payload = _base_record(experiment_identity_id=_MD5_12)
+    with pytest.raises(CrossLaneIdentityJoinError, match="MD5 alias"):
+        validate_cross_lane_identity_join_v1(payload)
+
+
+def test_conflicting_identities_rejected() -> None:
+    payload = _base_record(experiment_id=str(uuid.uuid4()))
+    with pytest.raises(CrossLaneIdentityJoinError, match="conflicting identities"):
+        validate_cross_lane_identity_join_v1(payload)
+
+    payload = _base_record(
+        plane_presence=_absent_planes(
+            IDENTITY=PlanePresence.PRESENT.value,
+            RUN=PlanePresence.PRESENT.value,
+        ),
+        run_id=_PACKAGE_N_SHA256,
+    )
+    with pytest.raises(CrossLaneIdentityJoinError, match="conflicting identities"):
+        validate_cross_lane_identity_join_v1(payload)
+
+    payload = _base_record(
+        historical_provenance={"experiment_identity_id": _OTHER_SHA256},
+    )
+    with pytest.raises(
+        CrossLaneIdentityJoinError, match="historical provenance canonical id mismatch"
+    ):
+        validate_cross_lane_identity_join_v1(payload)
+
+
+def test_historical_provenance_read_only_and_unmodified() -> None:
+    original_provenance = {
+        "legacy_experiment_id": "3f1a9c2e-4b8d-4e21-9c77-aaaaaaaaaaaa",
+        "legacy_alias_md5_12": _MD5_12,
+        "source_note": "pre-join explorer row",
+    }
+    payload = _base_record(
+        plane_presence=_absent_planes(),
+        historical_provenance=original_provenance,
+    )
+    del payload["experiment_identity_id"]
+    snapshot = copy.deepcopy(original_provenance)
+    record = validate_cross_lane_identity_join_v1(payload)
+    original_provenance["legacy_experiment_id"] = "MUTATED"
+    payload["historical_provenance"]["source_note"] = "MUTATED_PAYLOAD"  # type: ignore[index]
+    assert dict(record.historical_provenance) == snapshot
+    assert payload["historical_provenance"]["legacy_experiment_id"] == "MUTATED"  # type: ignore[index]
+    with pytest.raises(TypeError):
+        record.historical_provenance["legacy_experiment_id"] = "rewrite"  # type: ignore[index]
+    frozen = read_historical_provenance(record)
+    assert isinstance(frozen, MappingProxyType)
+    assert dict(frozen) == snapshot
+    round_trip = validate_cross_lane_identity_join_v1(record.to_canonical_mapping())
+    assert dict(round_trip.historical_provenance) == snapshot
+
+
+def test_unknown_plane_rejected() -> None:
+    payload = _base_record()
+    planes = _absent_planes(IDENTITY=PlanePresence.PRESENT.value)
+    planes["ORDERS"] = PlanePresence.PRESENT.value
+    payload["plane_presence"] = planes
+    with pytest.raises(CrossLaneIdentityJoinError, match="unknown join plane"):
+        validate_cross_lane_identity_join_v1(payload)
+
+
+def test_invalid_record_cannot_serialize_as_valid_join() -> None:
+    with pytest.raises(CrossLaneIdentityJoinError):
+        validate_cross_lane_identity_join_v1({"contract_id": CONTRACT_ID})
+    valid = validate_cross_lane_identity_join_v1(_base_record())
+    serialized = valid.to_canonical_mapping()
+    assert (
+        validate_cross_lane_identity_join_v1(serialized).experiment_identity_id == _PACKAGE_N_SHA256
+    )
+
+
+def test_runtime_invariants_remain_unauthorized() -> None:
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+    payload = _base_record(
+        safety={"MULTI_FUTURE_RUNTIME_AUTHORIZED": True},
+    )
+    with pytest.raises(CrossLaneIdentityJoinError, match="MULTI_FUTURE_RUNTIME_AUTHORIZED"):
+        validate_cross_lane_identity_join_v1(payload)
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_no_cap72_or_src_execution_import() -> None:
+    modules = _imported_modules(CONTRACT_PATH)
+    assert not any(mod == "src.execution" or mod.startswith("src.execution.") for mod in modules)
+    assert not any(
+        "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in modules
+    )
+    assert "src.experiments.base" not in modules
+    assert "src.analytics.explorer" not in modules

--- a/tests/experiments/test_eg_i82_end_to_end_live_owner_graph_attestation_v1.py
+++ b/tests/experiments/test_eg_i82_end_to_end_live_owner_graph_attestation_v1.py
@@ -1,0 +1,569 @@
+"""U-I82-R24 tests for durable end-to-end live-owner graph attestation."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import uuid
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from src.analytics.explorer import ExperimentSummary, _row_to_summary
+from src.experiments.base import ExperimentConfig, ParamSweep
+from src.experiments.cross_lane_identity_join_v1 import (
+    JOIN_PLANES,
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+)
+from src.experiments.eg_i82_end_to_end_live_owner_graph_attestation_v1 import (
+    CONTRACT_ID,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    EG_I82_END_TO_END_LIVE_OWNER_GRAPH_ATTESTATION_REGISTERED,
+    EXPECTED_EDGE_COUNT,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    REAL_LIVE_OWNER_PATHS,
+    REQUIRED_GRAPH_EDGE_IDS,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    EgI82EndToEndLiveOwnerGraphAttestationError,
+    attest_eg_i82_end_to_end_live_owner_graph_v1,
+    is_eg_i82_end_to_end_live_owner_graph_attestation_registered,
+    require_eg_i82_complete_live_edge_matrix_v1,
+)
+from src.experiments.eg_i82_join_verifier_v1 import NAMED_JOIN_LANES
+from src.experiments.experiment_identity_manifest_v1 import (
+    ARTIFACT_FILENAME,
+    build_manifest,
+)
+from src.governance.promotion_loop.candidate_lineage_manifest_v1 import (
+    LineageRef,
+    LineageRefType,
+    LineageRelation,
+)
+from src.governance.promotion_loop.experiment_lineage_ref_producer_v1 import (
+    EXPERIMENT_OWNER_DOMAIN,
+)
+from src.levelup.v0_models import EvidenceBundleRefV0, LevelUpManifestV0, SliceContractV0
+from src.live_eval.live_session_eval import compute_metrics
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.preregistration_contract_v1 import (
+    load_preregistration_contract_dict_v1,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ATTESTATION_PATH = (
+    REPO_ROOT / "src" / "experiments" / "eg_i82_end_to_end_live_owner_graph_attestation_v1.py"
+)
+VERIFIER_PATH = REPO_ROOT / "src" / "experiments" / "eg_i82_join_verifier_v1.py"
+MASTER_RUNBOOK_PATH = REPO_ROOT / "docs" / "runbooks" / "canonical" / "PEAK_TRADE_MASTER_RUNBOOK.md"
+MAP_OF_TRUTH_PATH = REPO_ROOT / "docs" / "governance" / "PEAK_TRADE_MAP_OF_TRUTH.md"
+I52_MODELS_PATH = REPO_ROOT / "src" / "levelup" / "v0_models.py"
+I61_EVAL_PATH = REPO_ROOT / "src" / "live_eval" / "live_session_eval.py"
+I65_EXPLORER_PATH = REPO_ROOT / "src" / "analytics" / "explorer.py"
+PREREG_FIX = (
+    REPO_ROOT
+    / "tests"
+    / "fixtures"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+    / "preregistration_valid_non_authoritative.json"
+)
+
+_OTHER_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r24-other").hexdigest()
+_CONTENT_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r24-content").hexdigest()
+_MD5_12 = "abcdef012345"
+_RUN_ID = str(uuid.uuid4())
+_CAMPAIGN_ID = "campaign-i82-r24"
+_SESSION_ID = "session-i82-r24"
+_CAPSULE_ID = "capsule-i82-r24"
+_LIVE_OWNER_FILES = (
+    REPO_ROOT / "src" / "governance" / "promotion_loop" / "experiment_lineage_ref_producer_v1.py",
+    REPO_ROOT
+    / "src"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+    / "preregistration_contract_v1.py",
+    I52_MODELS_PATH,
+    REPO_ROOT / "src" / "ingress" / "capsules" / "evidence_capsule.py",
+    I61_EVAL_PATH,
+    I65_EXPLORER_PATH,
+)
+
+
+def _sample_config() -> ExperimentConfig:
+    return ExperimentConfig(
+        name="MA Optimization",
+        strategy_name="ma_crossover",
+        param_sweeps=[
+            ParamSweep("slow", [50, 100], description="ignored in identity"),
+            ParamSweep("fast", [5, 10]),
+        ],
+        symbols=["ETH/EUR", "BTC/EUR"],
+        timeframe="1h",
+        start_date="2024-01-01",
+        end_date="2024-06-01",
+        initial_capital=10000.0,
+        base_params={"window": 3},
+    )
+
+
+def _i52_live() -> dict[str, object]:
+    evidence = EvidenceBundleRefV0(relative_dir="out/ops/slice_demo_001/")
+    slice_model = SliceContractV0(
+        slice_id="S1-R3",
+        title="Live execution gated",
+        contract_summary="Without enabled+armed+token → no order.",
+        evidence=evidence,
+    )
+    return LevelUpManifestV0(title="Test", slices=(slice_model,)).model_dump(mode="python")
+
+
+def _i56_live() -> dict[str, object]:
+    return {
+        "capsule_id": _CAPSULE_ID,
+        "run_id": "default",
+        "ts_ms": 1000,
+        "artifacts": [],
+        "labels": {},
+        "facts": {},
+    }
+
+
+def _i65_live() -> dict[str, object]:
+    return {
+        "experiment_id": _RUN_ID,
+        "run_type": "backtest",
+        "run_name": "hist-run",
+    }
+
+
+def _canonical_owners(*, identity: str | None = None) -> dict[str, dict[str, object]]:
+    manifest = build_manifest(_sample_config())
+    package_n = str(manifest["experiment_identity_id"])
+    if identity is None:
+        identity = package_n
+    assert is_package_n_sha256_canonical_id(package_n)
+    return {
+        "I16": {
+            "manifest": manifest,
+            "artifact_path": ARTIFACT_FILENAME,
+            "run_id": "run-i16-r24",
+            "campaign_id": _CAMPAIGN_ID,
+            "session_id": _SESSION_ID,
+        },
+        "I17": {
+            "live": load_preregistration_contract_dict_v1(PREREG_FIX),
+            "experiment_identity_id": identity,
+            "run_id": "run-i17-r24",
+            "legacy_alias_md5_12": _MD5_12,
+        },
+        "I52": {
+            "live": _i52_live(),
+            "experiment_identity_id": identity,
+            "run_id": "run-i52-r24",
+            "campaign_id": _CAMPAIGN_ID,
+            "session_id": "session-i52-r24",
+            "legacy_alias_md5_12": _MD5_12,
+            "content_sha256": _CONTENT_SHA256,
+        },
+        "I56": {
+            "live": _i56_live(),
+            "experiment_identity_id": identity,
+            "campaign_id": _CAMPAIGN_ID,
+            "session_id": "session-i56-r24",
+            "legacy_alias_md5_12": _MD5_12,
+        },
+        "I61": {
+            "live": compute_metrics([]),
+            "experiment_identity_id": identity,
+            "run_id": "run-i61-r24",
+            "campaign_id": _CAMPAIGN_ID,
+            "session_id": "session-i61-r24",
+            "legacy_alias_md5_12": _MD5_12,
+            "content_sha256": _CONTENT_SHA256,
+            "evidence_ref": "evidence/i61-r24",
+        },
+        "I65": {
+            "live": _i65_live(),
+            "experiment_identity_id": identity,
+            "campaign_id": _CAMPAIGN_ID,
+            "session_id": "session-i65-r24",
+            "legacy_alias_md5_12": _MD5_12,
+            "content_sha256": _CONTENT_SHA256,
+            "evidence_ref": "evidence/i65-r24",
+        },
+    }
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_attestation_is_registered_and_requires_exactly_42_edges() -> None:
+    assert CONTRACT_ID == "eg_i82_end_to_end_live_owner_graph_attestation_v1"
+    assert EG_I82_END_TO_END_LIVE_OWNER_GRAPH_ATTESTATION_REGISTERED is True
+    assert is_eg_i82_end_to_end_live_owner_graph_attestation_registered() is True
+    assert EXPECTED_EDGE_COUNT == 42
+    assert len(REQUIRED_GRAPH_EDGE_IDS) == 42
+    assert len(NAMED_JOIN_LANES) == 6
+    assert len(JOIN_PLANES) == 7
+    assert set(REAL_LIVE_OWNER_PATHS) == set(NAMED_JOIN_LANES)
+
+
+def test_canonical_full_live_owner_graph_passes() -> None:
+    owners = _canonical_owners()
+    snapshot = copy.deepcopy(owners)
+    first = attest_eg_i82_end_to_end_live_owner_graph_v1(owners)
+    second = attest_eg_i82_end_to_end_live_owner_graph_v1(owners)
+    assert owners == snapshot
+    assert first.to_canonical_mapping() == second.to_canonical_mapping()
+    assert first.package_n_sha256 == snapshot["I16"]["manifest"]["experiment_identity_id"]
+    assert is_package_n_sha256_canonical_id(first.package_n_sha256)
+    assert first.expected_edge_count == 42
+    assert first.edges_evaluated == 42
+    assert first.edges_proven == 42
+    assert first.edges_disproven == 0
+    assert first.edges_not_proven == 0
+    assert first.edges_not_applicable == 0
+    assert first.all_required_edges_proven is True
+    assert first.static_flag_aggregation_only is False
+    assert first.full_graph_traversal is True
+    assert first.end_to_end_join_graph_proven is True
+    assert first.eg_i82_join_closure_proven is True
+    assert first.eg_i82_join_status == "CLOSED_PROVEN"
+    assert tuple(edge.edge_id for edge in first.edges) == REQUIRED_GRAPH_EDGE_IDS
+    assert all(edge.canonical_join_key == first.package_n_sha256 for edge in first.edges)
+    assert all(edge.proven for edge in first.edges)
+    assert set(first.live_owner_paths.values()) == set(REAL_LIVE_OWNER_PATHS.values())
+    assert all(
+        first.lane_identity_presence[lane] == PlanePresence.PRESENT.value
+        for lane in NAMED_JOIN_LANES
+    )
+    campaign_edges = [edge for edge in first.edges if edge.plane == "CAMPAIGN"]
+    assert any(edge.presence == PlanePresence.PRESENT.value for edge in campaign_edges)
+    assert any(edge.presence == PlanePresence.ABSENT_DECLARED.value for edge in campaign_edges)
+
+
+def test_declared_absence_is_deterministic_and_proven() -> None:
+    owners = _canonical_owners()
+    for lane in ("I16", "I52", "I56", "I61", "I65"):
+        owners[lane].pop("campaign_id", None)
+    result = attest_eg_i82_end_to_end_live_owner_graph_v1(owners)
+    campaign = {edge.lane: edge for edge in result.edges if edge.plane == "CAMPAIGN"}
+    assert campaign["I17"].presence == PlanePresence.ABSENT_DECLARED.value
+    assert campaign["I16"].presence == PlanePresence.ABSENT_DECLARED.value
+    assert campaign["I17"].proven is True
+    assert result.edges_proven == 42
+    assert result.eg_i82_join_status == "CLOSED_PROVEN"
+
+
+def test_exactly_one_missing_required_edge_fail_closed() -> None:
+    owners = _canonical_owners()
+    result = attest_eg_i82_end_to_end_live_owner_graph_v1(owners)
+    edges = [edge.to_canonical_mapping() for edge in result.edges]
+    removed = edges.pop(
+        edges.index(next(item for item in edges if item["edge_id"] == "I65xEVIDENCE"))
+    )
+    assert removed["edge_id"] == "I65xEVIDENCE"
+    with pytest.raises(
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+        match="missing required edge rejected: I65xEVIDENCE",
+    ):
+        require_eg_i82_complete_live_edge_matrix_v1(
+            edges,
+            package_n_sha256=result.package_n_sha256,
+        )
+
+
+def test_wrong_join_key_on_one_edge_fail_closed() -> None:
+    owners = _canonical_owners()
+    owners["I65"]["experiment_identity_id"] = str(uuid.uuid4())
+    with pytest.raises(
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+        match="noncanonical ID substitution rejected",
+    ):
+        attest_eg_i82_end_to_end_live_owner_graph_v1(owners)
+
+
+def test_conflicting_package_n_within_owner_fail_closed() -> None:
+    owners = _canonical_owners()
+    manifest = owners["I16"]["manifest"]
+    owners["I16"]["ref"] = LineageRef(
+        ref_type=LineageRefType.EXPERIMENT,
+        ref_id=_OTHER_SHA256,
+        relation=LineageRelation.SOURCES,
+        owner_domain=EXPERIMENT_OWNER_DOMAIN,
+        required=False,
+        digest=str(manifest["integrity"]["content_sha256"]),
+        artifact_path=ARTIFACT_FILENAME,
+    )
+    with pytest.raises(
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+        match="conflicting identity rejected",
+    ):
+        attest_eg_i82_end_to_end_live_owner_graph_v1(owners)
+
+
+def test_conflicting_package_n_across_owners_fail_closed() -> None:
+    owners = _canonical_owners()
+    owners["I65"]["experiment_identity_id"] = _OTHER_SHA256
+    with pytest.raises(
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+        match="conflicting identity rejected",
+    ):
+        attest_eg_i82_end_to_end_live_owner_graph_v1(owners)
+
+
+def test_run_as_identity_fail_closed() -> None:
+    owners = _canonical_owners()
+    owners["I65"]["experiment_identity_id"] = str(owners["I65"]["live"]["experiment_id"])
+    with pytest.raises(
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+        match="noncanonical ID substitution rejected",
+    ):
+        attest_eg_i82_end_to_end_live_owner_graph_v1(owners)
+
+
+def test_alias_as_identity_fail_closed() -> None:
+    owners = _canonical_owners()
+    owners["I52"]["experiment_identity_id"] = _MD5_12
+    with pytest.raises(
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+        match="noncanonical ID substitution rejected",
+    ):
+        attest_eg_i82_end_to_end_live_owner_graph_v1(owners)
+
+
+def test_synthetic_package_n_identity_fail_closed() -> None:
+    source = ATTESTATION_PATH.read_text(encoding="utf-8")
+    assert "hashlib" not in source
+    owners = _canonical_owners()
+    owners["I56"].pop("experiment_identity_id")
+    with pytest.raises(
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+        match="implicit absence rejected",
+    ):
+        attest_eg_i82_end_to_end_live_owner_graph_v1(owners)
+
+
+def test_implicit_absence_of_owner_fail_closed() -> None:
+    owners = _canonical_owners()
+    owners.pop("I61")
+    with pytest.raises(
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+        match="implicit absence rejected: named lane I61 is missing",
+    ):
+        attest_eg_i82_end_to_end_live_owner_graph_v1(owners)
+
+
+def test_cross_lane_substitution_fail_closed() -> None:
+    owners = _canonical_owners()
+    owners["I52"]["I16"] = {"manifest": owners["I16"]["manifest"]}
+    with pytest.raises(
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+        match="cross-lane substitution rejected",
+    ):
+        attest_eg_i82_end_to_end_live_owner_graph_v1(owners)
+    live = dict(owners["I61"]["live"])
+    live["I16"] = "not-allowed"
+    owners["I61"]["live"] = live
+    with pytest.raises(
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+        match="cross-lane substitution rejected",
+    ):
+        attest_eg_i82_end_to_end_live_owner_graph_v1(owners)
+
+
+def test_cross_plane_substitution_fail_closed() -> None:
+    owners = _canonical_owners()
+    live = dict(owners["I61"]["live"])
+    live["plane_presence"] = {"IDENTITY": "PRESENT"}
+    owners["I61"]["live"] = live
+    with pytest.raises(
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+        match="cross-plane substitution rejected",
+    ):
+        attest_eg_i82_end_to_end_live_owner_graph_v1(owners)
+
+
+def test_malformed_owner_payload_fail_closed() -> None:
+    owners = _canonical_owners()
+    owners["I52"]["live"] = "not-an-object"
+    with pytest.raises(
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+        match="malformed plane data rejected",
+    ):
+        attest_eg_i82_end_to_end_live_owner_graph_v1(owners)
+
+
+def test_ambiguous_join_fail_closed() -> None:
+    owners = _canonical_owners()
+    owners["I56"]["live"] = [_i56_live(), _i56_live()]
+    with pytest.raises(
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+        match="ambiguous join rejected",
+    ):
+        attest_eg_i82_end_to_end_live_owner_graph_v1(owners)
+
+
+def test_duplicate_and_unexpected_edge_fail_closed() -> None:
+    owners = _canonical_owners()
+    result = attest_eg_i82_end_to_end_live_owner_graph_v1(owners)
+    edges = [edge.to_canonical_mapping() for edge in result.edges]
+    duplicated = edges + [edges[0]]
+    with pytest.raises(
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+        match="duplicate/conflicting edge registration rejected",
+    ):
+        require_eg_i82_complete_live_edge_matrix_v1(
+            duplicated,
+            package_n_sha256=result.package_n_sha256,
+        )
+    extra = edges + [
+        {
+            "edge_id": "I99xIDENTITY",
+            "lane": "I99",
+            "plane": "IDENTITY",
+            "presence": PlanePresence.PRESENT.value,
+            "canonical_join_key": result.package_n_sha256,
+        }
+    ]
+    with pytest.raises(
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+        match="unexpected extra edge rejected",
+    ):
+        require_eg_i82_complete_live_edge_matrix_v1(
+            extra,
+            package_n_sha256=result.package_n_sha256,
+        )
+    owners_extra = dict(owners)
+    owners_extra["I99"] = {"live": {}, "experiment_identity_id": result.package_n_sha256}
+    with pytest.raises(
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+        match="unexpected extra edge rejected",
+    ):
+        attest_eg_i82_end_to_end_live_owner_graph_v1(owners_extra)
+
+
+def test_static_join_records_are_not_accepted_as_live_owners() -> None:
+    owners = _canonical_owners()
+    result = attest_eg_i82_end_to_end_live_owner_graph_v1(owners)
+    static = {
+        lane: {
+            "plane_presence": {plane: PlanePresence.PRESENT.value for plane in JOIN_PLANES},
+            "experiment_identity_id": result.package_n_sha256,
+            "contract_id": "static",
+        }
+        for lane in NAMED_JOIN_LANES
+    }
+    with pytest.raises(
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+        match=(
+            "static join record rejected|malformed plane data rejected|"
+            "cross-plane substitution rejected"
+        ),
+    ):
+        attest_eg_i82_end_to_end_live_owner_graph_v1(static)
+
+
+def test_wrong_join_key_on_matrix_edge_fail_closed() -> None:
+    owners = _canonical_owners()
+    result = attest_eg_i82_end_to_end_live_owner_graph_v1(owners)
+    edges = [edge.to_canonical_mapping() for edge in result.edges]
+    for item in edges:
+        if item["edge_id"] == "I17xRUN":
+            item["canonical_join_key"] = _OTHER_SHA256
+    with pytest.raises(
+        EgI82EndToEndLiveOwnerGraphAttestationError,
+        match="conflicting identity rejected: I17xRUN join key disagrees",
+    ):
+        require_eg_i82_complete_live_edge_matrix_v1(
+            edges,
+            package_n_sha256=result.package_n_sha256,
+        )
+
+
+def test_historical_readability_paths_remain() -> None:
+    explorer_source = I65_EXPLORER_PATH.read_text(encoding="utf-8")
+    assert 'experiment_id=str(row.get("run_id", ""))' in explorer_source
+    row = pd.Series(
+        {
+            "run_id": _RUN_ID,
+            "run_type": "backtest",
+            "run_name": "hist-run",
+            "strategy_key": "ma_crossover",
+            "sweep_name": None,
+            "scan_name": None,
+            "portfolio_name": None,
+            "symbol": "BTC-USDT",
+            "metadata_json": "{}",
+            "timestamp": "2026-01-01T00:00:00",
+            "params_json": "{}",
+            "sharpe": 1.2,
+            "total_return": 0.1,
+            "max_drawdown": -0.05,
+            "cagr": 0.08,
+            "stats_json": "{}",
+        }
+    )
+    summary = _row_to_summary(row)
+    assert isinstance(summary, ExperimentSummary)
+    assert summary.experiment_id == _RUN_ID
+    assert not hasattr(summary, "experiment_identity_id")
+    models_source = I52_MODELS_PATH.read_text(encoding="utf-8")
+    assert 'extra="forbid"' in models_source
+    eval_source = I61_EVAL_PATH.read_text(encoding="utf-8")
+    assert "class Fill:" in eval_source
+    assert "def compute_metrics(" in eval_source
+
+
+def test_runtime_and_import_invariants() -> None:
+    modules = _imported_modules(ATTESTATION_PATH)
+    assert "src.analytics.explorer" in modules
+    assert "src.levelup.v0_models" in modules
+    assert "src.ingress.capsules.evidence_capsule" in modules
+    assert "src.live_eval.live_session_eval" in modules
+    assert (
+        "src.ops.paper_shadow_observation_operator_go_session_preregistration_v1"
+        ".preregistration_contract_v1" in modules
+    )
+    assert "src.governance.promotion_loop.experiment_lineage_ref_producer_v1" in modules
+    assert "src.experiments.eg_i82_join_verifier_v1" in modules
+    assert "hashlib" not in modules
+    assert not any(mod == "src.execution" or mod.startswith("src.execution.") for mod in modules)
+    assert not any(
+        "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in modules
+    )
+    source = ATTESTATION_PATH.read_text(encoding="utf-8")
+    assert "place_order" not in source
+    verifier_source = VERIFIER_PATH.read_text(encoding="utf-8")
+    assert "eg_i82_end_to_end_live_owner_graph_attestation_v1" not in verifier_source
+    for path in _LIVE_OWNER_FILES:
+        text = path.read_text(encoding="utf-8")
+        assert "eg_i82_end_to_end_live_owner_graph_attestation_v1" not in text
+        assert "attest_eg_i82_end_to_end_live_owner_graph_v1" not in text
+    master = MASTER_RUNBOOK_PATH.read_text(encoding="utf-8")
+    assert "## 5.8 EG-I82-JOIN Package-N live-owner identity-join closeout" in master
+    assert "EG_I82_JOIN_STATUS=CLOSED_PROVEN" in master
+    assert "SUCCESSOR_PHASE_AUTHORIZED=false" in master
+    assert "RUNTIME_AUTHORIZATION_EFFECT=NONE" in master
+    assert "ORDER_EFFECT=NONE" in master
+    map_of_truth = MAP_OF_TRUTH_PATH.read_text(encoding="utf-8")
+    assert "## 8.2 EG-I82-JOIN closeout (navigation only)" in map_of_truth
+    assert "THIS_SECTION_DEFINES_NO_SEMANTICS=true" in map_of_truth
+    assert "EG_I82_JOIN_STATUS=CLOSED_PROVEN" not in map_of_truth
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1

--- a/tests/experiments/test_eg_i82_join_verifier_v1.py
+++ b/tests/experiments/test_eg_i82_join_verifier_v1.py
@@ -1,0 +1,371 @@
+"""U-I82-R11 tests for dormant EG-I82 cross-lane join verifier."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import uuid
+from pathlib import Path
+
+import pytest
+
+from src.experiments.base import ExperimentConfig, ParamSweep
+from src.experiments.cross_lane_identity_join_record_v1 import (
+    build_cross_lane_identity_join_record_v1,
+)
+from src.experiments.cross_lane_identity_join_v1 import (
+    CONTRACT_VERSION,
+    JOIN_PLANES,
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+    validate_cross_lane_identity_join_v1,
+)
+from src.experiments.eg_i82_join_verifier_v1 import (
+    CONTRACT_ID,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    EG_I82_CROSS_LANE_VERIFIER_REGISTERED,
+    EgI82JoinVerifierError,
+    LANE_DORMANT_CONTRACT_IDS,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    NAMED_JOIN_LANES,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    is_eg_i82_cross_lane_verifier_registered,
+    verify_eg_i82_cross_lane_join_v1,
+)
+from src.experiments.experiment_identity_manifest_v1 import build_manifest
+from src.experiments.i16_package_n_join_emission_v1 import (
+    emit_i16_package_n_join_from_producer_v1,
+    emit_i16_package_n_join_v1,
+)
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VERIFIER_PATH = REPO_ROOT / "src" / "experiments" / "eg_i82_join_verifier_v1.py"
+I16_EMISSION_PATH = REPO_ROOT / "src" / "experiments" / "i16_package_n_join_emission_v1.py"
+
+_PACKAGE_N_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r11-package-n").hexdigest()
+_OTHER_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r11-other").hexdigest()
+_CONTENT_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r11-content").hexdigest()
+_MD5_12 = "abcdef012345"
+_RUN_ID = str(uuid.uuid4())
+_LIVE_CONTRACT_MODULES = (
+    "src.ingress.capsules.evidence_capsule",
+    "src.levelup.v0_models",
+    "src.live_eval.live_session_eval",
+    "src.analytics.explorer",
+    "src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.preregistration_contract_v1",
+    "src.core.experiments",
+)
+_DORMANT_ATTACHMENT_MODULES = (
+    "src.governance.promotion_loop.i16_remaining_planes_join_attachment_v1",
+    "src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.i17_paper_shadow_join_attachment_v1",
+    "src.levelup.i52_levelup_join_attachment_v1",
+    "src.ingress.capsules.i56_ingress_join_attachment_v1",
+    "src.live_eval.i61_live_eval_join_attachment_v1",
+    "src.analytics.i65_explorer_join_attachment_v1",
+    "src.experiments.i16_package_n_join_emission_v1",
+)
+
+
+def _sample_config() -> ExperimentConfig:
+    return ExperimentConfig(
+        name="MA Optimization",
+        strategy_name="ma_crossover",
+        param_sweeps=[
+            ParamSweep("slow", [50, 100], description="ignored in identity"),
+            ParamSweep("fast", [5, 10]),
+        ],
+        symbols=["ETH/EUR", "BTC/EUR"],
+        timeframe="1h",
+        start_date="2024-01-01",
+        end_date="2024-06-01",
+        initial_capital=10000.0,
+        base_params={"window": 3},
+    )
+
+
+def _absent(plane: str) -> dict[str, str]:
+    return {"plane": plane, "presence": PlanePresence.ABSENT_DECLARED.value}
+
+
+def _present(plane: str, value: str, join_key: str = _PACKAGE_N_SHA256) -> dict[str, str]:
+    return {
+        "plane": plane,
+        "presence": PlanePresence.PRESENT.value,
+        "join_key": join_key,
+        "value": value,
+    }
+
+
+def _complete(*overrides: dict[str, str]) -> list[dict[str, str]]:
+    by_plane = {plane: _absent(plane) for plane in JOIN_PLANES}
+    for item in overrides:
+        by_plane[item["plane"]] = item
+    return [by_plane[plane] for plane in JOIN_PLANES]
+
+
+def _absent_record():
+    return build_cross_lane_identity_join_record_v1(_complete())
+
+
+def _identity_record(
+    identity: str = _PACKAGE_N_SHA256,
+    *,
+    run_id: str | None = None,
+    content_sha256: str | None = None,
+    session_id: str | None = None,
+    historical_provenance: dict[str, str] | None = None,
+):
+    overrides = [_present("IDENTITY", identity, join_key=identity)]
+    if run_id is not None:
+        overrides.append(_present("RUN", run_id, join_key=identity))
+    if content_sha256 is not None:
+        overrides.append(_present("CONTENT_HASH", content_sha256, join_key=identity))
+    if session_id is not None:
+        overrides.append(_present("SESSION", session_id, join_key=identity))
+    return build_cross_lane_identity_join_record_v1(
+        _complete(*overrides),
+        package_n_identity_id=identity,
+        historical_provenance=historical_provenance,
+    )
+
+
+def _lanes(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {lane: _absent_record() for lane in NAMED_JOIN_LANES}
+    payload.update(overrides)
+    return payload
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_verifier_is_registered_and_reachable() -> None:
+    assert CONTRACT_ID == "eg_i82_join_verifier_v1"
+    assert EG_I82_CROSS_LANE_VERIFIER_REGISTERED is True
+    assert is_eg_i82_cross_lane_verifier_registered() is True
+    assert NAMED_JOIN_LANES == ("I16", "I17", "I52", "I56", "I61", "I65")
+    assert LANE_DORMANT_CONTRACT_IDS["I16"] == "i16_package_n_join_emission_v1"
+    result = verify_eg_i82_cross_lane_join_v1(_lanes())
+    assert result.verifier_registered is True
+    assert result.contract_id == CONTRACT_ID
+
+
+def test_i16_producer_emission_reaches_join_path() -> None:
+    config = _sample_config()
+    emitted = emit_i16_package_n_join_from_producer_v1(config)
+    result = verify_eg_i82_cross_lane_join_v1(_lanes(I16=emitted))
+    assert result.package_n_sha256 == emitted.experiment_identity_id
+    assert is_package_n_sha256_canonical_id(result.package_n_sha256) is True
+    assert result.lane_identity_presence["I16"] == PlanePresence.PRESENT.value
+    again = emit_i16_package_n_join_v1(build_manifest(config))
+    assert again.experiment_identity_id == result.package_n_sha256
+
+
+def test_identical_canonical_identities_across_lanes_accepted() -> None:
+    result = verify_eg_i82_cross_lane_join_v1(
+        _lanes(
+            I16=_identity_record(),
+            I17=_identity_record(),
+            I52=_identity_record(),
+        )
+    )
+    assert result.package_n_sha256 == _PACKAGE_N_SHA256
+    assert result.lane_identity_presence["I16"] == PlanePresence.PRESENT.value
+    assert result.lane_identity_presence["I17"] == PlanePresence.PRESENT.value
+    assert result.lane_identity_presence["I65"] == PlanePresence.ABSENT_DECLARED.value
+
+
+def test_declared_absence_supported() -> None:
+    result = verify_eg_i82_cross_lane_join_v1(_lanes())
+    assert result.package_n_sha256 is None
+    for lane in NAMED_JOIN_LANES:
+        assert result.lane_identity_presence[lane] == PlanePresence.ABSENT_DECLARED.value
+
+
+def test_present_versus_declared_absent_follows_join_semantics() -> None:
+    result = verify_eg_i82_cross_lane_join_v1(_lanes(I16=_identity_record()))
+    assert result.package_n_sha256 == _PACKAGE_N_SHA256
+    assert result.lane_identity_presence["I16"] == PlanePresence.PRESENT.value
+    for lane in ("I17", "I52", "I56", "I61", "I65"):
+        assert result.lane_identity_presence[lane] == PlanePresence.ABSENT_DECLARED.value
+
+
+def test_conflicting_identity_rejected() -> None:
+    with pytest.raises(EgI82JoinVerifierError, match="conflicting identity rejected"):
+        verify_eg_i82_cross_lane_join_v1(
+            _lanes(
+                I16=_identity_record(_PACKAGE_N_SHA256),
+                I17=_identity_record(_OTHER_SHA256),
+            )
+        )
+
+
+def test_ambiguous_join_rejected() -> None:
+    with pytest.raises(EgI82JoinVerifierError, match="ambiguous join rejected"):
+        verify_eg_i82_cross_lane_join_v1(
+            _lanes(
+                I16=[_identity_record(_PACKAGE_N_SHA256), _identity_record(_OTHER_SHA256)],
+            )
+        )
+
+
+def test_implicit_absence_rejected() -> None:
+    lanes = _lanes()
+    del lanes["I17"]
+    with pytest.raises(EgI82JoinVerifierError, match="implicit absence rejected"):
+        verify_eg_i82_cross_lane_join_v1(lanes)
+    with pytest.raises(EgI82JoinVerifierError, match="implicit absence rejected"):
+        verify_eg_i82_cross_lane_join_v1(_lanes(I52=None))
+    payload = _identity_record().to_canonical_mapping()
+    del payload["experiment_identity_id"]
+    with pytest.raises(EgI82JoinVerifierError, match="implicit absence rejected"):
+        verify_eg_i82_cross_lane_join_v1(_lanes(I16=payload))
+
+
+def test_malformed_lane_data_rejected() -> None:
+    with pytest.raises(EgI82JoinVerifierError, match="malformed plane data rejected"):
+        verify_eg_i82_cross_lane_join_v1(_lanes(I16="not-an-object"))
+    with pytest.raises(EgI82JoinVerifierError, match="malformed plane data rejected"):
+        verify_eg_i82_cross_lane_join_v1("not-lanes")  # type: ignore[arg-type]
+    payload = _identity_record().to_canonical_mapping()
+    payload["plane_presence"] = {**payload["plane_presence"], "ORDERS": "PRESENT"}
+    with pytest.raises(EgI82JoinVerifierError, match="malformed plane data rejected"):
+        verify_eg_i82_cross_lane_join_v1(_lanes(I16=payload))
+
+
+def test_noncanonical_id_substitution_rejected() -> None:
+    with pytest.raises(EgI82JoinVerifierError, match="noncanonical ID substitution rejected"):
+        verify_eg_i82_cross_lane_join_v1(_lanes(I16={"run_id": _RUN_ID}))
+    payload = _identity_record().to_canonical_mapping()
+    payload["experiment_identity_id"] = _RUN_ID
+    with pytest.raises(EgI82JoinVerifierError, match="noncanonical ID substitution rejected"):
+        verify_eg_i82_cross_lane_join_v1(_lanes(I16=payload))
+
+
+def test_cross_lane_substitution_rejected() -> None:
+    with pytest.raises(EgI82JoinVerifierError, match="cross-lane substitution rejected"):
+        verify_eg_i82_cross_lane_join_v1(
+            _lanes(
+                I16=_identity_record(_PACKAGE_N_SHA256, content_sha256=_CONTENT_SHA256),
+                I17=_identity_record(_CONTENT_SHA256),
+            )
+        )
+
+
+def test_cross_plane_substitution_rejected() -> None:
+    with pytest.raises(EgI82JoinVerifierError, match="cross-plane substitution rejected"):
+        verify_eg_i82_cross_lane_join_v1(
+            _lanes(I16=_identity_record(_PACKAGE_N_SHA256, content_sha256=_PACKAGE_N_SHA256))
+        )
+
+
+def test_legacy_experiment_id_is_not_authoritative() -> None:
+    provenance = {"legacy_experiment_id": "legacy-source-alias", "experiment_id": _RUN_ID}
+    result = verify_eg_i82_cross_lane_join_v1(
+        _lanes(I16=_identity_record(historical_provenance=provenance))
+    )
+    assert result.package_n_sha256 == _PACKAGE_N_SHA256
+    assert result.package_n_sha256 != provenance["legacy_experiment_id"]
+    assert result.package_n_sha256 != provenance["experiment_id"]
+    absent = verify_eg_i82_cross_lane_join_v1(
+        _lanes(
+            I65=build_cross_lane_identity_join_record_v1(
+                _complete(),
+                historical_provenance=provenance,
+            )
+        )
+    )
+    assert absent.package_n_sha256 is None
+
+
+def test_run_id_is_not_authoritative() -> None:
+    result = verify_eg_i82_cross_lane_join_v1(_lanes(I16=_identity_record(run_id=_RUN_ID)))
+    assert result.package_n_sha256 == _PACKAGE_N_SHA256
+    assert result.package_n_sha256 != _RUN_ID
+    with pytest.raises(EgI82JoinVerifierError, match="noncanonical ID substitution rejected"):
+        verify_eg_i82_cross_lane_join_v1(_lanes(I16={"run_id": _RUN_ID, "experiment_id": _RUN_ID}))
+
+
+def test_verifier_behavior_is_deterministic() -> None:
+    raw = _lanes(I16=_identity_record(), I61=_identity_record())
+    lanes = {lane: value.to_canonical_mapping() for lane, value in raw.items()}
+    first = verify_eg_i82_cross_lane_join_v1(lanes).to_canonical_mapping()
+    second = verify_eg_i82_cross_lane_join_v1(copy.deepcopy(lanes)).to_canonical_mapping()
+    assert first == second
+    assert first["package_n_sha256"] == _PACKAGE_N_SHA256
+    assert first["schema_version"] == CONTRACT_VERSION
+
+
+def test_inputs_are_not_mutated() -> None:
+    original = _identity_record().to_canonical_mapping()
+    snapshot = copy.deepcopy(original)
+    lanes = _lanes(I16=original)
+    result = verify_eg_i82_cross_lane_join_v1(lanes)
+    original["experiment_identity_id"] = "MUTATED"
+    lanes["I17"] = "MUTATED"
+    assert result.package_n_sha256 == snapshot["experiment_identity_id"]
+    assert original["experiment_identity_id"] == "MUTATED"
+
+
+def test_no_persistence_migration_backfill_or_runtime_effects() -> None:
+    source = VERIFIER_PATH.read_text(encoding="utf-8")
+    assert "open(" not in source
+    assert "write_text" not in source
+    assert "Path(" not in source
+    assert "socket" not in source
+    assert "urllib" not in source
+    assert "requests" not in source
+    assert "submit_order" not in source
+    assert "place_order" not in source
+    modules = _imported_modules(VERIFIER_PATH)
+    assert "src.experiments.cross_lane_identity_join_v1" in modules
+    assert "src.experiments.cross_lane_identity_join_record_v1" not in modules
+    assert not any(mod == "src.execution" or mod.startswith("src.execution.") for mod in modules)
+    assert not any(
+        "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in modules
+    )
+    for forbidden in (*_LIVE_CONTRACT_MODULES, *_DORMANT_ATTACHMENT_MODULES):
+        assert forbidden not in modules
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+
+
+def test_i16_emission_and_live_contracts_remain_unregistered() -> None:
+    emission_source = I16_EMISSION_PATH.read_text(encoding="utf-8")
+    assert "eg_i82_join_verifier_v1" not in emission_source
+    assert "verify_eg_i82_cross_lane_join_v1" not in emission_source
+    live_paths = (
+        REPO_ROOT / "src" / "ingress" / "capsules" / "evidence_capsule.py",
+        REPO_ROOT / "src" / "levelup" / "v0_models.py",
+        REPO_ROOT / "src" / "live_eval" / "live_session_eval.py",
+        REPO_ROOT / "src" / "analytics" / "explorer.py",
+        REPO_ROOT
+        / "src"
+        / "ops"
+        / "paper_shadow_observation_operator_go_session_preregistration_v1"
+        / "preregistration_contract_v1.py",
+    )
+    for path in live_paths:
+        text = path.read_text(encoding="utf-8")
+        assert "eg_i82_join_verifier_v1" not in text
+        assert "verify_eg_i82_cross_lane_join_v1" not in text
+
+
+def test_r1_record_round_trip_still_validates() -> None:
+    record = _identity_record()
+    validated = validate_cross_lane_identity_join_v1(record.to_canonical_mapping())
+    result = verify_eg_i82_cross_lane_join_v1(_lanes(I56=validated))
+    assert result.package_n_sha256 == _PACKAGE_N_SHA256

--- a/tests/experiments/test_i16_package_n_join_emission_v1.py
+++ b/tests/experiments/test_i16_package_n_join_emission_v1.py
@@ -1,0 +1,211 @@
+"""U-I82-R10 tests for dormant I16 Package-N producer join emission."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import uuid
+from pathlib import Path
+
+import pytest
+
+from src.experiments.base import ExperimentConfig, ParamSweep
+from src.experiments.cross_lane_identity_join_v1 import (
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+)
+from src.experiments.experiment_identity_manifest_v1 import (
+    ARTIFACT_FILENAME,
+    build_manifest,
+)
+from src.experiments.i16_package_n_join_emission_v1 import (
+    CONTRACT_ID,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    I16PackageNJoinEmissionError,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    emit_i16_package_n_join_from_producer_v1,
+    emit_i16_package_n_join_v1,
+)
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EMISSION_PATH = REPO_ROOT / "src" / "experiments" / "i16_package_n_join_emission_v1.py"
+PRODUCER_PATH = REPO_ROOT / "src" / "experiments" / "experiment_identity_manifest_v1.py"
+CLI_PATH = REPO_ROOT / "scripts" / "run_experiment_identity_manifest_v1.py"
+
+_MD5_12 = "abcdef012345"
+_RUN_ID = str(uuid.uuid4())
+
+
+def _sample_config() -> ExperimentConfig:
+    return ExperimentConfig(
+        name="MA Optimization",
+        strategy_name="ma_crossover",
+        param_sweeps=[
+            ParamSweep("slow", [50, 100], description="ignored in identity"),
+            ParamSweep("fast", [5, 10]),
+        ],
+        symbols=["ETH/EUR", "BTC/EUR"],
+        timeframe="1h",
+        start_date="2024-01-01",
+        end_date="2024-06-01",
+        initial_capital=10000.0,
+        base_params={"window": 3},
+    )
+
+
+def test_canonical_package_n_sha256_reaches_i82_join() -> None:
+    config = _sample_config()
+    manifest = build_manifest(config)
+    record = emit_i16_package_n_join_v1(manifest)
+    assert CONTRACT_ID == "i16_package_n_join_emission_v1"
+    assert record.experiment_identity_id == manifest["experiment_identity_id"]
+    assert is_package_n_sha256_canonical_id(record.experiment_identity_id) is True
+    assert record.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert record.legacy_alias_md5_12 == manifest["legacy_aliases"]["legacy_experiment_id_md5_12"]
+    assert record.content_sha256 == manifest["integrity"]["content_sha256"]
+    assert record.experiment_identity_id != record.legacy_alias_md5_12
+    assert record.experiment_identity_id != record.content_sha256
+
+
+def test_producer_path_is_deterministic() -> None:
+    config = _sample_config()
+    first = emit_i16_package_n_join_from_producer_v1(config).to_canonical_mapping()
+    second = emit_i16_package_n_join_from_producer_v1(copy.deepcopy(config)).to_canonical_mapping()
+    assert first == second
+    assert first["experiment_identity_id"] == build_manifest(config)["experiment_identity_id"]
+
+
+def test_declared_absence_for_run_campaign_session_evidence() -> None:
+    record = emit_i16_package_n_join_v1(build_manifest(_sample_config()))
+    assert record.plane_presence["RUN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["CAMPAIGN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["SESSION"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["EVIDENCE"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.run_id is None
+    assert record.campaign_id is None
+    assert record.session_id is None
+    assert record.evidence_ref is None
+
+
+def test_implicit_absence_rejected() -> None:
+    with pytest.raises(I16PackageNJoinEmissionError, match="malformed Package-N producer manifest"):
+        emit_i16_package_n_join_v1({})
+
+
+def test_noncanonical_id_substitution_rejected() -> None:
+    manifest = build_manifest(_sample_config())
+    mutated = copy.deepcopy(manifest)
+    mutated["experiment_identity_id"] = _RUN_ID
+    with pytest.raises(I16PackageNJoinEmissionError, match="malformed Package-N producer manifest"):
+        emit_i16_package_n_join_v1(mutated)
+    mutated_md5 = copy.deepcopy(manifest)
+    mutated_md5["experiment_identity_id"] = _MD5_12
+    with pytest.raises(I16PackageNJoinEmissionError, match="malformed Package-N producer manifest"):
+        emit_i16_package_n_join_v1(mutated_md5)
+
+
+def test_run_id_on_producer_manifest_rejected() -> None:
+    manifest = build_manifest(_sample_config())
+    mutated = copy.deepcopy(manifest)
+    mutated["run_id"] = _RUN_ID
+    with pytest.raises(I16PackageNJoinEmissionError, match="noncanonical ID substitution"):
+        emit_i16_package_n_join_v1(mutated)
+
+
+def test_conflicting_identity_rejected() -> None:
+    manifest = build_manifest(_sample_config())
+    mutated = copy.deepcopy(manifest)
+    mutated["experiment_identity_id"] = hashlib.sha256(b"peak-trade-u-i82-r10-other").hexdigest()
+    with pytest.raises(I16PackageNJoinEmissionError, match="malformed Package-N producer manifest"):
+        emit_i16_package_n_join_v1(mutated)
+
+
+def test_ambiguous_and_malformed_join_rejected() -> None:
+    with pytest.raises(I16PackageNJoinEmissionError, match="must be an object"):
+        emit_i16_package_n_join_v1("not-an-object")  # type: ignore[arg-type]
+    manifest = build_manifest(_sample_config())
+    mutated = copy.deepcopy(manifest)
+    mutated["integrity"] = "bad"
+    with pytest.raises(I16PackageNJoinEmissionError, match="malformed"):
+        emit_i16_package_n_join_v1(mutated)
+
+
+def test_source_experiment_id_is_non_authoritative() -> None:
+    source = "legacy-source-alias"
+    record = emit_i16_package_n_join_from_producer_v1(_sample_config(), source_experiment_id=source)
+    assert record.experiment_identity_id != source
+    assert dict(record.historical_provenance)["source_experiment_id"] == source
+    assert is_package_n_sha256_canonical_id(record.experiment_identity_id) is True
+
+
+def test_attachment_does_not_mutate_inputs() -> None:
+    manifest = build_manifest(_sample_config())
+    snapshot = copy.deepcopy(manifest)
+    record = emit_i16_package_n_join_v1(manifest)
+    manifest["experiment_identity_id"] = "MUTATED"
+    manifest["legacy_aliases"]["legacy_experiment_id_md5_12"] = "MUTATED"
+    assert record.experiment_identity_id == snapshot["experiment_identity_id"]
+    assert record.legacy_alias_md5_12 == snapshot["legacy_aliases"]["legacy_experiment_id_md5_12"]
+    assert snapshot != manifest
+
+
+def test_producer_artifact_schema_has_no_join_record() -> None:
+    manifest = build_manifest(_sample_config())
+    assert "plane_presence" not in manifest
+    assert "join_key" not in manifest
+    assert ARTIFACT_FILENAME == "experiment_identity_manifest_v1.json"
+
+
+def test_producer_and_cli_remain_unhooked() -> None:
+    producer = PRODUCER_PATH.read_text(encoding="utf-8")
+    cli = CLI_PATH.read_text(encoding="utf-8")
+    assert "emit_i16_package_n_join_v1" not in producer
+    assert "attach_i16_remaining_planes_join_v1" not in producer
+    assert "emit_i16_package_n_join_v1" not in cli
+    assert "i16_package_n_join_emission_v1" not in cli
+
+
+def test_runtime_invariants_remain_unauthorized() -> None:
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_no_cap72_execution_or_live_contract_registration() -> None:
+    modules = _imported_modules(EMISSION_PATH)
+    assert not any(mod == "src.execution" or mod.startswith("src.execution.") for mod in modules)
+    assert not any(
+        "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in modules
+    )
+    assert "src.experiments.base" not in modules
+    assert "src.ingress.capsules.evidence_capsule" not in modules
+    assert "src.levelup.v0_models" not in modules
+    assert "src.live_eval.live_session_eval" not in modules
+    assert "src.analytics.explorer" not in modules
+    assert (
+        "src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.preregistration_contract_v1"
+        not in modules
+    )
+    assert "src.governance.promotion_loop.i16_remaining_planes_join_attachment_v1" in modules
+    source = EMISSION_PATH.read_text(encoding="utf-8")
+    assert "open(" not in source
+    assert "produce_experiment_identity_manifest_v1" not in source
+    assert "write_text" not in source
+    assert "Path(" not in source

--- a/tests/governance/promotion_loop/test_i16_lineage_remaining_planes_live_join_v1.py
+++ b/tests/governance/promotion_loop/test_i16_lineage_remaining_planes_live_join_v1.py
@@ -1,0 +1,379 @@
+"""U-I82-R18 tests for I16 named-lane remaining-plane join on lineage producer."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import json
+import shutil
+import uuid
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from src.experiments.base import ExperimentConfig, ParamSweep
+from src.experiments.cross_lane_identity_join_v1 import (
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+)
+from src.experiments.experiment_identity_manifest_v1 import (
+    ARTIFACT_FILENAME,
+    produce_experiment_identity_manifest_v1,
+)
+from src.governance.promotion_loop.experiment_lineage_ref_producer_v1 import (
+    build_experiment_lineage_ref_from_manifest,
+    produce_experiment_lineage_ref_v1,
+    produce_experiment_lineage_ref_v1_to_path,
+    serialize_experiment_lineage_ref_v1,
+)
+from src.governance.promotion_loop.i16_lineage_remaining_planes_live_join_v1 import (
+    CONTRACT_ID,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    I16LineageRemainingPlanesLiveJoinError,
+    I16_LINEAGE_REMAINING_PLANES_JOIN_REGISTERED,
+    LIVE_CONTRACT_SURFACES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    is_i16_lineage_remaining_planes_join_registered,
+    join_i16_lineage_remaining_planes_v1,
+)
+from src.governance.promotion_loop.i16_remaining_planes_join_attachment_v1 import (
+    CONTRACT_ID as R4_CONTRACT_ID,
+)
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+REGISTRATION_PATH = (
+    REPO_ROOT
+    / "src"
+    / "governance"
+    / "promotion_loop"
+    / "i16_lineage_remaining_planes_live_join_v1.py"
+)
+PRODUCER_PATH = (
+    REPO_ROOT / "src" / "governance" / "promotion_loop" / "experiment_lineage_ref_producer_v1.py"
+)
+ATTACHMENT_PATH = (
+    REPO_ROOT
+    / "src"
+    / "governance"
+    / "promotion_loop"
+    / "i16_remaining_planes_join_attachment_v1.py"
+)
+BINDING_PATH = (
+    REPO_ROOT
+    / "src"
+    / "meta"
+    / "learning_loop"
+    / "comparison_promotion_candidate_identity_binding_v1.py"
+)
+DURABLE_PATH = (
+    REPO_ROOT / "src" / "meta" / "learning_loop" / "experiment_durable_evidence_binding_v1.py"
+)
+_DURABLE_OUTPUT_ROOT = REPO_ROOT / ".package_m_pytest_outputs"
+
+_RUN_ID = str(uuid.uuid4())
+_SESSION_ID = "runtime-session-i16-r18"
+_CAMPAIGN_ID = "campaign-i16-r18"
+_PACKAGE_N_OTHER = "a" * 64
+
+
+def _sample_config() -> ExperimentConfig:
+    return ExperimentConfig(
+        name="MA Optimization",
+        strategy_name="ma_crossover",
+        param_sweeps=[
+            ParamSweep("slow", [50, 100], description="ignored in identity"),
+            ParamSweep("fast", [5, 10]),
+        ],
+        symbols=["ETH/EUR", "BTC/EUR"],
+        timeframe="1h",
+        start_date="2024-01-01",
+        end_date="2024-06-01",
+        initial_capital=10000.0,
+        base_params={"window": 3},
+    )
+
+
+@pytest.fixture
+def durable_output_dir() -> Callable[[], Path]:
+    """Output paths outside /tmp for Package-N manifest production."""
+    _DURABLE_OUTPUT_ROOT.mkdir(exist_ok=True)
+    created: list[Path] = []
+
+    def _make() -> Path:
+        path = _DURABLE_OUTPUT_ROOT / uuid.uuid4().hex
+        created.append(path)
+        return path
+
+    yield _make
+
+    for path in created:
+        if path.exists():
+            shutil.rmtree(path, ignore_errors=True)
+
+
+def _write_manifest_dir(durable_output_dir: Callable[[], Path]) -> tuple[Path, dict[str, object]]:
+    manifest_dir = durable_output_dir()
+    produce_experiment_identity_manifest_v1(_sample_config(), manifest_dir)
+    manifest = json.loads((manifest_dir / ARTIFACT_FILENAME).read_text(encoding="utf-8"))
+    return manifest_dir, manifest
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_lineage_remaining_planes_join_is_registered_and_reachable() -> None:
+    assert CONTRACT_ID == "i16_lineage_remaining_planes_live_join_v1"
+    assert R4_CONTRACT_ID == "i16_remaining_planes_join_attachment_v1"
+    assert I16_LINEAGE_REMAINING_PLANES_JOIN_REGISTERED is True
+    assert is_i16_lineage_remaining_planes_join_registered() is True
+    assert LIVE_CONTRACT_SURFACES == ("lineage_ref",)
+
+
+def test_named_lane_producer_attaches_remaining_planes(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
+    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    assert result.ref.ref_id == manifest["experiment_identity_id"]
+    assert is_package_n_sha256_canonical_id(result.ref.ref_id) is True
+    assert result.join.experiment_identity_id == result.ref.ref_id
+    assert result.join.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["RUN"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["CAMPAIGN"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["SESSION"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.run_id is None
+    assert result.ref.ref_id != manifest["legacy_aliases"]["legacy_experiment_id_md5_12"]
+
+
+def test_declared_absence_for_run_campaign_session_on_named_lane(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
+    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    assert result.join.plane_presence["RUN"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["CAMPAIGN"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["SESSION"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.campaign_id is None
+    assert result.join.session_id is None
+
+
+def test_present_run_sidecar_is_joined_and_not_identity(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
+    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir, run_id=_RUN_ID)
+    assert result.join.plane_presence["RUN"] == PlanePresence.PRESENT.value
+    assert result.join.run_id == _RUN_ID
+    assert result.join.experiment_identity_id == manifest["experiment_identity_id"]
+    assert result.join.experiment_identity_id != _RUN_ID
+    assert result.ref.ref_id == manifest["experiment_identity_id"]
+
+
+def test_present_campaign_and_session_sidecars_are_not_identity(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
+    result = produce_experiment_lineage_ref_v1(
+        manifest_dir=manifest_dir,
+        campaign_id=_CAMPAIGN_ID,
+        session_id=_SESSION_ID,
+    )
+    assert result.join.plane_presence["CAMPAIGN"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["SESSION"] == PlanePresence.PRESENT.value
+    assert result.join.campaign_id == _CAMPAIGN_ID
+    assert result.join.session_id == _SESSION_ID
+    assert result.join.experiment_identity_id == manifest["experiment_identity_id"]
+    assert result.join.experiment_identity_id != _CAMPAIGN_ID
+    assert result.join.experiment_identity_id != _SESSION_ID
+
+
+def test_run_id_must_not_substitute_identity(durable_output_dir: Callable[[], Path]) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
+    identity = str(manifest["experiment_identity_id"])
+    with pytest.raises(Exception, match="cross-plane substitution rejected"):
+        produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir, run_id=identity)
+
+
+def test_session_id_must_not_substitute_identity(durable_output_dir: Callable[[], Path]) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
+    identity = str(manifest["experiment_identity_id"])
+    with pytest.raises(Exception, match="cross-plane substitution rejected"):
+        produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir, session_id=identity)
+
+
+def test_conflicting_ref_id_rejected(durable_output_dir: Callable[[], Path]) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
+    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    mutated = copy.deepcopy(result.ref)
+    object.__setattr__(mutated, "ref_id", _PACKAGE_N_OTHER)
+    with pytest.raises(I16LineageRemainingPlanesLiveJoinError, match="conflicting identity"):
+        join_i16_lineage_remaining_planes_v1(
+            manifest,
+            ref=mutated,
+            artifact_path=ARTIFACT_FILENAME,
+        )
+
+
+def test_cross_lane_substitution_rejected(durable_output_dir: Callable[[], Path]) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
+    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    polluted = copy.deepcopy(manifest)
+    polluted["I17"] = {"session_id": _SESSION_ID}
+    with pytest.raises(I16LineageRemainingPlanesLiveJoinError, match="cross-lane substitution"):
+        join_i16_lineage_remaining_planes_v1(
+            polluted,
+            ref=result.ref,
+            artifact_path=ARTIFACT_FILENAME,
+        )
+
+
+def test_cross_plane_substitution_rejected(durable_output_dir: Callable[[], Path]) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
+    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    polluted = copy.deepcopy(manifest)
+    polluted["plane_presence"] = {"IDENTITY": "PRESENT"}
+    with pytest.raises(I16LineageRemainingPlanesLiveJoinError, match="cross-plane substitution"):
+        join_i16_lineage_remaining_planes_v1(
+            polluted,
+            ref=result.ref,
+            artifact_path=ARTIFACT_FILENAME,
+        )
+
+
+def test_malformed_sidecar_rejected(durable_output_dir: Callable[[], Path]) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
+    with pytest.raises(Exception, match="malformed plane data"):
+        produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir, run_id="   ")
+
+
+def test_legacy_experiment_id_and_run_id_remain_non_authoritative(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
+    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir, run_id=_RUN_ID)
+    legacy = manifest["legacy_aliases"]["legacy_experiment_id_md5_12"]
+    assert result.join.experiment_identity_id != legacy
+    assert result.join.experiment_identity_id != _RUN_ID
+    assert result.ref.ref_id != legacy
+    assert result.ref.ref_id != _RUN_ID
+
+
+def test_join_is_deterministic(durable_output_dir: Callable[[], Path]) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
+    first = produce_experiment_lineage_ref_v1(
+        manifest_dir=manifest_dir, run_id=_RUN_ID
+    ).join.to_canonical_mapping()
+    second = produce_experiment_lineage_ref_v1(
+        manifest_dir=manifest_dir, run_id=_RUN_ID
+    ).join.to_canonical_mapping()
+    assert first == second
+
+
+def test_producer_does_not_mutate_manifest(durable_output_dir: Callable[[], Path]) -> None:
+    manifest_dir, _manifest = _write_manifest_dir(durable_output_dir)
+    artifact = manifest_dir / ARTIFACT_FILENAME
+    snapshot = artifact.read_text(encoding="utf-8")
+    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir, run_id=_RUN_ID)
+    assert artifact.read_text(encoding="utf-8") == snapshot
+    assert result.join.run_id == _RUN_ID
+
+
+def test_written_lineage_json_has_no_join_record(durable_output_dir: Callable[[], Path]) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
+    output_path = durable_output_dir() / "ref.json"
+    result = produce_experiment_lineage_ref_v1_to_path(
+        manifest_dir=manifest_dir,
+        output_path=output_path,
+        run_id=_RUN_ID,
+    )
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert "plane_presence" not in payload
+    assert "run_id" not in payload
+    assert "campaign_id" not in payload
+    assert "session_id" not in payload
+    assert "join" not in payload
+    assert payload["ref_id"] == manifest["experiment_identity_id"]
+    assert payload["ref_id"] == result.ref.ref_id
+    assert result.join.run_id == _RUN_ID
+    serialized = serialize_experiment_lineage_ref_v1(result.ref)
+    assert "plane_presence" not in serialized
+
+
+def test_build_from_manifest_fail_closed_joins_remaining_planes(
+    durable_output_dir: Callable[[], Path],
+) -> None:
+    _manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
+    ref = build_experiment_lineage_ref_from_manifest(manifest, run_id=_RUN_ID)
+    assert ref.ref_id == manifest["experiment_identity_id"]
+    join = join_i16_lineage_remaining_planes_v1(
+        manifest, ref=ref, artifact_path=ARTIFACT_FILENAME, run_id=_RUN_ID
+    )
+    assert join.plane_presence["RUN"] == PlanePresence.PRESENT.value
+
+
+def test_md5_still_not_ref_id(durable_output_dir: Callable[[], Path]) -> None:
+    manifest_dir, manifest = _write_manifest_dir(durable_output_dir)
+    result = produce_experiment_lineage_ref_v1(manifest_dir=manifest_dir)
+    assert result.ref.ref_id != manifest["legacy_aliases"]["legacy_experiment_id_md5_12"]
+    assert (
+        result.join.legacy_alias_md5_12 == manifest["legacy_aliases"]["legacy_experiment_id_md5_12"]
+    )
+    assert result.join.experiment_identity_id == result.ref.ref_id
+
+
+def test_runtime_invariants_remain_unauthorized() -> None:
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+
+
+def test_named_lane_producer_is_hooked_and_forbidden_surfaces_are_not() -> None:
+    producer_modules = _imported_modules(PRODUCER_PATH)
+    join_modules = _imported_modules(REGISTRATION_PATH)
+    assert (
+        "src.governance.promotion_loop.i16_lineage_remaining_planes_live_join_v1"
+        in producer_modules
+    )
+    assert "src.governance.promotion_loop.i16_remaining_planes_join_attachment_v1" in join_modules
+    assert not any(
+        mod == "src.execution" or mod.startswith("src.execution.") for mod in producer_modules
+    )
+    assert not any(
+        mod == "src.execution" or mod.startswith("src.execution.") for mod in join_modules
+    )
+    for modules in (producer_modules, join_modules):
+        assert not any(
+            "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in modules
+        )
+        assert "src.analytics.explorer" not in modules
+        assert "src.ingress.capsules.evidence_capsule" not in modules
+        assert "src.levelup.v0_models" not in modules
+        assert "src.live_eval.live_session_eval" not in modules
+        assert "src.experiments.base" not in modules
+    attachment_source = ATTACHMENT_PATH.read_text(encoding="utf-8")
+    assert "i16_lineage_remaining_planes_live_join_v1" not in attachment_source
+    binding_source = BINDING_PATH.read_text(encoding="utf-8")
+    durable_source = DURABLE_PATH.read_text(encoding="utf-8")
+    assert "i16_lineage_remaining_planes_live_join_v1" not in binding_source
+    assert "i16_lineage_remaining_planes_live_join_v1" not in durable_source
+    join_source = REGISTRATION_PATH.read_text(encoding="utf-8")
+    assert "write_text" not in join_source
+    assert "open(" not in join_source
+    producer_source = PRODUCER_PATH.read_text(encoding="utf-8")
+    assert "serialize_experiment_lineage_ref_v1(ref)" in producer_source
+    assert "serialize_experiment_lineage_ref_v1(result.join" not in producer_source
+    assert "write_experiment_lineage_ref_v1_atomic(\n        result.ref" in producer_source

--- a/tests/governance/promotion_loop/test_i16_remaining_planes_join_attachment_v1.py
+++ b/tests/governance/promotion_loop/test_i16_remaining_planes_join_attachment_v1.py
@@ -1,0 +1,187 @@
+"""U-I82-R4 tests for dormant I16 remaining-plane join attachment."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import uuid
+from pathlib import Path
+
+import pytest
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+)
+from src.governance.promotion_loop.i16_remaining_planes_join_attachment_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    I16RemainingPlanesJoinAttachmentError,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    attach_i16_remaining_planes_join_v1,
+)
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+ATTACHMENT_PATH = (
+    REPO_ROOT
+    / "src"
+    / "governance"
+    / "promotion_loop"
+    / "i16_remaining_planes_join_attachment_v1.py"
+)
+
+_PACKAGE_N_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r4-package-n").hexdigest()
+_OTHER_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r4-other").hexdigest()
+_CONTENT_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r4-content").hexdigest()
+_MD5_12 = "abcdef012345"
+_RUN_ID = str(uuid.uuid4())
+_SESSION_ID = "runtime-session-i16-r4"
+
+
+def _i16_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "experiment_identity_id": _PACKAGE_N_SHA256,
+        "ref_id": _PACKAGE_N_SHA256,
+        "digest": _CONTENT_SHA256,
+        "artifact_path": "experiment_identity_manifest_v1.json",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_canonical_package_n_sha256_run_join() -> None:
+    record = attach_i16_remaining_planes_join_v1(_i16_payload(run_id=_RUN_ID))
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.run_id == _RUN_ID
+    assert record.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert record.plane_presence["RUN"] == PlanePresence.PRESENT.value
+    assert record.experiment_identity_id != _RUN_ID
+
+
+def test_campaign_and_session_absent_declared_by_default() -> None:
+    record = attach_i16_remaining_planes_join_v1(_i16_payload())
+    assert record.plane_presence["CAMPAIGN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["SESSION"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["RUN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.campaign_id is None
+    assert record.session_id is None
+    assert record.run_id is None
+
+
+def test_explicit_session_present_is_not_identity() -> None:
+    record = attach_i16_remaining_planes_join_v1(_i16_payload(session_id=_SESSION_ID))
+    assert record.session_id == _SESSION_ID
+    assert record.plane_presence["SESSION"] == PlanePresence.PRESENT.value
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.experiment_identity_id != _SESSION_ID
+
+
+def test_uuid_run_id_as_identity_rejected() -> None:
+    assert is_package_n_sha256_canonical_id(_RUN_ID) is False
+    with pytest.raises(I16RemainingPlanesJoinAttachmentError, match="Package-N SHA256"):
+        attach_i16_remaining_planes_join_v1(
+            _i16_payload(experiment_identity_id=_RUN_ID, ref_id=_RUN_ID)
+        )
+
+
+def test_md5_as_ref_id_rejected() -> None:
+    with pytest.raises(I16RemainingPlanesJoinAttachmentError, match="must not be UUID/run_id/MD5"):
+        attach_i16_remaining_planes_join_v1(_i16_payload(ref_id=_MD5_12))
+
+
+def test_legacy_experiment_id_as_identity_rejected() -> None:
+    with pytest.raises(I16RemainingPlanesJoinAttachmentError, match="forbidden I16 join field"):
+        attach_i16_remaining_planes_join_v1(_i16_payload(experiment_id=_RUN_ID))
+
+
+def test_conflicting_ref_id_and_identity_rejected() -> None:
+    with pytest.raises(I16RemainingPlanesJoinAttachmentError, match="conflicting Package-N SHA256"):
+        attach_i16_remaining_planes_join_v1(
+            _i16_payload(experiment_identity_id=_PACKAGE_N_SHA256, ref_id=_OTHER_SHA256)
+        )
+
+
+def test_missing_identity_rejected() -> None:
+    with pytest.raises(I16RemainingPlanesJoinAttachmentError, match="IDENTITY missing"):
+        attach_i16_remaining_planes_join_v1({"run_id": _RUN_ID})
+
+
+def test_run_id_must_not_substitute_identity() -> None:
+    with pytest.raises(I16RemainingPlanesJoinAttachmentError, match="must not substitute"):
+        attach_i16_remaining_planes_join_v1(_i16_payload(run_id=_PACKAGE_N_SHA256))
+
+
+def test_session_id_must_not_substitute_identity() -> None:
+    with pytest.raises(I16RemainingPlanesJoinAttachmentError, match="must not substitute"):
+        attach_i16_remaining_planes_join_v1(_i16_payload(session_id=_PACKAGE_N_SHA256))
+
+
+def test_join_is_deterministic() -> None:
+    payload = _i16_payload(run_id=_RUN_ID, session_id=_SESSION_ID)
+    first = attach_i16_remaining_planes_join_v1(payload).to_canonical_mapping()
+    second = attach_i16_remaining_planes_join_v1(copy.deepcopy(payload)).to_canonical_mapping()
+    assert first == second
+
+
+def test_attachment_does_not_mutate_inputs() -> None:
+    payload = _i16_payload(
+        run_id=_RUN_ID,
+        historical_provenance={"legacy_experiment_id": _RUN_ID},
+    )
+    snapshot = copy.deepcopy(payload)
+    record = attach_i16_remaining_planes_join_v1(payload)
+    payload["run_id"] = "MUTATED"
+    payload["historical_provenance"]["legacy_experiment_id"] = "MUTATED"  # type: ignore[index]
+    assert record.run_id == snapshot["run_id"]
+    assert dict(record.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+    assert payload != snapshot
+
+
+def test_historical_provenance_non_authoritative() -> None:
+    payload = _i16_payload(
+        historical_provenance={"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID}
+    )
+    record = attach_i16_remaining_planes_join_v1(payload)
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.experiment_identity_id != _RUN_ID
+    assert dict(record.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+
+
+def test_runtime_invariants_remain_unauthorized() -> None:
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_no_runtime_registration_or_forbidden_imports() -> None:
+    modules = _imported_modules(ATTACHMENT_PATH)
+    assert not any(mod == "src.execution" or mod.startswith("src.execution.") for mod in modules)
+    assert not any(
+        "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in modules
+    )
+    assert "src.governance.promotion_loop.experiment_lineage_ref_producer_v1" not in modules
+    assert (
+        "src.meta.learning_loop.comparison_promotion_candidate_identity_binding_v1" not in modules
+    )
+    assert "src.meta.learning_loop.experiment_durable_evidence_binding_v1" not in modules
+    assert "src.experiments.base" not in modules
+    source = ATTACHMENT_PATH.read_text(encoding="utf-8")
+    assert "open(" not in source
+    assert "produce_experiment_lineage_ref_v1" not in source
+    assert "append_experiment_record" not in source

--- a/tests/ingress/test_i56_ingress_join_attachment_v1.py
+++ b/tests/ingress/test_i56_ingress_join_attachment_v1.py
@@ -1,0 +1,261 @@
+"""U-I82-R7 tests for dormant I56 Ingress join attachment."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import uuid
+from pathlib import Path
+
+import pytest
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+)
+from src.ingress.capsules.evidence_capsule import EvidenceCapsule
+from src.ingress.capsules.i56_ingress_join_attachment_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    I56IngressJoinAttachmentError,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    attach_i56_ingress_join_v1,
+)
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ATTACHMENT_PATH = REPO_ROOT / "src" / "ingress" / "capsules" / "i56_ingress_join_attachment_v1.py"
+
+_PACKAGE_N_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r7-package-n").hexdigest()
+_OTHER_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r7-other").hexdigest()
+_ARTIFACT_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r7-artifact").hexdigest()
+_MD5_12 = "abcdef012345"
+_MD5_32 = "d41d8cd98f00b204e9800998ecf8427e"
+_RUN_ID = str(uuid.uuid4())
+_DEFAULT_RUN_ID = "default"
+_CAPSULE_ID = "default.capsule"
+
+
+def _i56_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "experiment_identity_id": _PACKAGE_N_SHA256,
+        "capsule_id": _CAPSULE_ID,
+        "run_id": _DEFAULT_RUN_ID,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_canonical_package_n_sha256_happy_path() -> None:
+    record = attach_i56_ingress_join_v1(_i56_payload())
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.evidence_ref == _CAPSULE_ID
+    assert record.run_id == _DEFAULT_RUN_ID
+    assert record.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert record.plane_presence["RUN"] == PlanePresence.PRESENT.value
+    assert record.plane_presence["EVIDENCE"] == PlanePresence.PRESENT.value
+    assert record.experiment_identity_id != _DEFAULT_RUN_ID
+    assert record.experiment_identity_id != _CAPSULE_ID
+    assert is_package_n_sha256_canonical_id(record.experiment_identity_id) is True
+
+
+def test_alias_campaign_session_absent_declared_by_default() -> None:
+    record = attach_i56_ingress_join_v1(_i56_payload())
+    assert record.plane_presence["ALIAS"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["CAMPAIGN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["SESSION"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.legacy_alias_md5_12 is None
+    assert record.campaign_id is None
+    assert record.session_id is None
+
+
+def test_declared_absent_without_run_or_capsule() -> None:
+    payload = {"experiment_identity_id": _PACKAGE_N_SHA256}
+    record = attach_i56_ingress_join_v1(payload)
+    assert record.plane_presence["RUN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["EVIDENCE"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["CONTENT_HASH"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.run_id is None
+    assert record.evidence_ref is None
+    assert record.content_sha256 is None
+
+
+def test_explicit_artifact_sha256_is_content_hash_not_identity() -> None:
+    record = attach_i56_ingress_join_v1(_i56_payload(artifact_sha256=_ARTIFACT_SHA256))
+    assert record.plane_presence["CONTENT_HASH"] == PlanePresence.PRESENT.value
+    assert record.content_sha256 == _ARTIFACT_SHA256
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.content_sha256 != record.experiment_identity_id
+
+
+def test_default_run_id_stays_run_plane() -> None:
+    record = attach_i56_ingress_join_v1(_i56_payload(run_id=_DEFAULT_RUN_ID))
+    assert record.plane_presence["RUN"] == PlanePresence.PRESENT.value
+    assert record.run_id == _DEFAULT_RUN_ID
+    assert record.experiment_identity_id != _DEFAULT_RUN_ID
+
+
+def test_implicit_absence_of_identity_rejected() -> None:
+    with pytest.raises(I56IngressJoinAttachmentError, match="IDENTITY missing"):
+        attach_i56_ingress_join_v1({"capsule_id": _CAPSULE_ID, "run_id": _DEFAULT_RUN_ID})
+
+
+def test_run_id_default_as_identity_rejected() -> None:
+    with pytest.raises(I56IngressJoinAttachmentError, match="run_id default cannot fill IDENTITY"):
+        attach_i56_ingress_join_v1(
+            _i56_payload(experiment_identity_id=_DEFAULT_RUN_ID, run_id=_DEFAULT_RUN_ID)
+        )
+
+
+def test_capsule_id_as_identity_rejected() -> None:
+    with pytest.raises(I56IngressJoinAttachmentError, match="capsule_id cannot fill IDENTITY"):
+        attach_i56_ingress_join_v1(
+            _i56_payload(experiment_identity_id=_CAPSULE_ID, capsule_id=_CAPSULE_ID)
+        )
+
+
+def test_uuid_run_id_as_identity_rejected() -> None:
+    assert is_package_n_sha256_canonical_id(_RUN_ID) is False
+    with pytest.raises(I56IngressJoinAttachmentError, match="Package-N SHA256"):
+        attach_i56_ingress_join_v1(_i56_payload(experiment_identity_id=_RUN_ID, run_id=_RUN_ID))
+
+
+def test_legacy_experiment_id_as_identity_rejected() -> None:
+    with pytest.raises(I56IngressJoinAttachmentError, match="forbidden I56 join field"):
+        attach_i56_ingress_join_v1(_i56_payload(experiment_id=_RUN_ID))
+
+
+def test_md5_as_identity_rejected() -> None:
+    with pytest.raises(I56IngressJoinAttachmentError, match="Package-N SHA256"):
+        attach_i56_ingress_join_v1(_i56_payload(experiment_identity_id=_MD5_12))
+    with pytest.raises(I56IngressJoinAttachmentError, match="Package-N SHA256"):
+        attach_i56_ingress_join_v1(_i56_payload(experiment_identity_id=_MD5_32))
+
+
+def test_run_id_must_not_substitute_identity() -> None:
+    with pytest.raises(I56IngressJoinAttachmentError, match="must not substitute"):
+        attach_i56_ingress_join_v1(_i56_payload(run_id=_PACKAGE_N_SHA256))
+
+
+def test_capsule_id_must_not_substitute_identity() -> None:
+    with pytest.raises(I56IngressJoinAttachmentError, match="must not substitute"):
+        attach_i56_ingress_join_v1(_i56_payload(capsule_id=_PACKAGE_N_SHA256))
+
+
+def test_raw_payload_and_secrets_rejected() -> None:
+    with pytest.raises(I56IngressJoinAttachmentError, match="forbidden I56 join field"):
+        attach_i56_ingress_join_v1(_i56_payload(payload={"raw": True}))
+    with pytest.raises(I56IngressJoinAttachmentError, match="forbidden I56 join field"):
+        attach_i56_ingress_join_v1(_i56_payload(secrets="token"))
+    with pytest.raises(I56IngressJoinAttachmentError, match="forbidden I56 join field"):
+        attach_i56_ingress_join_v1(_i56_payload(transcript="leak"))
+
+
+def test_conflicting_evidence_values_rejected() -> None:
+    with pytest.raises(I56IngressJoinAttachmentError, match="conflicting EVIDENCE"):
+        attach_i56_ingress_join_v1(
+            _i56_payload(evidence_ref="other.capsule", capsule_id=_CAPSULE_ID)
+        )
+
+
+def test_conflicting_content_hash_values_rejected() -> None:
+    with pytest.raises(I56IngressJoinAttachmentError, match="conflicting CONTENT_HASH"):
+        attach_i56_ingress_join_v1(
+            _i56_payload(artifact_sha256=_ARTIFACT_SHA256, content_sha256=_OTHER_SHA256)
+        )
+
+
+def test_conflicting_identity_values_rejected() -> None:
+    with pytest.raises(I56IngressJoinAttachmentError, match="forbidden I56 join field"):
+        attach_i56_ingress_join_v1(_i56_payload(ref_id=_OTHER_SHA256))
+    with pytest.raises(I56IngressJoinAttachmentError, match="conflicting identities"):
+        attach_i56_ingress_join_v1(
+            _i56_payload(historical_provenance={"experiment_identity_id": _OTHER_SHA256})
+        )
+
+
+def test_malformed_and_ambiguous_join_rejected() -> None:
+    with pytest.raises(I56IngressJoinAttachmentError, match="must be an object"):
+        attach_i56_ingress_join_v1("not-an-object")  # type: ignore[arg-type]
+    with pytest.raises(I56IngressJoinAttachmentError, match="unknown I56 join field"):
+        attach_i56_ingress_join_v1(_i56_payload(ts_ms=1))
+    with pytest.raises(I56IngressJoinAttachmentError, match="empty or whitespace-padded"):
+        attach_i56_ingress_join_v1(_i56_payload(experiment_identity_id="   "))
+
+
+def test_join_is_deterministic() -> None:
+    payload = _i56_payload(artifact_sha256=_ARTIFACT_SHA256, run_id=_DEFAULT_RUN_ID)
+    first = attach_i56_ingress_join_v1(payload).to_canonical_mapping()
+    second = attach_i56_ingress_join_v1(copy.deepcopy(payload)).to_canonical_mapping()
+    assert first == second
+
+
+def test_attachment_does_not_mutate_inputs() -> None:
+    payload = _i56_payload(
+        historical_provenance={"legacy_capsule_id": _CAPSULE_ID, "run_id": _DEFAULT_RUN_ID}
+    )
+    snapshot = copy.deepcopy(payload)
+    record = attach_i56_ingress_join_v1(payload)
+    payload["run_id"] = "MUTATED"
+    payload["historical_provenance"]["run_id"] = "MUTATED"  # type: ignore[index]
+    assert dict(record.historical_provenance)["run_id"] == _DEFAULT_RUN_ID
+    assert dict(record.historical_provenance)["legacy_capsule_id"] == _CAPSULE_ID
+    assert payload != snapshot
+
+
+def test_historical_provenance_non_authoritative() -> None:
+    payload = _i56_payload(
+        historical_provenance={"legacy_capsule_id": _CAPSULE_ID, "run_id": _DEFAULT_RUN_ID}
+    )
+    record = attach_i56_ingress_join_v1(payload)
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.experiment_identity_id != _CAPSULE_ID
+    assert record.experiment_identity_id != _DEFAULT_RUN_ID
+    assert dict(record.historical_provenance)["legacy_capsule_id"] == _CAPSULE_ID
+
+
+def test_live_evidence_capsule_contract_unregistered() -> None:
+    capsule = EvidenceCapsule(capsule_id=_CAPSULE_ID, run_id=_DEFAULT_RUN_ID, ts_ms=0)
+    serialized = capsule.to_dict()
+    assert "experiment_identity_id" not in serialized
+    assert serialized["run_id"] == _DEFAULT_RUN_ID
+    assert serialized["capsule_id"] == _CAPSULE_ID
+
+
+def test_runtime_invariants_remain_unauthorized() -> None:
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_no_runtime_registration_or_forbidden_imports() -> None:
+    modules = _imported_modules(ATTACHMENT_PATH)
+    assert not any(mod == "src.execution" or mod.startswith("src.execution.") for mod in modules)
+    assert not any(
+        "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in modules
+    )
+    assert "src.ingress.capsules.evidence_capsule" not in modules
+    assert "src.ingress.capsules.evidence_capsule_builder" not in modules
+    assert "src.ingress.orchestrator.ingress_orchestrator" not in modules
+    assert "src.ingress.cli.ingress_cli" not in modules
+    assert "src.experiments.base" not in modules
+    source = ATTACHMENT_PATH.read_text(encoding="utf-8")
+    assert "open(" not in source
+    assert "write_evidence_capsule" not in source
+    assert "run_ingress" not in source
+    assert "build_evidence_capsule" not in source

--- a/tests/ingress/test_i56_ingress_live_contract_join_v1.py
+++ b/tests/ingress/test_i56_ingress_live_contract_join_v1.py
@@ -1,0 +1,363 @@
+"""U-I82-R14 tests for dormant I56 live-contract join registration."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import uuid
+from pathlib import Path
+
+import pytest
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+)
+from src.ingress.capsules.i56_ingress_live_contract_join_v1 import (
+    CONTRACT_ID,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    I56_LIVE_CONTRACT_REGISTERED,
+    I56IngressLiveContractJoinError,
+    LIVE_CONTRACT_SURFACES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    is_i56_live_contract_registered,
+    register_i56_live_contract_join_v1,
+)
+from src.levelup.i52_levelup_live_contract_join_v1 import (
+    I52_LIVE_CONTRACT_REGISTERED,
+    is_i52_live_contract_registered,
+)
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.i17_paper_shadow_live_contract_join_v1 import (
+    I17_LIVE_CONTRACT_REGISTERED,
+    is_i17_live_contract_registered,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REGISTRATION_PATH = (
+    REPO_ROOT / "src" / "ingress" / "capsules" / "i56_ingress_live_contract_join_v1.py"
+)
+ATTACHMENT_PATH = REPO_ROOT / "src" / "ingress" / "capsules" / "i56_ingress_join_attachment_v1.py"
+CAPSULE_PATH = REPO_ROOT / "src" / "ingress" / "capsules" / "evidence_capsule.py"
+BUILDER_PATH = REPO_ROOT / "src" / "ingress" / "capsules" / "evidence_capsule_builder.py"
+INIT_PATH = REPO_ROOT / "src" / "ingress" / "capsules" / "__init__.py"
+I17_REGISTRATION_PATH = (
+    REPO_ROOT
+    / "src"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+    / "i17_paper_shadow_live_contract_join_v1.py"
+)
+I52_REGISTRATION_PATH = REPO_ROOT / "src" / "levelup" / "i52_levelup_live_contract_join_v1.py"
+_LIVE_CONTRACT_FILES = (CAPSULE_PATH, BUILDER_PATH, INIT_PATH, ATTACHMENT_PATH)
+
+_PACKAGE_N_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r14-package-n").hexdigest()
+_OTHER_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r14-other").hexdigest()
+_ARTIFACT_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r14-artifact").hexdigest()
+_MD5_12 = "abcdef012345"
+_MD5_32 = "d41d8cd98f00b204e9800998ecf8427e"
+_RUN_ID = str(uuid.uuid4())
+_DEFAULT_RUN_ID = "default"
+_CAPSULE_ID = "default.capsule"
+
+
+def _capsule(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "capsule_id": _CAPSULE_ID,
+        "run_id": _DEFAULT_RUN_ID,
+        "ts_ms": 1000,
+        "artifacts": [],
+        "labels": {},
+        "facts": {},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _artifact() -> dict[str, object]:
+    return {"path": "/ops/events/ev.jsonl", "sha256": _ARTIFACT_SHA256}
+
+
+def _envelope(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "experiment_identity_id": _PACKAGE_N_SHA256,
+        "capsule": _capsule(),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_live_contract_registration_flag_is_reachable() -> None:
+    assert CONTRACT_ID == "i56_ingress_live_contract_join_v1"
+    assert I56_LIVE_CONTRACT_REGISTERED is True
+    assert is_i56_live_contract_registered() is True
+    assert LIVE_CONTRACT_SURFACES == ("capsule", "artifact")
+    assert I17_LIVE_CONTRACT_REGISTERED is True
+    assert is_i17_live_contract_registered() is True
+    assert I52_LIVE_CONTRACT_REGISTERED is True
+    assert is_i52_live_contract_registered() is True
+
+
+def test_canonical_package_n_sha256_present_join_from_capsule() -> None:
+    record = register_i56_live_contract_join_v1(_envelope())
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert is_package_n_sha256_canonical_id(record.experiment_identity_id) is True
+    assert record.run_id == _DEFAULT_RUN_ID
+    assert record.evidence_ref == _CAPSULE_ID
+    assert record.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert record.plane_presence["RUN"] == PlanePresence.PRESENT.value
+    assert record.plane_presence["EVIDENCE"] == PlanePresence.PRESENT.value
+    assert record.experiment_identity_id != _DEFAULT_RUN_ID
+    assert record.experiment_identity_id != _CAPSULE_ID
+
+
+def test_declared_absence_for_alias_campaign_session_content_hash() -> None:
+    record = register_i56_live_contract_join_v1(_envelope())
+    assert record.plane_presence["ALIAS"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["CAMPAIGN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["SESSION"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["CONTENT_HASH"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.legacy_alias_md5_12 is None
+    assert record.campaign_id is None
+    assert record.session_id is None
+    assert record.content_sha256 is None
+
+
+def test_artifact_present_join_uses_sha256_as_content_hash() -> None:
+    record = register_i56_live_contract_join_v1(
+        {
+            "experiment_identity_id": _PACKAGE_N_SHA256,
+            "artifact": _artifact(),
+        }
+    )
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.plane_presence["CONTENT_HASH"] == PlanePresence.PRESENT.value
+    assert record.content_sha256 == _ARTIFACT_SHA256
+    assert record.plane_presence["EVIDENCE"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["RUN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.content_sha256 != record.experiment_identity_id
+
+
+def test_capsule_artifact_sha256_is_content_hash_not_identity() -> None:
+    record = register_i56_live_contract_join_v1(
+        _envelope(capsule=_capsule(artifacts=[_artifact()]))
+    )
+    assert record.content_sha256 == _ARTIFACT_SHA256
+    assert record.plane_presence["CONTENT_HASH"] == PlanePresence.PRESENT.value
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.content_sha256 != record.experiment_identity_id
+
+
+def test_explicit_declared_alias_remains_non_authoritative() -> None:
+    record = register_i56_live_contract_join_v1(
+        _envelope(legacy_alias_md5_12=_MD5_12, session_id="sess-non-auth")
+    )
+    assert record.legacy_alias_md5_12 == _MD5_12
+    assert record.session_id == "sess-non-auth"
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.experiment_identity_id != _MD5_12
+    assert record.run_id == _DEFAULT_RUN_ID
+    assert record.experiment_identity_id != _DEFAULT_RUN_ID
+
+
+def test_implicit_absence_of_identity_rejected() -> None:
+    with pytest.raises(I56IngressLiveContractJoinError, match="implicit absence rejected"):
+        register_i56_live_contract_join_v1({"capsule": _capsule()})
+
+
+def test_implicit_absence_of_live_surface_rejected() -> None:
+    with pytest.raises(I56IngressLiveContractJoinError, match="implicit absence rejected"):
+        register_i56_live_contract_join_v1({"experiment_identity_id": _PACKAGE_N_SHA256})
+
+
+def test_noncanonical_id_substitution_rejected() -> None:
+    with pytest.raises(I56IngressLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i56_live_contract_join_v1(_envelope(experiment_identity_id=_RUN_ID))
+    with pytest.raises(I56IngressLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i56_live_contract_join_v1(_envelope(experiment_identity_id=_MD5_12))
+    with pytest.raises(I56IngressLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i56_live_contract_join_v1(_envelope(experiment_identity_id=_MD5_32))
+    with pytest.raises(I56IngressLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i56_live_contract_join_v1(_envelope(experiment_identity_id=_DEFAULT_RUN_ID))
+    with pytest.raises(I56IngressLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i56_live_contract_join_v1(_envelope(experiment_identity_id=_CAPSULE_ID))
+
+
+def test_legacy_experiment_id_and_run_id_on_envelope_rejected() -> None:
+    with pytest.raises(I56IngressLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i56_live_contract_join_v1(_envelope(experiment_id=_RUN_ID))
+    with pytest.raises(I56IngressLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i56_live_contract_join_v1(_envelope(run_id=_DEFAULT_RUN_ID))
+
+
+def test_conflicting_identity_rejected() -> None:
+    with pytest.raises(I56IngressLiveContractJoinError, match="conflicting"):
+        register_i56_live_contract_join_v1(
+            _envelope(historical_provenance={"experiment_identity_id": _OTHER_SHA256})
+        )
+    with pytest.raises(I56IngressLiveContractJoinError, match="conflicting"):
+        register_i56_live_contract_join_v1(_envelope(evidence_ref="other.capsule"))
+    with pytest.raises(I56IngressLiveContractJoinError, match="conflicting"):
+        register_i56_live_contract_join_v1(
+            _envelope(
+                capsule=_capsule(
+                    artifacts=[
+                        _artifact(),
+                        {"path": "/ops/events/other.jsonl", "sha256": _OTHER_SHA256},
+                    ]
+                )
+            )
+        )
+
+
+def test_ambiguous_join_rejected() -> None:
+    with pytest.raises(I56IngressLiveContractJoinError, match="ambiguous join rejected"):
+        register_i56_live_contract_join_v1(
+            {
+                "experiment_identity_id": _PACKAGE_N_SHA256,
+                "capsule": _capsule(),
+                "artifact": _artifact(),
+            }
+        )
+    with pytest.raises(I56IngressLiveContractJoinError, match="ambiguous join rejected"):
+        register_i56_live_contract_join_v1(
+            {
+                "experiment_identity_id": _PACKAGE_N_SHA256,
+                "capsule": [_capsule(), _capsule(capsule_id="other.capsule")],
+            }
+        )
+
+
+def test_malformed_plane_data_rejected() -> None:
+    with pytest.raises(I56IngressLiveContractJoinError, match="malformed plane data"):
+        register_i56_live_contract_join_v1("not-an-object")  # type: ignore[arg-type]
+    with pytest.raises(I56IngressLiveContractJoinError, match="malformed plane data"):
+        register_i56_live_contract_join_v1(
+            {"experiment_identity_id": _PACKAGE_N_SHA256, "capsule": "bad"}
+        )
+    mutated = _capsule()
+    mutated.pop("capsule_id")
+    with pytest.raises(I56IngressLiveContractJoinError, match="malformed plane data"):
+        register_i56_live_contract_join_v1(_envelope(capsule=mutated))
+    with pytest.raises(I56IngressLiveContractJoinError, match="malformed plane data"):
+        register_i56_live_contract_join_v1(_envelope(capsule=_capsule(payload={"secret": "x"})))
+
+
+def test_cross_plane_substitution_rejected() -> None:
+    with pytest.raises(I56IngressLiveContractJoinError, match="cross-plane substitution"):
+        register_i56_live_contract_join_v1(_envelope(plane_presence={"IDENTITY": "PRESENT"}))
+    with pytest.raises(I56IngressLiveContractJoinError, match="cross-plane substitution"):
+        register_i56_live_contract_join_v1(
+            _envelope(capsule=_capsule(capsule_id=_PACKAGE_N_SHA256))
+        )
+    with pytest.raises(I56IngressLiveContractJoinError, match="cross-plane substitution"):
+        register_i56_live_contract_join_v1(_envelope(capsule=_capsule(run_id=_PACKAGE_N_SHA256)))
+
+
+def test_cross_lane_substitution_rejected() -> None:
+    with pytest.raises(I56IngressLiveContractJoinError, match="cross-lane substitution"):
+        register_i56_live_contract_join_v1(_envelope(I61={"session_dir": "/tmp/eval"}))
+    with pytest.raises(I56IngressLiveContractJoinError, match="malformed plane data"):
+        register_i56_live_contract_join_v1(
+            {
+                "experiment_identity_id": _PACKAGE_N_SHA256,
+                "capsule": {
+                    "slice_id": "S1-R3",
+                    "relative_dir": "out/ops/slice_demo_001/",
+                },
+            }
+        )
+
+
+def test_identity_inside_live_payload_rejected() -> None:
+    live = _capsule()
+    live["experiment_identity_id"] = _PACKAGE_N_SHA256
+    with pytest.raises(I56IngressLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i56_live_contract_join_v1(_envelope(capsule=live))
+
+
+def test_join_is_deterministic() -> None:
+    payload = _envelope(capsule=_capsule(artifacts=[_artifact()]))
+    first = register_i56_live_contract_join_v1(payload).to_canonical_mapping()
+    second = register_i56_live_contract_join_v1(copy.deepcopy(payload)).to_canonical_mapping()
+    assert first == second
+
+
+def test_registration_does_not_mutate_inputs() -> None:
+    payload = _envelope(historical_provenance={"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID})
+    snapshot = copy.deepcopy(payload)
+    record = register_i56_live_contract_join_v1(payload)
+    payload["experiment_identity_id"] = "MUTATED"
+    payload["capsule"]["run_id"] = "MUTATED"  # type: ignore[index]
+    payload["historical_provenance"]["legacy_experiment_id"] = "MUTATED"  # type: ignore[index]
+    assert record.experiment_identity_id == snapshot["experiment_identity_id"]
+    assert record.run_id == snapshot["capsule"]["run_id"]  # type: ignore[index]
+    assert dict(record.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+    assert payload != snapshot
+
+
+def test_legacy_experiment_id_and_run_id_remain_non_authoritative() -> None:
+    payload = _envelope(historical_provenance={"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID})
+    record = register_i56_live_contract_join_v1(payload)
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.experiment_identity_id != _RUN_ID
+    assert record.run_id == _DEFAULT_RUN_ID
+    assert record.experiment_identity_id != _DEFAULT_RUN_ID
+    assert dict(record.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+
+
+def test_runtime_invariants_remain_unauthorized() -> None:
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_no_cap72_execution_hook_or_persistence() -> None:
+    modules = _imported_modules(REGISTRATION_PATH)
+    assert not any(mod == "src.execution" or mod.startswith("src.execution.") for mod in modules)
+    assert not any(
+        "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in modules
+    )
+    assert "src.experiments.base" not in modules
+    assert "src.ingress.capsules.evidence_capsule_builder" not in modules
+    assert "src.ingress.orchestrator.ingress_orchestrator" not in modules
+    assert "src.ingress.cli.ingress_cli" not in modules
+    assert "src.ingress.io.evidence_capsule_writer" not in modules
+    assert "src.live_eval.live_session_eval" not in modules
+    assert "src.analytics.explorer" not in modules
+    assert "src.ingress.capsules.evidence_capsule" in modules
+    assert "src.ingress.capsules.i56_ingress_join_attachment_v1" in modules
+    source = REGISTRATION_PATH.read_text(encoding="utf-8")
+    assert "open(" not in source
+    assert "write_text" not in source
+    assert "Path(" not in source
+    assert "build_evidence_capsule" not in source
+
+
+def test_live_contracts_and_prior_registrations_remain_unhooked() -> None:
+    for path in _LIVE_CONTRACT_FILES:
+        source = path.read_text(encoding="utf-8")
+        assert "register_i56_live_contract_join_v1" not in source
+        assert "i56_ingress_live_contract_join_v1" not in source
+    capsule = CAPSULE_PATH.read_text(encoding="utf-8")
+    assert "experiment_identity_id" not in capsule
+    for prior in (I17_REGISTRATION_PATH, I52_REGISTRATION_PATH):
+        source = prior.read_text(encoding="utf-8")
+        assert "i56_ingress_live_contract_join_v1" not in source
+        assert "I56_LIVE_CONTRACT_REGISTERED = True" not in source

--- a/tests/ingress/test_i56_ingress_named_lane_identity_join_v1.py
+++ b/tests/ingress/test_i56_ingress_named_lane_identity_join_v1.py
@@ -1,0 +1,411 @@
+"""U-I82-R21 tests for I56 named-lane IDENTITY join on EvidenceCapsule."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import uuid
+from pathlib import Path
+
+import pytest
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+)
+from src.ingress.capsules.evidence_capsule import (
+    ArtifactRef,
+    EvidenceCapsule,
+    parse_artifact_ref_with_identity_join_v1,
+    parse_evidence_capsule_with_identity_join_v1,
+)
+from src.ingress.capsules.i56_ingress_join_attachment_v1 import CONTRACT_ID as R7_CONTRACT_ID
+from src.ingress.capsules.i56_ingress_named_lane_identity_join_v1 import (
+    CONTRACT_ID,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    I56_NAMED_LANE_IDENTITY_JOIN_REGISTERED,
+    I56IngressNamedLaneIdentityJoinError,
+    LIVE_CONTRACT_SURFACES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    is_i56_named_lane_identity_join_registered,
+    join_i56_named_lane_identity_v1,
+)
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+JOIN_PATH = (
+    REPO_ROOT / "src" / "ingress" / "capsules" / "i56_ingress_named_lane_identity_join_v1.py"
+)
+ATTACHMENT_PATH = REPO_ROOT / "src" / "ingress" / "capsules" / "i56_ingress_join_attachment_v1.py"
+CAPSULE_PATH = REPO_ROOT / "src" / "ingress" / "capsules" / "evidence_capsule.py"
+BUILDER_PATH = REPO_ROOT / "src" / "ingress" / "capsules" / "evidence_capsule_builder.py"
+INIT_PATH = REPO_ROOT / "src" / "ingress" / "capsules" / "__init__.py"
+WRITER_PATH = REPO_ROOT / "src" / "ingress" / "io" / "evidence_capsule_writer.py"
+ORCH_PATH = REPO_ROOT / "src" / "ingress" / "orchestrator" / "ingress_orchestrator.py"
+R14_PATH = REPO_ROOT / "src" / "ingress" / "capsules" / "i56_ingress_live_contract_join_v1.py"
+_JOIN_MODULE = "src.ingress.capsules.i56_ingress_named_lane_identity_join_v1"
+
+_PACKAGE_N_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r21-package-n").hexdigest()
+_OTHER_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r21-other").hexdigest()
+_ARTIFACT_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r21-artifact").hexdigest()
+_MD5_12 = "abcdef012345"
+_MD5_32 = "d41d8cd98f00b204e9800998ecf8427e"
+_RUN_ID = str(uuid.uuid4())
+_DEFAULT_RUN_ID = "default"
+_CAPSULE_ID = "default.capsule"
+_CAMPAIGN_ID = "campaign-i56-r21"
+_SESSION_ID = "session-i56-r21"
+
+
+def _capsule(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "capsule_id": _CAPSULE_ID,
+        "run_id": _DEFAULT_RUN_ID,
+        "ts_ms": 1000,
+        "artifacts": [],
+        "labels": {},
+        "facts": {},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _artifact() -> dict[str, object]:
+    return {"path": "/ops/events/ev.jsonl", "sha256": _ARTIFACT_SHA256}
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_named_lane_identity_join_is_registered_and_reachable() -> None:
+    assert CONTRACT_ID == "i56_ingress_named_lane_identity_join_v1"
+    assert R7_CONTRACT_ID == "i56_ingress_join_attachment_v1"
+    assert I56_NAMED_LANE_IDENTITY_JOIN_REGISTERED is True
+    assert is_i56_named_lane_identity_join_registered() is True
+    assert LIVE_CONTRACT_SURFACES == ("capsule", "artifact")
+
+
+def test_named_capsule_producer_attaches_identity() -> None:
+    result = parse_evidence_capsule_with_identity_join_v1(
+        _capsule(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.experiment_identity_id == _PACKAGE_N_SHA256
+    assert is_package_n_sha256_canonical_id(result.join.experiment_identity_id) is True
+    assert result.join.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["RUN"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["EVIDENCE"] == PlanePresence.PRESENT.value
+    assert result.join.run_id == _DEFAULT_RUN_ID
+    assert result.join.evidence_ref == _CAPSULE_ID
+    assert result.join.experiment_identity_id != _DEFAULT_RUN_ID
+    assert result.join.experiment_identity_id != _CAPSULE_ID
+    dumped = result.contract.to_dict()
+    assert "experiment_identity_id" not in dumped
+    assert dumped["run_id"] == _DEFAULT_RUN_ID
+
+
+def test_declared_absence_for_alias_campaign_session_content_hash() -> None:
+    result = parse_evidence_capsule_with_identity_join_v1(
+        _capsule(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.plane_presence["ALIAS"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["CAMPAIGN"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["SESSION"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["CONTENT_HASH"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.legacy_alias_md5_12 is None
+    assert result.join.campaign_id is None
+    assert result.join.session_id is None
+    assert result.join.content_sha256 is None
+
+
+def test_present_sidecars_are_joined_and_not_identity() -> None:
+    result = parse_evidence_capsule_with_identity_join_v1(
+        _capsule(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        campaign_id=_CAMPAIGN_ID,
+        session_id=_SESSION_ID,
+        legacy_alias_md5_12=_MD5_12,
+        content_sha256=_ARTIFACT_SHA256,
+    )
+    assert result.join.plane_presence["CAMPAIGN"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["SESSION"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["ALIAS"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["CONTENT_HASH"] == PlanePresence.PRESENT.value
+    assert result.join.campaign_id == _CAMPAIGN_ID
+    assert result.join.session_id == _SESSION_ID
+    assert result.join.legacy_alias_md5_12 == _MD5_12
+    assert result.join.content_sha256 == _ARTIFACT_SHA256
+    assert result.join.experiment_identity_id != _CAMPAIGN_ID
+    assert result.join.experiment_identity_id != _SESSION_ID
+    assert result.join.experiment_identity_id != _MD5_12
+    assert result.join.experiment_identity_id != _ARTIFACT_SHA256
+    assert result.join.run_id == _DEFAULT_RUN_ID
+
+
+def test_capsule_artifact_sha256_is_content_hash_not_identity() -> None:
+    result = parse_evidence_capsule_with_identity_join_v1(
+        _capsule(artifacts=[_artifact()]),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.content_sha256 == _ARTIFACT_SHA256
+    assert result.join.plane_presence["CONTENT_HASH"] == PlanePresence.PRESENT.value
+    assert result.join.experiment_identity_id == _PACKAGE_N_SHA256
+    assert result.join.content_sha256 != result.join.experiment_identity_id
+
+
+def test_artifact_named_lane_attaches_identity() -> None:
+    result = parse_artifact_ref_with_identity_join_v1(
+        _artifact(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.experiment_identity_id == _PACKAGE_N_SHA256
+    assert result.join.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["CONTENT_HASH"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["RUN"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["EVIDENCE"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.content_sha256 == result.contract.sha256
+    assert result.join.content_sha256 != result.join.experiment_identity_id
+
+
+def test_existing_capsule_still_accepts_identity_free_schema() -> None:
+    capsule = EvidenceCapsule(
+        capsule_id=_CAPSULE_ID,
+        run_id=_DEFAULT_RUN_ID,
+        ts_ms=1000,
+        artifacts=[ArtifactRef(path="/ops/events/ev.jsonl", sha256=_ARTIFACT_SHA256)],
+    )
+    dumped = capsule.to_dict()
+    assert "experiment_identity_id" not in dumped
+    assert dumped["run_id"] == _DEFAULT_RUN_ID
+
+
+def test_implicit_absence_of_identity_rejected() -> None:
+    with pytest.raises(I56IngressNamedLaneIdentityJoinError, match="implicit absence rejected"):
+        parse_evidence_capsule_with_identity_join_v1(_capsule())
+
+
+def test_noncanonical_id_substitution_rejected() -> None:
+    with pytest.raises(I56IngressNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        parse_evidence_capsule_with_identity_join_v1(
+            _capsule(),
+            experiment_identity_id=_RUN_ID,
+        )
+    with pytest.raises(I56IngressNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        parse_evidence_capsule_with_identity_join_v1(
+            _capsule(),
+            experiment_identity_id=_MD5_12,
+        )
+    with pytest.raises(I56IngressNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        parse_evidence_capsule_with_identity_join_v1(
+            _capsule(),
+            experiment_identity_id=_MD5_32,
+        )
+    with pytest.raises(I56IngressNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        parse_evidence_capsule_with_identity_join_v1(
+            _capsule(),
+            experiment_identity_id=_DEFAULT_RUN_ID,
+        )
+    with pytest.raises(I56IngressNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        parse_evidence_capsule_with_identity_join_v1(
+            _capsule(),
+            experiment_identity_id=_CAPSULE_ID,
+        )
+
+
+def test_run_id_and_capsule_id_must_not_substitute_identity() -> None:
+    with pytest.raises(I56IngressNamedLaneIdentityJoinError, match="cross-plane substitution"):
+        parse_evidence_capsule_with_identity_join_v1(
+            _capsule(run_id=_PACKAGE_N_SHA256),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+    with pytest.raises(I56IngressNamedLaneIdentityJoinError, match="cross-plane substitution"):
+        parse_evidence_capsule_with_identity_join_v1(
+            _capsule(capsule_id=_PACKAGE_N_SHA256),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_identity_inside_live_payload_rejected() -> None:
+    live = _capsule()
+    live["experiment_identity_id"] = _PACKAGE_N_SHA256
+    with pytest.raises(I56IngressNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        join_i56_named_lane_identity_v1(
+            live,
+            surface="capsule",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_conflicting_identity_rejected() -> None:
+    with pytest.raises(I56IngressNamedLaneIdentityJoinError, match="conflicting"):
+        parse_evidence_capsule_with_identity_join_v1(
+            _capsule(),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            historical_provenance={"experiment_identity_id": _OTHER_SHA256},
+        )
+    with pytest.raises(I56IngressNamedLaneIdentityJoinError, match="conflicting"):
+        parse_evidence_capsule_with_identity_join_v1(
+            _capsule(),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            evidence_ref="other.capsule",
+        )
+    with pytest.raises(I56IngressNamedLaneIdentityJoinError, match="conflicting"):
+        parse_evidence_capsule_with_identity_join_v1(
+            _capsule(
+                artifacts=[
+                    _artifact(),
+                    {"path": "/ops/events/other.jsonl", "sha256": _OTHER_SHA256},
+                ]
+            ),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_ambiguous_join_rejected() -> None:
+    with pytest.raises(I56IngressNamedLaneIdentityJoinError, match="ambiguous join rejected"):
+        join_i56_named_lane_identity_v1(
+            [_capsule(), _capsule(capsule_id="other.capsule")],
+            surface="capsule",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_malformed_plane_data_rejected() -> None:
+    with pytest.raises(I56IngressNamedLaneIdentityJoinError, match="malformed plane data"):
+        join_i56_named_lane_identity_v1(
+            "not-an-object",  # type: ignore[arg-type]
+            surface="capsule",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+    with pytest.raises(I56IngressNamedLaneIdentityJoinError, match="malformed plane data"):
+        parse_evidence_capsule_with_identity_join_v1(
+            _capsule(),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            session_id="   ",
+        )
+    with pytest.raises(I56IngressNamedLaneIdentityJoinError, match="malformed plane data"):
+        parse_evidence_capsule_with_identity_join_v1(
+            _capsule(payload={"secret": "x"}),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_cross_lane_substitution_rejected() -> None:
+    live = _capsule()
+    live["I61"] = {"session_dir": "/tmp/eval"}
+    with pytest.raises(I56IngressNamedLaneIdentityJoinError, match="cross-lane substitution"):
+        join_i56_named_lane_identity_v1(
+            live,
+            surface="capsule",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_cross_plane_substitution_rejected() -> None:
+    live = _capsule()
+    live["plane_presence"] = {"IDENTITY": "PRESENT"}
+    with pytest.raises(I56IngressNamedLaneIdentityJoinError, match="cross-plane substitution"):
+        join_i56_named_lane_identity_v1(
+            live,
+            surface="capsule",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_join_is_deterministic() -> None:
+    first = parse_evidence_capsule_with_identity_join_v1(
+        _capsule(artifacts=[_artifact()]),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    ).join.to_canonical_mapping()
+    second = parse_evidence_capsule_with_identity_join_v1(
+        _capsule(artifacts=[_artifact()]),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    ).join.to_canonical_mapping()
+    assert first == second
+
+
+def test_named_lane_does_not_mutate_inputs() -> None:
+    raw = _capsule()
+    snapshot = copy.deepcopy(raw)
+    result = parse_evidence_capsule_with_identity_join_v1(
+        raw,
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        historical_provenance={"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID},
+    )
+    raw["run_id"] = "MUTATED"
+    assert result.contract.run_id == snapshot["run_id"]
+    assert dict(raw) != snapshot
+
+
+def test_legacy_experiment_id_and_run_id_remain_non_authoritative() -> None:
+    result = parse_evidence_capsule_with_identity_join_v1(
+        _capsule(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        historical_provenance={"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID},
+    )
+    assert result.join.experiment_identity_id == _PACKAGE_N_SHA256
+    assert result.join.experiment_identity_id != _RUN_ID
+    assert result.join.run_id == _DEFAULT_RUN_ID
+    assert result.join.experiment_identity_id != _DEFAULT_RUN_ID
+    assert dict(result.join.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+
+
+def test_runtime_invariants_remain_unauthorized() -> None:
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+
+
+def test_named_lane_producer_is_hooked_and_forbidden_surfaces_are_not() -> None:
+    join_modules = _imported_modules(JOIN_PATH)
+    assert "src.ingress.capsules.i56_ingress_join_attachment_v1" in join_modules
+    assert "src.ingress.capsules.evidence_capsule" not in join_modules
+    capsule_modules = _imported_modules(CAPSULE_PATH)
+    assert _JOIN_MODULE in capsule_modules
+    assert not any(
+        mod == "src.execution" or mod.startswith("src.execution.") for mod in capsule_modules
+    )
+    assert not any(
+        "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in capsule_modules
+    )
+    assert "src.analytics.explorer" not in capsule_modules
+    assert "src.live_eval.live_session_eval" not in capsule_modules
+    assert "src.experiments.base" not in capsule_modules
+    assert not any(
+        mod == "src.execution" or mod.startswith("src.execution.") for mod in join_modules
+    )
+    join_source = JOIN_PATH.read_text(encoding="utf-8")
+    assert "write_text" not in join_source
+    assert "open(" not in join_source
+    assert "Path(" not in join_source
+    assert "build_evidence_capsule" not in join_source
+    capsule_source = CAPSULE_PATH.read_text(encoding="utf-8")
+    assert "experiment_identity_id" not in capsule_source
+    assert "i56_ingress_live_contract_join_v1" not in capsule_source
+    init_source = INIT_PATH.read_text(encoding="utf-8")
+    builder_source = BUILDER_PATH.read_text(encoding="utf-8")
+    writer_source = WRITER_PATH.read_text(encoding="utf-8")
+    orch_source = ORCH_PATH.read_text(encoding="utf-8")
+    attachment_source = ATTACHMENT_PATH.read_text(encoding="utf-8")
+    r14_source = R14_PATH.read_text(encoding="utf-8")
+    assert "i56_ingress_named_lane_identity_join_v1" not in init_source
+    assert "i56_ingress_named_lane_identity_join_v1" not in builder_source
+    assert "i56_ingress_named_lane_identity_join_v1" not in writer_source
+    assert "i56_ingress_named_lane_identity_join_v1" not in orch_source
+    assert "i56_ingress_named_lane_identity_join_v1" not in attachment_source
+    assert "i56_ingress_named_lane_identity_join_v1" not in r14_source
+    assert _PACKAGE_N_SHA256 not in capsule_source

--- a/tests/levelup/test_i52_levelup_join_attachment_v1.py
+++ b/tests/levelup/test_i52_levelup_join_attachment_v1.py
@@ -1,0 +1,219 @@
+"""U-I82-R6 tests for dormant I52 Level-Up join attachment."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import uuid
+from pathlib import Path
+
+import pytest
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+)
+from src.levelup.i52_levelup_join_attachment_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    I52LevelUpJoinAttachmentError,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    attach_i52_levelup_join_v1,
+)
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ATTACHMENT_PATH = REPO_ROOT / "src" / "levelup" / "i52_levelup_join_attachment_v1.py"
+
+_PACKAGE_N_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r6-package-n").hexdigest()
+_OTHER_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r6-other").hexdigest()
+_CONTENT_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r6-content").hexdigest()
+_MD5_12 = "abcdef012345"
+_MD5_32 = "d41d8cd98f00b204e9800998ecf8427e"
+_RUN_ID = str(uuid.uuid4())
+_SLICE_ID = "S1-R3"
+_RELATIVE_DIR = "out/ops/slice_demo_001/"
+
+
+def _i52_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "experiment_identity_id": _PACKAGE_N_SHA256,
+        "slice_id": _SLICE_ID,
+        "relative_dir": _RELATIVE_DIR,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_canonical_package_n_sha256_happy_path() -> None:
+    record = attach_i52_levelup_join_v1(_i52_payload())
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.evidence_ref == _RELATIVE_DIR
+    assert record.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert record.plane_presence["EVIDENCE"] == PlanePresence.PRESENT.value
+    assert record.experiment_identity_id != _SLICE_ID
+    assert is_package_n_sha256_canonical_id(record.experiment_identity_id) is True
+
+
+def test_alias_run_campaign_session_absent_declared_by_default() -> None:
+    record = attach_i52_levelup_join_v1(_i52_payload())
+    assert record.plane_presence["ALIAS"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["RUN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["CAMPAIGN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["SESSION"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.legacy_alias_md5_12 is None
+    assert record.run_id is None
+    assert record.campaign_id is None
+    assert record.session_id is None
+
+
+def test_explicit_absent_declared_without_relative_dir() -> None:
+    payload = {
+        "experiment_identity_id": _PACKAGE_N_SHA256,
+        "slice_id": _SLICE_ID,
+    }
+    record = attach_i52_levelup_join_v1(payload)
+    assert record.plane_presence["EVIDENCE"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.evidence_ref is None
+    assert record.plane_presence["CONTENT_HASH"] == PlanePresence.ABSENT_DECLARED.value
+
+
+def test_explicit_content_sha256_is_content_hash_not_identity() -> None:
+    record = attach_i52_levelup_join_v1(_i52_payload(content_sha256=_CONTENT_SHA256))
+    assert record.plane_presence["CONTENT_HASH"] == PlanePresence.PRESENT.value
+    assert record.content_sha256 == _CONTENT_SHA256
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.content_sha256 != record.experiment_identity_id
+
+
+def test_missing_identity_rejected() -> None:
+    with pytest.raises(I52LevelUpJoinAttachmentError, match="IDENTITY missing"):
+        attach_i52_levelup_join_v1({"slice_id": _SLICE_ID, "relative_dir": _RELATIVE_DIR})
+
+
+def test_uuid_run_id_as_identity_rejected() -> None:
+    assert is_package_n_sha256_canonical_id(_RUN_ID) is False
+    with pytest.raises(I52LevelUpJoinAttachmentError, match="Package-N SHA256"):
+        attach_i52_levelup_join_v1(_i52_payload(experiment_identity_id=_RUN_ID, run_id=_RUN_ID))
+
+
+def test_legacy_experiment_id_as_identity_rejected() -> None:
+    with pytest.raises(I52LevelUpJoinAttachmentError, match="forbidden I52 join field"):
+        attach_i52_levelup_join_v1(_i52_payload(experiment_id=_RUN_ID))
+
+
+def test_md5_as_identity_rejected() -> None:
+    with pytest.raises(I52LevelUpJoinAttachmentError, match="Package-N SHA256"):
+        attach_i52_levelup_join_v1(_i52_payload(experiment_identity_id=_MD5_12))
+    with pytest.raises(I52LevelUpJoinAttachmentError, match="Package-N SHA256"):
+        attach_i52_levelup_join_v1(_i52_payload(experiment_identity_id=_MD5_32))
+
+
+def test_slice_id_as_identity_rejected() -> None:
+    with pytest.raises(I52LevelUpJoinAttachmentError, match="Package-N SHA256"):
+        attach_i52_levelup_join_v1(_i52_payload(experiment_identity_id=_SLICE_ID))
+
+
+def test_slice_id_must_not_substitute_identity() -> None:
+    with pytest.raises(I52LevelUpJoinAttachmentError, match="must not substitute"):
+        attach_i52_levelup_join_v1(_i52_payload(slice_id=_PACKAGE_N_SHA256))
+
+
+def test_relative_dir_outside_out_ops_rejected() -> None:
+    with pytest.raises(I52LevelUpJoinAttachmentError, match="must start with"):
+        attach_i52_levelup_join_v1(_i52_payload(relative_dir="out/evidence/x"))
+
+
+def test_relative_dir_path_traversal_rejected() -> None:
+    with pytest.raises(I52LevelUpJoinAttachmentError, match="path traversal"):
+        attach_i52_levelup_join_v1(_i52_payload(relative_dir="out/ops/../other"))
+
+
+def test_conflicting_evidence_values_rejected() -> None:
+    with pytest.raises(I52LevelUpJoinAttachmentError, match="conflicting EVIDENCE"):
+        attach_i52_levelup_join_v1(
+            _i52_payload(evidence_ref="out/ops/slice_a/", relative_dir="out/ops/slice_b/")
+        )
+
+
+def test_conflicting_identity_values_rejected() -> None:
+    with pytest.raises(I52LevelUpJoinAttachmentError, match="forbidden I52 join field"):
+        attach_i52_levelup_join_v1(_i52_payload(ref_id=_OTHER_SHA256))
+    with pytest.raises(I52LevelUpJoinAttachmentError, match="conflicting identities"):
+        attach_i52_levelup_join_v1(
+            _i52_payload(historical_provenance={"experiment_identity_id": _OTHER_SHA256})
+        )
+
+
+def test_unknown_join_field_extra_forbid_rejected() -> None:
+    with pytest.raises(I52LevelUpJoinAttachmentError, match="unknown I52 join field"):
+        attach_i52_levelup_join_v1(_i52_payload(authorization_id="not-in-i52-join"))
+
+
+def test_join_is_deterministic() -> None:
+    payload = _i52_payload(content_sha256=_CONTENT_SHA256, run_id=_RUN_ID)
+    first = attach_i52_levelup_join_v1(payload).to_canonical_mapping()
+    second = attach_i52_levelup_join_v1(copy.deepcopy(payload)).to_canonical_mapping()
+    assert first == second
+
+
+def test_attachment_does_not_mutate_inputs() -> None:
+    payload = _i52_payload(
+        historical_provenance={"legacy_experiment_id": _RUN_ID, "slice_id": _SLICE_ID}
+    )
+    snapshot = copy.deepcopy(payload)
+    record = attach_i52_levelup_join_v1(payload)
+    payload["slice_id"] = "MUTATED"
+    payload["historical_provenance"]["legacy_experiment_id"] = "MUTATED"  # type: ignore[index]
+    assert dict(record.historical_provenance)["slice_id"] == _SLICE_ID
+    assert dict(record.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+    assert payload != snapshot
+
+
+def test_historical_provenance_non_authoritative() -> None:
+    payload = _i52_payload(
+        historical_provenance={"legacy_experiment_id": _RUN_ID, "slice_id": _SLICE_ID}
+    )
+    record = attach_i52_levelup_join_v1(payload)
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.experiment_identity_id != _SLICE_ID
+    assert record.experiment_identity_id != _RUN_ID
+    assert dict(record.historical_provenance)["slice_id"] == _SLICE_ID
+
+
+def test_runtime_invariants_remain_unauthorized() -> None:
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_no_runtime_registration_or_forbidden_imports() -> None:
+    modules = _imported_modules(ATTACHMENT_PATH)
+    assert not any(mod == "src.execution" or mod.startswith("src.execution.") for mod in modules)
+    assert not any(
+        "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in modules
+    )
+    assert "src.levelup.v0_models" not in modules
+    assert "src.levelup.v0_io" not in modules
+    assert "src.levelup.cli" not in modules
+    assert "src.experiments.base" not in modules
+    source = ATTACHMENT_PATH.read_text(encoding="utf-8")
+    assert "open(" not in source
+    assert "write_manifest" not in source
+    assert "read_manifest" not in source
+    assert "model_validate" not in source

--- a/tests/levelup/test_i52_levelup_live_contract_join_v1.py
+++ b/tests/levelup/test_i52_levelup_live_contract_join_v1.py
@@ -1,0 +1,366 @@
+"""U-I82-R13 tests for dormant I52 live-contract join registration."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import uuid
+from pathlib import Path
+
+import pytest
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+)
+from src.levelup.i52_levelup_live_contract_join_v1 import (
+    CONTRACT_ID,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    I52_LIVE_CONTRACT_REGISTERED,
+    I52LevelUpLiveContractJoinError,
+    LIVE_CONTRACT_SURFACES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    is_i52_live_contract_registered,
+    register_i52_live_contract_join_v1,
+)
+from src.levelup.v0_models import EvidenceBundleRefV0, LevelUpManifestV0, SliceContractV0
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.i17_paper_shadow_live_contract_join_v1 import (
+    I17_LIVE_CONTRACT_REGISTERED,
+    is_i17_live_contract_registered,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REGISTRATION_PATH = REPO_ROOT / "src" / "levelup" / "i52_levelup_live_contract_join_v1.py"
+ATTACHMENT_PATH = REPO_ROOT / "src" / "levelup" / "i52_levelup_join_attachment_v1.py"
+MODELS_PATH = REPO_ROOT / "src" / "levelup" / "v0_models.py"
+IO_PATH = REPO_ROOT / "src" / "levelup" / "v0_io.py"
+CLI_PATH = REPO_ROOT / "src" / "levelup" / "cli.py"
+INIT_PATH = REPO_ROOT / "src" / "levelup" / "__init__.py"
+I17_REGISTRATION_PATH = (
+    REPO_ROOT
+    / "src"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+    / "i17_paper_shadow_live_contract_join_v1.py"
+)
+_LIVE_CONTRACT_FILES = (MODELS_PATH, IO_PATH, CLI_PATH, INIT_PATH, ATTACHMENT_PATH)
+
+_PACKAGE_N_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r13-package-n").hexdigest()
+_OTHER_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r13-other").hexdigest()
+_CONTENT_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r13-content").hexdigest()
+_MD5_12 = "abcdef012345"
+_MD5_32 = "d41d8cd98f00b204e9800998ecf8427e"
+_RUN_ID = str(uuid.uuid4())
+_SLICE_ID = "S1-R3"
+_RELATIVE_DIR = "out/ops/slice_demo_001/"
+
+
+def _slice_payload(*, with_evidence: bool = True) -> dict[str, object]:
+    evidence = EvidenceBundleRefV0(relative_dir=_RELATIVE_DIR) if with_evidence else None
+    return SliceContractV0(
+        slice_id=_SLICE_ID,
+        title="Live execution gated",
+        contract_summary="Without enabled+armed+token → no order.",
+        evidence=evidence,
+    ).model_dump(mode="python")
+
+
+def _manifest_payload(*, slices: tuple[dict[str, object], ...] | None = None) -> dict[str, object]:
+    if slices is None:
+        slices = (_slice_payload(),)
+    models = tuple(SliceContractV0.model_validate(item) for item in slices)
+    return LevelUpManifestV0(title="Test", slices=models).model_dump(mode="python")
+
+
+def _evidence_payload() -> dict[str, object]:
+    return EvidenceBundleRefV0(relative_dir=_RELATIVE_DIR).model_dump(mode="python")
+
+
+def _envelope(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "experiment_identity_id": _PACKAGE_N_SHA256,
+        "manifest": _manifest_payload(),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_live_contract_registration_flag_is_reachable() -> None:
+    assert CONTRACT_ID == "i52_levelup_live_contract_join_v1"
+    assert I52_LIVE_CONTRACT_REGISTERED is True
+    assert is_i52_live_contract_registered() is True
+    assert LIVE_CONTRACT_SURFACES == ("manifest", "slice", "evidence_bundle")
+    assert I17_LIVE_CONTRACT_REGISTERED is True
+    assert is_i17_live_contract_registered() is True
+
+
+def test_canonical_package_n_sha256_present_join_from_manifest() -> None:
+    record = register_i52_live_contract_join_v1(_envelope())
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert is_package_n_sha256_canonical_id(record.experiment_identity_id) is True
+    assert record.evidence_ref == _RELATIVE_DIR
+    assert record.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert record.plane_presence["EVIDENCE"] == PlanePresence.PRESENT.value
+    assert record.experiment_identity_id != _SLICE_ID
+    assert record.experiment_identity_id != _RELATIVE_DIR
+
+
+def test_declared_absence_for_alias_run_campaign_session_content_hash() -> None:
+    record = register_i52_live_contract_join_v1(_envelope())
+    assert record.plane_presence["ALIAS"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["RUN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["CAMPAIGN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["SESSION"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["CONTENT_HASH"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.legacy_alias_md5_12 is None
+    assert record.run_id is None
+    assert record.campaign_id is None
+    assert record.session_id is None
+    assert record.content_sha256 is None
+
+
+def test_empty_manifest_is_declared_absence_not_implicit() -> None:
+    record = register_i52_live_contract_join_v1(
+        {
+            "experiment_identity_id": _PACKAGE_N_SHA256,
+            "manifest": _manifest_payload(slices=()),
+        }
+    )
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert record.plane_presence["EVIDENCE"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.evidence_ref is None
+
+
+def test_slice_present_join() -> None:
+    record = register_i52_live_contract_join_v1(
+        {
+            "experiment_identity_id": _PACKAGE_N_SHA256,
+            "slice": _slice_payload(),
+        }
+    )
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.evidence_ref == _RELATIVE_DIR
+    assert record.plane_presence["EVIDENCE"] == PlanePresence.PRESENT.value
+
+
+def test_evidence_bundle_present_join() -> None:
+    record = register_i52_live_contract_join_v1(
+        {
+            "experiment_identity_id": _PACKAGE_N_SHA256,
+            "evidence_bundle": _evidence_payload(),
+        }
+    )
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.evidence_ref == _RELATIVE_DIR
+    assert record.plane_presence["EVIDENCE"] == PlanePresence.PRESENT.value
+    assert record.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+
+
+def test_explicit_declared_run_and_alias_remain_non_authoritative() -> None:
+    record = register_i52_live_contract_join_v1(
+        _envelope(run_id=_RUN_ID, legacy_alias_md5_12=_MD5_12, content_sha256=_CONTENT_SHA256)
+    )
+    assert record.run_id == _RUN_ID
+    assert record.legacy_alias_md5_12 == _MD5_12
+    assert record.content_sha256 == _CONTENT_SHA256
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.experiment_identity_id != _RUN_ID
+    assert record.experiment_identity_id != _MD5_12
+    assert record.experiment_identity_id != _CONTENT_SHA256
+
+
+def test_implicit_absence_of_identity_rejected() -> None:
+    with pytest.raises(I52LevelUpLiveContractJoinError, match="implicit absence rejected"):
+        register_i52_live_contract_join_v1({"manifest": _manifest_payload()})
+
+
+def test_implicit_absence_of_live_surface_rejected() -> None:
+    with pytest.raises(I52LevelUpLiveContractJoinError, match="implicit absence rejected"):
+        register_i52_live_contract_join_v1({"experiment_identity_id": _PACKAGE_N_SHA256})
+
+
+def test_noncanonical_id_substitution_rejected() -> None:
+    with pytest.raises(I52LevelUpLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i52_live_contract_join_v1(_envelope(experiment_identity_id=_RUN_ID))
+    with pytest.raises(I52LevelUpLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i52_live_contract_join_v1(_envelope(experiment_identity_id=_MD5_12))
+    with pytest.raises(I52LevelUpLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i52_live_contract_join_v1(_envelope(experiment_identity_id=_MD5_32))
+    with pytest.raises(I52LevelUpLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i52_live_contract_join_v1(_envelope(experiment_identity_id=_SLICE_ID))
+
+
+def test_legacy_experiment_id_and_slice_id_on_envelope_rejected() -> None:
+    with pytest.raises(I52LevelUpLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i52_live_contract_join_v1(_envelope(experiment_id=_RUN_ID))
+    with pytest.raises(I52LevelUpLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i52_live_contract_join_v1(_envelope(slice_id=_SLICE_ID))
+
+
+def test_conflicting_identity_rejected() -> None:
+    with pytest.raises(I52LevelUpLiveContractJoinError, match="conflicting"):
+        register_i52_live_contract_join_v1(
+            _envelope(historical_provenance={"experiment_identity_id": _OTHER_SHA256})
+        )
+    with pytest.raises(I52LevelUpLiveContractJoinError, match="conflicting"):
+        register_i52_live_contract_join_v1(_envelope(evidence_ref="out/ops/other_slice/"))
+
+
+def test_ambiguous_join_rejected() -> None:
+    with pytest.raises(I52LevelUpLiveContractJoinError, match="ambiguous join rejected"):
+        register_i52_live_contract_join_v1(
+            {
+                "experiment_identity_id": _PACKAGE_N_SHA256,
+                "manifest": _manifest_payload(),
+                "slice": _slice_payload(),
+            }
+        )
+    second = _slice_payload()
+    second["slice_id"] = "S2-R3"
+    with pytest.raises(I52LevelUpLiveContractJoinError, match="ambiguous join rejected"):
+        register_i52_live_contract_join_v1(
+            {
+                "experiment_identity_id": _PACKAGE_N_SHA256,
+                "manifest": _manifest_payload(slices=(_slice_payload(), second)),
+            }
+        )
+
+
+def test_malformed_plane_data_rejected() -> None:
+    with pytest.raises(I52LevelUpLiveContractJoinError, match="malformed plane data"):
+        register_i52_live_contract_join_v1("not-an-object")  # type: ignore[arg-type]
+    with pytest.raises(I52LevelUpLiveContractJoinError, match="malformed plane data"):
+        register_i52_live_contract_join_v1(
+            {"experiment_identity_id": _PACKAGE_N_SHA256, "manifest": "bad"}
+        )
+    mutated = _slice_payload()
+    mutated.pop("slice_id")
+    with pytest.raises(I52LevelUpLiveContractJoinError, match="malformed plane data"):
+        register_i52_live_contract_join_v1(
+            {"experiment_identity_id": _PACKAGE_N_SHA256, "slice": mutated}
+        )
+
+
+def test_cross_plane_substitution_rejected() -> None:
+    with pytest.raises(I52LevelUpLiveContractJoinError, match="cross-plane substitution"):
+        register_i52_live_contract_join_v1(_envelope(plane_presence={"IDENTITY": "PRESENT"}))
+    live = _slice_payload()
+    live["slice_id"] = _PACKAGE_N_SHA256
+    with pytest.raises(I52LevelUpLiveContractJoinError, match="cross-plane substitution"):
+        register_i52_live_contract_join_v1(
+            {"experiment_identity_id": _PACKAGE_N_SHA256, "slice": live}
+        )
+
+
+def test_cross_lane_substitution_rejected() -> None:
+    with pytest.raises(I52LevelUpLiveContractJoinError, match="cross-lane substitution"):
+        register_i52_live_contract_join_v1(_envelope(I17={"session_id": "pso_fixture"}))
+    i17_as_manifest = {
+        "session_id": "pso_fixture_session_non_auth_v1",
+        "evidence_root": "evidence/fixtures/paper_shadow_observation_non_authoritative_v1",
+    }
+    with pytest.raises(I52LevelUpLiveContractJoinError, match="malformed plane data"):
+        register_i52_live_contract_join_v1(
+            {
+                "experiment_identity_id": _PACKAGE_N_SHA256,
+                "manifest": i17_as_manifest,
+            }
+        )
+
+
+def test_identity_inside_live_payload_rejected() -> None:
+    live = _slice_payload()
+    live["experiment_identity_id"] = _PACKAGE_N_SHA256
+    with pytest.raises(I52LevelUpLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i52_live_contract_join_v1(
+            {"experiment_identity_id": _PACKAGE_N_SHA256, "slice": live}
+        )
+
+
+def test_join_is_deterministic() -> None:
+    payload = _envelope(content_sha256=_CONTENT_SHA256)
+    first = register_i52_live_contract_join_v1(payload).to_canonical_mapping()
+    second = register_i52_live_contract_join_v1(copy.deepcopy(payload)).to_canonical_mapping()
+    assert first == second
+
+
+def test_registration_does_not_mutate_inputs() -> None:
+    payload = _envelope(historical_provenance={"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID})
+    snapshot = copy.deepcopy(payload)
+    record = register_i52_live_contract_join_v1(payload)
+    payload["experiment_identity_id"] = "MUTATED"
+    payload["manifest"]["title"] = "MUTATED"  # type: ignore[index]
+    payload["historical_provenance"]["legacy_experiment_id"] = "MUTATED"  # type: ignore[index]
+    assert record.experiment_identity_id == snapshot["experiment_identity_id"]
+    assert dict(record.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+    assert payload != snapshot
+
+
+def test_legacy_experiment_id_and_run_id_remain_non_authoritative() -> None:
+    payload = _envelope(
+        run_id=_RUN_ID,
+        historical_provenance={"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID},
+    )
+    record = register_i52_live_contract_join_v1(payload)
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.experiment_identity_id != _RUN_ID
+    assert record.run_id == _RUN_ID
+    assert dict(record.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+
+
+def test_runtime_invariants_remain_unauthorized() -> None:
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_no_cap72_execution_hook_or_persistence() -> None:
+    modules = _imported_modules(REGISTRATION_PATH)
+    assert not any(mod == "src.execution" or mod.startswith("src.execution.") for mod in modules)
+    assert not any(
+        "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in modules
+    )
+    assert "src.experiments.base" not in modules
+    assert "src.levelup.v0_io" not in modules
+    assert "src.levelup.cli" not in modules
+    assert "src.ingress.capsules.evidence_capsule" not in modules
+    assert "src.live_eval.live_session_eval" not in modules
+    assert "src.analytics.explorer" not in modules
+    assert "src.levelup.v0_models" in modules
+    assert "src.levelup.i52_levelup_join_attachment_v1" in modules
+    source = REGISTRATION_PATH.read_text(encoding="utf-8")
+    assert "open(" not in source
+    assert "write_text" not in source
+    assert "Path(" not in source
+    assert "write_manifest" not in source
+    assert "read_manifest" not in source
+
+
+def test_live_contracts_and_i17_remain_unhooked() -> None:
+    for path in _LIVE_CONTRACT_FILES:
+        source = path.read_text(encoding="utf-8")
+        assert "register_i52_live_contract_join_v1" not in source
+        assert "i52_levelup_live_contract_join_v1" not in source
+    models = MODELS_PATH.read_text(encoding="utf-8")
+    assert "experiment_identity_id" not in models
+    i17 = I17_REGISTRATION_PATH.read_text(encoding="utf-8")
+    assert "i52_levelup_live_contract_join_v1" not in i17
+    assert "I52_LIVE_CONTRACT_REGISTERED = True" not in i17

--- a/tests/levelup/test_i52_levelup_named_lane_identity_join_v1.py
+++ b/tests/levelup/test_i52_levelup_named_lane_identity_join_v1.py
@@ -1,0 +1,415 @@
+"""U-I82-R20 tests for I52 named-lane IDENTITY join on v0 models."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import uuid
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+)
+from src.levelup.i52_levelup_join_attachment_v1 import CONTRACT_ID as R6_CONTRACT_ID
+from src.levelup.i52_levelup_named_lane_identity_join_v1 import (
+    CONTRACT_ID,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    I52_NAMED_LANE_IDENTITY_JOIN_REGISTERED,
+    I52LevelUpNamedLaneIdentityJoinError,
+    LIVE_CONTRACT_SURFACES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    is_i52_named_lane_identity_join_registered,
+    join_i52_named_lane_identity_v1,
+)
+from src.levelup.v0_models import (
+    EvidenceBundleRefV0,
+    LevelUpManifestV0,
+    SliceContractV0,
+    parse_evidence_bundle_with_identity_join_v1,
+    parse_levelup_manifest_with_identity_join_v1,
+    parse_slice_contract_with_identity_join_v1,
+)
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+JOIN_PATH = REPO_ROOT / "src" / "levelup" / "i52_levelup_named_lane_identity_join_v1.py"
+ATTACHMENT_PATH = REPO_ROOT / "src" / "levelup" / "i52_levelup_join_attachment_v1.py"
+MODELS_PATH = REPO_ROOT / "src" / "levelup" / "v0_models.py"
+IO_PATH = REPO_ROOT / "src" / "levelup" / "v0_io.py"
+CLI_PATH = REPO_ROOT / "src" / "levelup" / "cli.py"
+INIT_PATH = REPO_ROOT / "src" / "levelup" / "__init__.py"
+R13_PATH = REPO_ROOT / "src" / "levelup" / "i52_levelup_live_contract_join_v1.py"
+_JOIN_MODULE = "src.levelup.i52_levelup_named_lane_identity_join_v1"
+
+_PACKAGE_N_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r20-package-n").hexdigest()
+_OTHER_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r20-other").hexdigest()
+_CONTENT_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r20-content").hexdigest()
+_MD5_12 = "abcdef012345"
+_MD5_32 = "d41d8cd98f00b204e9800998ecf8427e"
+_RUN_ID = str(uuid.uuid4())
+_CAMPAIGN_ID = "campaign-i52-r20"
+_SESSION_ID = "session-i52-r20"
+_SLICE_ID = "S1-R3"
+_RELATIVE_DIR = "out/ops/slice_demo_001/"
+
+
+def _slice_payload(*, with_evidence: bool = True) -> dict[str, object]:
+    evidence = EvidenceBundleRefV0(relative_dir=_RELATIVE_DIR) if with_evidence else None
+    return SliceContractV0(
+        slice_id=_SLICE_ID,
+        title="Live execution gated",
+        contract_summary="Without enabled+armed+token → no order.",
+        evidence=evidence,
+    ).model_dump(mode="python")
+
+
+def _manifest_payload(*, slices: tuple[dict[str, object], ...] | None = None) -> dict[str, object]:
+    if slices is None:
+        slices = (_slice_payload(),)
+    models = tuple(SliceContractV0.model_validate(item) for item in slices)
+    return LevelUpManifestV0(title="Test", slices=models).model_dump(mode="python")
+
+
+def _evidence_payload() -> dict[str, object]:
+    return EvidenceBundleRefV0(relative_dir=_RELATIVE_DIR).model_dump(mode="python")
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_named_lane_identity_join_is_registered_and_reachable() -> None:
+    assert CONTRACT_ID == "i52_levelup_named_lane_identity_join_v1"
+    assert R6_CONTRACT_ID == "i52_levelup_join_attachment_v1"
+    assert I52_NAMED_LANE_IDENTITY_JOIN_REGISTERED is True
+    assert is_i52_named_lane_identity_join_registered() is True
+    assert LIVE_CONTRACT_SURFACES == ("manifest", "slice", "evidence_bundle")
+
+
+def test_named_manifest_producer_attaches_identity() -> None:
+    result = parse_levelup_manifest_with_identity_join_v1(
+        _manifest_payload(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.experiment_identity_id == _PACKAGE_N_SHA256
+    assert is_package_n_sha256_canonical_id(result.join.experiment_identity_id) is True
+    assert result.join.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["EVIDENCE"] == PlanePresence.PRESENT.value
+    assert result.join.evidence_ref == _RELATIVE_DIR
+    assert result.join.experiment_identity_id != _SLICE_ID
+    assert result.join.experiment_identity_id != _RELATIVE_DIR
+    dumped = result.contract.model_dump(mode="python")
+    assert "experiment_identity_id" not in dumped
+    assert dumped["slices"][0]["slice_id"] == _SLICE_ID
+
+
+def test_declared_absence_for_alias_run_campaign_session_content_hash() -> None:
+    result = parse_levelup_manifest_with_identity_join_v1(
+        _manifest_payload(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.plane_presence["ALIAS"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["RUN"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["CAMPAIGN"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["SESSION"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["CONTENT_HASH"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.legacy_alias_md5_12 is None
+    assert result.join.run_id is None
+    assert result.join.campaign_id is None
+    assert result.join.session_id is None
+    assert result.join.content_sha256 is None
+
+
+def test_empty_manifest_is_declared_absence_not_implicit() -> None:
+    result = parse_levelup_manifest_with_identity_join_v1(
+        _manifest_payload(slices=()),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.experiment_identity_id == _PACKAGE_N_SHA256
+    assert result.join.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["EVIDENCE"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.evidence_ref is None
+
+
+def test_present_sidecars_are_joined_and_not_identity() -> None:
+    result = parse_levelup_manifest_with_identity_join_v1(
+        _manifest_payload(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        run_id=_RUN_ID,
+        campaign_id=_CAMPAIGN_ID,
+        session_id=_SESSION_ID,
+        legacy_alias_md5_12=_MD5_12,
+        content_sha256=_CONTENT_SHA256,
+    )
+    assert result.join.plane_presence["RUN"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["CAMPAIGN"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["SESSION"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["ALIAS"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["CONTENT_HASH"] == PlanePresence.PRESENT.value
+    assert result.join.run_id == _RUN_ID
+    assert result.join.campaign_id == _CAMPAIGN_ID
+    assert result.join.session_id == _SESSION_ID
+    assert result.join.legacy_alias_md5_12 == _MD5_12
+    assert result.join.content_sha256 == _CONTENT_SHA256
+    assert result.join.experiment_identity_id != _RUN_ID
+    assert result.join.experiment_identity_id != _CAMPAIGN_ID
+    assert result.join.experiment_identity_id != _SESSION_ID
+    assert result.join.experiment_identity_id != _MD5_12
+    assert result.join.experiment_identity_id != _CONTENT_SHA256
+
+
+def test_slice_named_lane_attaches_identity() -> None:
+    result = parse_slice_contract_with_identity_join_v1(
+        _slice_payload(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.experiment_identity_id == _PACKAGE_N_SHA256
+    assert result.contract.slice_id == _SLICE_ID
+    assert result.join.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["EVIDENCE"] == PlanePresence.PRESENT.value
+    assert "experiment_identity_id" not in result.contract.model_dump(mode="python")
+
+
+def test_evidence_bundle_named_lane_attaches_identity() -> None:
+    result = parse_evidence_bundle_with_identity_join_v1(
+        _evidence_payload(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.experiment_identity_id == _PACKAGE_N_SHA256
+    assert result.join.evidence_ref == result.contract.relative_dir
+    assert result.join.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["EVIDENCE"] == PlanePresence.PRESENT.value
+    assert "experiment_identity_id" not in result.contract.model_dump(mode="python")
+
+
+def test_existing_model_validate_still_accepts_identity_free_schema() -> None:
+    manifest = LevelUpManifestV0.model_validate(_manifest_payload())
+    dumped = manifest.model_dump(mode="python")
+    assert "experiment_identity_id" not in dumped
+    assert dumped["slices"][0]["slice_id"] == _SLICE_ID
+
+
+def test_implicit_absence_of_identity_rejected() -> None:
+    with pytest.raises(I52LevelUpNamedLaneIdentityJoinError, match="implicit absence rejected"):
+        parse_levelup_manifest_with_identity_join_v1(_manifest_payload())
+
+
+def test_noncanonical_id_substitution_rejected() -> None:
+    with pytest.raises(I52LevelUpNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        parse_levelup_manifest_with_identity_join_v1(
+            _manifest_payload(),
+            experiment_identity_id=_RUN_ID,
+        )
+    with pytest.raises(I52LevelUpNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        parse_levelup_manifest_with_identity_join_v1(
+            _manifest_payload(),
+            experiment_identity_id=_MD5_12,
+        )
+    with pytest.raises(I52LevelUpNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        parse_levelup_manifest_with_identity_join_v1(
+            _manifest_payload(),
+            experiment_identity_id=_MD5_32,
+        )
+    with pytest.raises(I52LevelUpNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        parse_levelup_manifest_with_identity_join_v1(
+            _manifest_payload(),
+            experiment_identity_id=_SLICE_ID,
+        )
+
+
+def test_slice_id_must_not_substitute_identity() -> None:
+    live = _slice_payload()
+    live["slice_id"] = _PACKAGE_N_SHA256
+    with pytest.raises(I52LevelUpNamedLaneIdentityJoinError, match="cross-plane substitution"):
+        join_i52_named_lane_identity_v1(
+            live,
+            surface="slice",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_identity_inside_live_payload_rejected() -> None:
+    live = _slice_payload()
+    live["experiment_identity_id"] = _PACKAGE_N_SHA256
+    with pytest.raises(I52LevelUpNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        join_i52_named_lane_identity_v1(
+            live,
+            surface="slice",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_conflicting_identity_rejected() -> None:
+    with pytest.raises(I52LevelUpNamedLaneIdentityJoinError, match="conflicting"):
+        parse_levelup_manifest_with_identity_join_v1(
+            _manifest_payload(),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            historical_provenance={"experiment_identity_id": _OTHER_SHA256},
+        )
+    with pytest.raises(I52LevelUpNamedLaneIdentityJoinError, match="conflicting"):
+        parse_levelup_manifest_with_identity_join_v1(
+            _manifest_payload(),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            evidence_ref="out/ops/other_slice/",
+        )
+
+
+def test_ambiguous_join_rejected() -> None:
+    second = _slice_payload()
+    second["slice_id"] = "S2-R3"
+    with pytest.raises(I52LevelUpNamedLaneIdentityJoinError, match="ambiguous join rejected"):
+        parse_levelup_manifest_with_identity_join_v1(
+            _manifest_payload(slices=(_slice_payload(), second)),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_malformed_plane_data_rejected() -> None:
+    with pytest.raises(I52LevelUpNamedLaneIdentityJoinError, match="malformed plane data"):
+        join_i52_named_lane_identity_v1(
+            "not-an-object",  # type: ignore[arg-type]
+            surface="manifest",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+    with pytest.raises(I52LevelUpNamedLaneIdentityJoinError, match="malformed plane data"):
+        parse_levelup_manifest_with_identity_join_v1(
+            _manifest_payload(),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            run_id="   ",
+        )
+
+
+def test_cross_lane_substitution_rejected() -> None:
+    live = _manifest_payload()
+    live["I17"] = {"session_id": "pso_fixture"}
+    with pytest.raises(I52LevelUpNamedLaneIdentityJoinError, match="cross-lane substitution"):
+        join_i52_named_lane_identity_v1(
+            live,
+            surface="manifest",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_cross_plane_substitution_rejected() -> None:
+    live = _manifest_payload()
+    live["plane_presence"] = {"IDENTITY": "PRESENT"}
+    with pytest.raises(I52LevelUpNamedLaneIdentityJoinError, match="cross-plane substitution"):
+        join_i52_named_lane_identity_v1(
+            live,
+            surface="manifest",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_join_is_deterministic() -> None:
+    first = parse_levelup_manifest_with_identity_join_v1(
+        _manifest_payload(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        run_id=_RUN_ID,
+    ).join.to_canonical_mapping()
+    second = parse_levelup_manifest_with_identity_join_v1(
+        _manifest_payload(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        run_id=_RUN_ID,
+    ).join.to_canonical_mapping()
+    assert first == second
+
+
+def test_named_lane_does_not_mutate_inputs() -> None:
+    raw = _manifest_payload()
+    snapshot = copy.deepcopy(raw)
+    result = parse_levelup_manifest_with_identity_join_v1(
+        raw,
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        historical_provenance={"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID},
+    )
+    raw["title"] = "MUTATED"
+    assert result.contract.title == snapshot["title"]
+    assert dict(raw) != snapshot
+
+
+def test_legacy_experiment_id_and_run_id_remain_non_authoritative() -> None:
+    result = parse_levelup_manifest_with_identity_join_v1(
+        _manifest_payload(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        run_id=_RUN_ID,
+        historical_provenance={"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID},
+    )
+    assert result.join.experiment_identity_id == _PACKAGE_N_SHA256
+    assert result.join.experiment_identity_id != _RUN_ID
+    assert result.join.run_id == _RUN_ID
+    assert dict(result.join.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+
+
+def test_persisted_schema_still_forbids_identity_field() -> None:
+    live = _manifest_payload()
+    live["experiment_identity_id"] = _PACKAGE_N_SHA256
+    with pytest.raises(ValidationError):
+        LevelUpManifestV0.model_validate(live)
+    slice_live = _slice_payload()
+    slice_live["experiment_identity_id"] = _PACKAGE_N_SHA256
+    with pytest.raises(ValidationError):
+        SliceContractV0.model_validate(slice_live)
+
+
+def test_runtime_invariants_remain_unauthorized() -> None:
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+
+
+def test_named_lane_producer_is_hooked_and_forbidden_surfaces_are_not() -> None:
+    join_modules = _imported_modules(JOIN_PATH)
+    assert "src.levelup.i52_levelup_join_attachment_v1" in join_modules
+    assert "src.levelup.v0_models" not in join_modules
+    models_modules = _imported_modules(MODELS_PATH)
+    assert _JOIN_MODULE in models_modules
+    assert not any(
+        mod == "src.execution" or mod.startswith("src.execution.") for mod in models_modules
+    )
+    assert not any(
+        "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in models_modules
+    )
+    assert "src.analytics.explorer" not in models_modules
+    assert "src.ingress.capsules.evidence_capsule" not in models_modules
+    assert "src.live_eval.live_session_eval" not in models_modules
+    assert "src.experiments.base" not in models_modules
+    assert not any(
+        mod == "src.execution" or mod.startswith("src.execution.") for mod in join_modules
+    )
+    join_source = JOIN_PATH.read_text(encoding="utf-8")
+    assert "write_text" not in join_source
+    assert "open(" not in join_source
+    assert "Path(" not in join_source
+    assert "write_manifest" not in join_source
+    assert "read_manifest" not in join_source
+    models_source = MODELS_PATH.read_text(encoding="utf-8")
+    assert "experiment_identity_id" not in models_source
+    assert "i52_levelup_live_contract_join_v1" not in models_source
+    init_source = INIT_PATH.read_text(encoding="utf-8")
+    assert "i52_levelup_named_lane_identity_join_v1" not in init_source
+    io_source = IO_PATH.read_text(encoding="utf-8")
+    cli_source = CLI_PATH.read_text(encoding="utf-8")
+    attachment_source = ATTACHMENT_PATH.read_text(encoding="utf-8")
+    r13_source = R13_PATH.read_text(encoding="utf-8")
+    assert "i52_levelup_named_lane_identity_join_v1" not in io_source
+    assert "i52_levelup_named_lane_identity_join_v1" not in cli_source
+    assert "i52_levelup_named_lane_identity_join_v1" not in attachment_source
+    assert "i52_levelup_named_lane_identity_join_v1" not in r13_source
+    assert _PACKAGE_N_SHA256 not in models_source

--- a/tests/live_eval/test_i61_live_eval_join_attachment_v1.py
+++ b/tests/live_eval/test_i61_live_eval_join_attachment_v1.py
@@ -1,0 +1,252 @@
+"""U-I82-R8 tests for dormant I61 live-eval identity envelope."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+)
+from src.live_eval.i61_live_eval_join_attachment_v1 import (
+    CONTRACT_ID,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    I61LiveEvalJoinAttachmentError,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    attach_i61_live_eval_join_v1,
+)
+from src.live_eval.live_session_eval import Fill, compute_metrics
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ATTACHMENT_PATH = REPO_ROOT / "src" / "live_eval" / "i61_live_eval_join_attachment_v1.py"
+FILL_PATH = REPO_ROOT / "src" / "live_eval" / "live_session_eval.py"
+CLI_PATH = REPO_ROOT / "scripts" / "evaluate_live_session.py"
+
+_PACKAGE_N_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r8-package-n").hexdigest()
+_OTHER_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r8-other").hexdigest()
+_CONTENT_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r8-content").hexdigest()
+_MD5_12 = "abcdef012345"
+_MD5_32 = "d41d8cd98f00b204e9800998ecf8427e"
+_RUN_ID = str(uuid.uuid4())
+_SESSION_ID = "live_eval_fixture_session_non_auth_v1"
+_SESSION_DIR = "evidence/fixtures/live_eval/session_dir"
+
+
+def _i61_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "experiment_identity_id": _PACKAGE_N_SHA256,
+        "session_id": _SESSION_ID,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_canonical_package_n_sha256_happy_path() -> None:
+    record = attach_i61_live_eval_join_v1(_i61_payload())
+    assert CONTRACT_ID == "live_session_eval_identity_envelope_v1"
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.session_id == _SESSION_ID
+    assert record.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert record.plane_presence["SESSION"] == PlanePresence.PRESENT.value
+    assert record.experiment_identity_id != _SESSION_ID
+    assert is_package_n_sha256_canonical_id(record.experiment_identity_id) is True
+
+
+def test_alias_run_campaign_absent_declared_by_default() -> None:
+    record = attach_i61_live_eval_join_v1(_i61_payload())
+    assert record.plane_presence["ALIAS"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["RUN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["CAMPAIGN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["EVIDENCE"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["CONTENT_HASH"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.legacy_alias_md5_12 is None
+    assert record.run_id is None
+    assert record.campaign_id is None
+
+
+def test_session_dir_hint_does_not_populate_session_plane() -> None:
+    payload = {
+        "experiment_identity_id": _PACKAGE_N_SHA256,
+        "session_dir": _SESSION_DIR,
+    }
+    record = attach_i61_live_eval_join_v1(payload)
+    assert record.plane_presence["SESSION"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.session_id is None
+    assert record.experiment_identity_id != _SESSION_DIR
+
+
+def test_explicit_content_sha256_is_content_hash_not_identity() -> None:
+    record = attach_i61_live_eval_join_v1(_i61_payload(content_sha256=_CONTENT_SHA256))
+    assert record.plane_presence["CONTENT_HASH"] == PlanePresence.PRESENT.value
+    assert record.content_sha256 == _CONTENT_SHA256
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.content_sha256 != record.experiment_identity_id
+
+
+def test_implicit_absence_of_identity_rejected() -> None:
+    with pytest.raises(I61LiveEvalJoinAttachmentError, match="IDENTITY missing"):
+        attach_i61_live_eval_join_v1({"session_id": _SESSION_ID, "session_dir": _SESSION_DIR})
+
+
+def test_session_dir_path_as_identity_rejected() -> None:
+    with pytest.raises(I61LiveEvalJoinAttachmentError, match="session-dir path is not identity"):
+        attach_i61_live_eval_join_v1(
+            _i61_payload(experiment_identity_id=_SESSION_DIR, session_dir=_SESSION_DIR)
+        )
+
+
+def test_session_dir_path_as_session_id_rejected() -> None:
+    with pytest.raises(I61LiveEvalJoinAttachmentError, match="session-dir path is not session_id"):
+        attach_i61_live_eval_join_v1(
+            _i61_payload(session_id=_SESSION_DIR, session_dir=_SESSION_DIR)
+        )
+
+
+def test_uuid_run_id_as_identity_rejected() -> None:
+    assert is_package_n_sha256_canonical_id(_RUN_ID) is False
+    with pytest.raises(I61LiveEvalJoinAttachmentError, match="Package-N SHA256"):
+        attach_i61_live_eval_join_v1(_i61_payload(experiment_identity_id=_RUN_ID, run_id=_RUN_ID))
+
+
+def test_legacy_experiment_id_as_identity_rejected() -> None:
+    with pytest.raises(I61LiveEvalJoinAttachmentError, match="forbidden I61 join field"):
+        attach_i61_live_eval_join_v1(_i61_payload(experiment_id=_RUN_ID))
+
+
+def test_md5_as_identity_rejected() -> None:
+    with pytest.raises(I61LiveEvalJoinAttachmentError, match="Package-N SHA256"):
+        attach_i61_live_eval_join_v1(_i61_payload(experiment_identity_id=_MD5_12))
+    with pytest.raises(I61LiveEvalJoinAttachmentError, match="Package-N SHA256"):
+        attach_i61_live_eval_join_v1(_i61_payload(experiment_identity_id=_MD5_32))
+
+
+def test_session_id_must_not_substitute_identity() -> None:
+    with pytest.raises(I61LiveEvalJoinAttachmentError, match="must not substitute"):
+        attach_i61_live_eval_join_v1(_i61_payload(session_id=_PACKAGE_N_SHA256))
+
+
+def test_run_id_must_not_substitute_identity() -> None:
+    with pytest.raises(I61LiveEvalJoinAttachmentError, match="must not substitute"):
+        attach_i61_live_eval_join_v1(_i61_payload(run_id=_PACKAGE_N_SHA256))
+
+
+def test_fill_fields_rejected_from_envelope() -> None:
+    with pytest.raises(I61LiveEvalJoinAttachmentError, match="forbidden I61 join field"):
+        attach_i61_live_eval_join_v1(_i61_payload(fill_price=50000.0))
+    with pytest.raises(I61LiveEvalJoinAttachmentError, match="forbidden I61 join field"):
+        attach_i61_live_eval_join_v1(_i61_payload(fills=[]))
+
+
+def test_conflicting_identity_values_rejected() -> None:
+    with pytest.raises(I61LiveEvalJoinAttachmentError, match="forbidden I61 join field"):
+        attach_i61_live_eval_join_v1(_i61_payload(ref_id=_OTHER_SHA256))
+    with pytest.raises(I61LiveEvalJoinAttachmentError, match="conflicting identities"):
+        attach_i61_live_eval_join_v1(
+            _i61_payload(historical_provenance={"experiment_identity_id": _OTHER_SHA256})
+        )
+
+
+def test_malformed_and_ambiguous_join_rejected() -> None:
+    with pytest.raises(I61LiveEvalJoinAttachmentError, match="must be an object"):
+        attach_i61_live_eval_join_v1("not-an-object")  # type: ignore[arg-type]
+    with pytest.raises(I61LiveEvalJoinAttachmentError, match="unknown I61 join field"):
+        attach_i61_live_eval_join_v1(_i61_payload(authorization_id="not-in-i61-envelope"))
+    with pytest.raises(I61LiveEvalJoinAttachmentError, match="empty or whitespace-padded"):
+        attach_i61_live_eval_join_v1(_i61_payload(experiment_identity_id="   "))
+    with pytest.raises(I61LiveEvalJoinAttachmentError, match="must be a string when present"):
+        attach_i61_live_eval_join_v1(_i61_payload(session_id=123))
+
+
+def test_join_is_deterministic() -> None:
+    payload = _i61_payload(content_sha256=_CONTENT_SHA256, run_id=_RUN_ID)
+    first = attach_i61_live_eval_join_v1(payload).to_canonical_mapping()
+    second = attach_i61_live_eval_join_v1(copy.deepcopy(payload)).to_canonical_mapping()
+    assert first == second
+
+
+def test_attachment_does_not_mutate_inputs() -> None:
+    payload = _i61_payload(
+        historical_provenance={"legacy_session_id": _SESSION_ID, "session_dir": _SESSION_DIR}
+    )
+    snapshot = copy.deepcopy(payload)
+    record = attach_i61_live_eval_join_v1(payload)
+    payload["session_id"] = "MUTATED"
+    payload["historical_provenance"]["legacy_session_id"] = "MUTATED"  # type: ignore[index]
+    assert dict(record.historical_provenance)["legacy_session_id"] == _SESSION_ID
+    assert dict(record.historical_provenance)["session_dir"] == _SESSION_DIR
+    assert payload != snapshot
+
+
+def test_historical_provenance_non_authoritative() -> None:
+    payload = _i61_payload(
+        historical_provenance={"legacy_session_id": _SESSION_ID, "session_dir": _SESSION_DIR}
+    )
+    record = attach_i61_live_eval_join_v1(payload)
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.experiment_identity_id != _SESSION_ID
+    assert record.experiment_identity_id != _SESSION_DIR
+    assert dict(record.historical_provenance)["session_dir"] == _SESSION_DIR
+
+
+def test_fill_only_eval_remains_non_join_and_metrics_still_compute() -> None:
+    fill = Fill(
+        ts=datetime(2025, 1, 15, 10, 0, 0, tzinfo=timezone.utc),
+        symbol="BTC/USD",
+        side="buy",
+        qty=0.1,
+        fill_price=50000.0,
+    )
+    metrics = compute_metrics([fill])
+    assert metrics["total_fills"] == 1
+    assert "experiment_identity_id" not in metrics
+    assert set(fill.__dataclass_fields__) == {"ts", "symbol", "side", "qty", "fill_price"}
+    source = FILL_PATH.read_text(encoding="utf-8")
+    assert "experiment_identity_id" not in source
+
+
+def test_runtime_invariants_remain_unauthorized() -> None:
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_no_runtime_registration_or_forbidden_imports() -> None:
+    modules = _imported_modules(ATTACHMENT_PATH)
+    assert not any(mod == "src.execution" or mod.startswith("src.execution.") for mod in modules)
+    assert not any(
+        "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in modules
+    )
+    assert "src.live_eval.live_session_eval" not in modules
+    assert "src.live_eval.live_session_io" not in modules
+    assert "src.experiments.base" not in modules
+    assert not any("evaluate_live_session" in mod for mod in modules)
+    source = ATTACHMENT_PATH.read_text(encoding="utf-8")
+    assert "open(" not in source
+    assert "compute_metrics" not in source
+    assert "read_fills_csv" not in source
+    cli_source = CLI_PATH.read_text(encoding="utf-8")
+    assert "attach_i61_live_eval_join_v1" not in cli_source
+    assert "experiment_identity_id" not in cli_source

--- a/tests/live_eval/test_i61_live_eval_live_contract_join_v1.py
+++ b/tests/live_eval/test_i61_live_eval_live_contract_join_v1.py
@@ -1,0 +1,365 @@
+"""U-I82-R15 tests for dormant I61 live-contract join registration."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+)
+from src.ingress.capsules.i56_ingress_live_contract_join_v1 import (
+    I56_LIVE_CONTRACT_REGISTERED,
+    is_i56_live_contract_registered,
+)
+from src.levelup.i52_levelup_live_contract_join_v1 import (
+    I52_LIVE_CONTRACT_REGISTERED,
+    is_i52_live_contract_registered,
+)
+from src.live_eval.i61_live_eval_join_attachment_v1 import CONTRACT_ID as R8_CONTRACT_ID
+from src.live_eval.i61_live_eval_live_contract_join_v1 import (
+    CONTRACT_ID,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    I61_LIVE_CONTRACT_REGISTERED,
+    I61LiveEvalLiveContractJoinError,
+    LIVE_CONTRACT_SURFACES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    is_i61_live_contract_registered,
+    register_i61_live_contract_join_v1,
+)
+from src.live_eval.live_session_eval import Fill, compute_metrics
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.i17_paper_shadow_live_contract_join_v1 import (
+    I17_LIVE_CONTRACT_REGISTERED,
+    is_i17_live_contract_registered,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REGISTRATION_PATH = REPO_ROOT / "src" / "live_eval" / "i61_live_eval_live_contract_join_v1.py"
+ATTACHMENT_PATH = REPO_ROOT / "src" / "live_eval" / "i61_live_eval_join_attachment_v1.py"
+EVAL_PATH = REPO_ROOT / "src" / "live_eval" / "live_session_eval.py"
+IO_PATH = REPO_ROOT / "src" / "live_eval" / "live_session_io.py"
+INIT_PATH = REPO_ROOT / "src" / "live_eval" / "__init__.py"
+CLI_PATH = REPO_ROOT / "scripts" / "evaluate_live_session.py"
+I17_REGISTRATION_PATH = (
+    REPO_ROOT
+    / "src"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+    / "i17_paper_shadow_live_contract_join_v1.py"
+)
+I52_REGISTRATION_PATH = REPO_ROOT / "src" / "levelup" / "i52_levelup_live_contract_join_v1.py"
+I56_REGISTRATION_PATH = (
+    REPO_ROOT / "src" / "ingress" / "capsules" / "i56_ingress_live_contract_join_v1.py"
+)
+_LIVE_CONTRACT_FILES = (EVAL_PATH, IO_PATH, INIT_PATH, ATTACHMENT_PATH, CLI_PATH)
+
+_PACKAGE_N_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r15-package-n").hexdigest()
+_OTHER_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r15-other").hexdigest()
+_CONTENT_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r15-content").hexdigest()
+_MD5_12 = "abcdef012345"
+_MD5_32 = "d41d8cd98f00b204e9800998ecf8427e"
+_RUN_ID = str(uuid.uuid4())
+_SESSION_ID = "live_eval_fixture_session_non_auth_v1"
+_SESSION_DIR = "evidence/fixtures/live_eval/session_dir"
+
+
+def _metrics() -> dict[str, object]:
+    return compute_metrics([])
+
+
+def _session() -> dict[str, object]:
+    return {"session_dir": _SESSION_DIR}
+
+
+def _envelope(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "experiment_identity_id": _PACKAGE_N_SHA256,
+        "metrics": _metrics(),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_live_contract_registration_flag_is_reachable() -> None:
+    assert CONTRACT_ID == "i61_live_eval_live_contract_join_v1"
+    assert R8_CONTRACT_ID == "live_session_eval_identity_envelope_v1"
+    assert I61_LIVE_CONTRACT_REGISTERED is True
+    assert is_i61_live_contract_registered() is True
+    assert LIVE_CONTRACT_SURFACES == ("metrics", "session")
+    assert I17_LIVE_CONTRACT_REGISTERED is True
+    assert is_i17_live_contract_registered() is True
+    assert I52_LIVE_CONTRACT_REGISTERED is True
+    assert is_i52_live_contract_registered() is True
+    assert I56_LIVE_CONTRACT_REGISTERED is True
+    assert is_i56_live_contract_registered() is True
+
+
+def test_canonical_package_n_sha256_present_join_from_metrics() -> None:
+    record = register_i61_live_contract_join_v1(_envelope(session_id=_SESSION_ID))
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert is_package_n_sha256_canonical_id(record.experiment_identity_id) is True
+    assert record.session_id == _SESSION_ID
+    assert record.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert record.plane_presence["SESSION"] == PlanePresence.PRESENT.value
+    assert record.experiment_identity_id != _SESSION_ID
+
+
+def test_declared_absence_for_alias_run_campaign_evidence_content_hash() -> None:
+    record = register_i61_live_contract_join_v1(_envelope())
+    assert record.plane_presence["ALIAS"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["RUN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["CAMPAIGN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["SESSION"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["EVIDENCE"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["CONTENT_HASH"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.legacy_alias_md5_12 is None
+    assert record.run_id is None
+    assert record.campaign_id is None
+    assert record.session_id is None
+    assert record.content_sha256 is None
+
+
+def test_session_dir_surface_does_not_populate_session_plane() -> None:
+    record = register_i61_live_contract_join_v1(
+        {
+            "experiment_identity_id": _PACKAGE_N_SHA256,
+            "session": _session(),
+        }
+    )
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.plane_presence["SESSION"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.session_id is None
+    assert record.experiment_identity_id != _SESSION_DIR
+
+
+def test_explicit_content_sha256_is_content_hash_not_identity() -> None:
+    record = register_i61_live_contract_join_v1(_envelope(content_sha256=_CONTENT_SHA256))
+    assert record.plane_presence["CONTENT_HASH"] == PlanePresence.PRESENT.value
+    assert record.content_sha256 == _CONTENT_SHA256
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.content_sha256 != record.experiment_identity_id
+
+
+def test_prior_i61_metrics_still_compute_from_fills() -> None:
+    fill = Fill(
+        ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        symbol="ETH-USD",
+        side="buy",
+        qty=1.0,
+        fill_price=100.0,
+    )
+    metrics = compute_metrics([fill])
+    assert metrics["total_fills"] == 1
+    record = register_i61_live_contract_join_v1(
+        {"experiment_identity_id": _PACKAGE_N_SHA256, "metrics": metrics}
+    )
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+
+
+def test_implicit_absence_of_identity_rejected() -> None:
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="implicit absence rejected"):
+        register_i61_live_contract_join_v1({"metrics": _metrics()})
+
+
+def test_implicit_absence_of_live_surface_rejected() -> None:
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="implicit absence rejected"):
+        register_i61_live_contract_join_v1({"experiment_identity_id": _PACKAGE_N_SHA256})
+
+
+def test_noncanonical_id_substitution_rejected() -> None:
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i61_live_contract_join_v1(_envelope(experiment_identity_id=_RUN_ID))
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i61_live_contract_join_v1(_envelope(experiment_identity_id=_MD5_12))
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i61_live_contract_join_v1(_envelope(experiment_identity_id=_MD5_32))
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i61_live_contract_join_v1(_envelope(experiment_identity_id=_SESSION_DIR))
+
+
+def test_legacy_experiment_id_on_envelope_rejected() -> None:
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i61_live_contract_join_v1(_envelope(experiment_id=_RUN_ID))
+
+
+def test_conflicting_identity_rejected() -> None:
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="conflicting"):
+        register_i61_live_contract_join_v1(
+            _envelope(historical_provenance={"experiment_identity_id": _OTHER_SHA256})
+        )
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="conflicting"):
+        register_i61_live_contract_join_v1(
+            {
+                "experiment_identity_id": _PACKAGE_N_SHA256,
+                "session": _session(),
+                "session_dir": "evidence/fixtures/live_eval/other_session",
+            }
+        )
+
+
+def test_ambiguous_join_rejected() -> None:
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="ambiguous join rejected"):
+        register_i61_live_contract_join_v1(
+            {
+                "experiment_identity_id": _PACKAGE_N_SHA256,
+                "metrics": _metrics(),
+                "session": _session(),
+            }
+        )
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="ambiguous join rejected"):
+        register_i61_live_contract_join_v1(
+            {
+                "experiment_identity_id": _PACKAGE_N_SHA256,
+                "metrics": [_metrics(), copy.deepcopy(_metrics())],
+            }
+        )
+
+
+def test_malformed_plane_data_rejected() -> None:
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="malformed plane data"):
+        register_i61_live_contract_join_v1("not-an-object")  # type: ignore[arg-type]
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="malformed plane data"):
+        register_i61_live_contract_join_v1(
+            {"experiment_identity_id": _PACKAGE_N_SHA256, "metrics": "bad"}
+        )
+    mutated = _metrics()
+    mutated.pop("total_fills")
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="malformed plane data"):
+        register_i61_live_contract_join_v1(_envelope(metrics=mutated))
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="malformed plane data"):
+        register_i61_live_contract_join_v1(
+            {"experiment_identity_id": _PACKAGE_N_SHA256, "session": {"session_dir": "nopath"}}
+        )
+
+
+def test_cross_plane_substitution_rejected() -> None:
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="cross-plane substitution"):
+        register_i61_live_contract_join_v1(_envelope(plane_presence={"IDENTITY": "PRESENT"}))
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="cross-plane substitution"):
+        register_i61_live_contract_join_v1(_envelope(fill_price=50000.0))
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="cross-plane substitution"):
+        register_i61_live_contract_join_v1(_envelope(fills=[]))
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="cross-plane substitution"):
+        register_i61_live_contract_join_v1(_envelope(session_id=_PACKAGE_N_SHA256))
+    live = _metrics()
+    live["fill_price"] = 50000.0
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="cross-plane substitution"):
+        register_i61_live_contract_join_v1(_envelope(metrics=live))
+
+
+def test_cross_lane_substitution_rejected() -> None:
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="cross-lane substitution"):
+        register_i61_live_contract_join_v1(_envelope(I65={"experiment_id": _RUN_ID}))
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="malformed plane data"):
+        register_i61_live_contract_join_v1(
+            {
+                "experiment_identity_id": _PACKAGE_N_SHA256,
+                "metrics": {
+                    "capsule_id": "default.capsule",
+                    "run_id": "default",
+                    "ts_ms": 1000,
+                },
+            }
+        )
+
+
+def test_identity_inside_live_payload_rejected() -> None:
+    live = _metrics()
+    live["experiment_identity_id"] = _PACKAGE_N_SHA256
+    with pytest.raises(I61LiveEvalLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i61_live_contract_join_v1(_envelope(metrics=live))
+
+
+def test_join_is_deterministic() -> None:
+    payload = _envelope(content_sha256=_CONTENT_SHA256, session_id=_SESSION_ID)
+    first = register_i61_live_contract_join_v1(payload).to_canonical_mapping()
+    second = register_i61_live_contract_join_v1(copy.deepcopy(payload)).to_canonical_mapping()
+    assert first == second
+
+
+def test_registration_does_not_mutate_inputs() -> None:
+    payload = _envelope(historical_provenance={"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID})
+    snapshot = copy.deepcopy(payload)
+    record = register_i61_live_contract_join_v1(payload)
+    payload["experiment_identity_id"] = "MUTATED"
+    payload["metrics"]["total_fills"] = 99  # type: ignore[index]
+    payload["historical_provenance"]["legacy_experiment_id"] = "MUTATED"  # type: ignore[index]
+    assert record.experiment_identity_id == snapshot["experiment_identity_id"]
+    assert dict(record.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+    assert payload != snapshot
+
+
+def test_legacy_experiment_id_and_run_id_remain_non_authoritative() -> None:
+    payload = _envelope(
+        run_id=_RUN_ID,
+        historical_provenance={"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID},
+    )
+    record = register_i61_live_contract_join_v1(payload)
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.experiment_identity_id != _RUN_ID
+    assert record.run_id == _RUN_ID
+    assert dict(record.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+
+
+def test_runtime_invariants_remain_unauthorized() -> None:
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_no_cap72_execution_hook_or_persistence() -> None:
+    modules = _imported_modules(REGISTRATION_PATH)
+    assert not any(mod == "src.execution" or mod.startswith("src.execution.") for mod in modules)
+    assert not any(
+        "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in modules
+    )
+    assert "src.experiments.base" not in modules
+    assert "src.live_eval.live_session_io" not in modules
+    assert "src.live_eval.live_session_eval" not in modules
+    assert "src.analytics.explorer" not in modules
+    assert "src.live_eval.i61_live_eval_join_attachment_v1" in modules
+    source = REGISTRATION_PATH.read_text(encoding="utf-8")
+    assert "open(" not in source
+    assert "write_text" not in source
+    assert "Path(" not in source
+    assert "compute_metrics" not in source
+    assert "read_fills_csv" not in source
+    assert "class Fill" not in source
+
+
+def test_live_contracts_and_prior_registrations_remain_unhooked() -> None:
+    for path in _LIVE_CONTRACT_FILES:
+        source = path.read_text(encoding="utf-8")
+        assert "register_i61_live_contract_join_v1" not in source
+        assert "i61_live_eval_live_contract_join_v1" not in source
+    eval_src = EVAL_PATH.read_text(encoding="utf-8")
+    assert "experiment_identity_id" not in eval_src
+    assert "class Fill:" in eval_src
+    for prior in (I17_REGISTRATION_PATH, I52_REGISTRATION_PATH, I56_REGISTRATION_PATH):
+        source = prior.read_text(encoding="utf-8")
+        assert "i61_live_eval_live_contract_join_v1" not in source
+        assert "I61_LIVE_CONTRACT_REGISTERED = True" not in source

--- a/tests/live_eval/test_i61_live_eval_named_lane_identity_join_v1.py
+++ b/tests/live_eval/test_i61_live_eval_named_lane_identity_join_v1.py
@@ -1,0 +1,443 @@
+"""U-I82-R22 tests for I61 named-lane IDENTITY join on live session eval."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+)
+from src.live_eval.i61_live_eval_join_attachment_v1 import CONTRACT_ID as R8_CONTRACT_ID
+from src.live_eval.i61_live_eval_named_lane_identity_join_v1 import (
+    CONTRACT_ID,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    I61_NAMED_LANE_IDENTITY_JOIN_REGISTERED,
+    I61LiveEvalNamedLaneIdentityJoinError,
+    LIVE_CONTRACT_SURFACES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    is_i61_named_lane_identity_join_registered,
+    join_i61_named_lane_identity_v1,
+)
+from src.live_eval.live_session_eval import (
+    Fill,
+    compute_metrics,
+    parse_live_session_dir_with_identity_join_v1,
+    parse_live_session_metrics_with_identity_join_v1,
+)
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+JOIN_PATH = REPO_ROOT / "src" / "live_eval" / "i61_live_eval_named_lane_identity_join_v1.py"
+ATTACHMENT_PATH = REPO_ROOT / "src" / "live_eval" / "i61_live_eval_join_attachment_v1.py"
+EVAL_PATH = REPO_ROOT / "src" / "live_eval" / "live_session_eval.py"
+IO_PATH = REPO_ROOT / "src" / "live_eval" / "live_session_io.py"
+INIT_PATH = REPO_ROOT / "src" / "live_eval" / "__init__.py"
+CLI_PATH = REPO_ROOT / "scripts" / "evaluate_live_session.py"
+R15_PATH = REPO_ROOT / "src" / "live_eval" / "i61_live_eval_live_contract_join_v1.py"
+_JOIN_MODULE = "src.live_eval.i61_live_eval_named_lane_identity_join_v1"
+
+_PACKAGE_N_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r22-package-n").hexdigest()
+_OTHER_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r22-other").hexdigest()
+_CONTENT_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r22-content").hexdigest()
+_MD5_12 = "abcdef012345"
+_MD5_32 = "d41d8cd98f00b204e9800998ecf8427e"
+_RUN_ID = str(uuid.uuid4())
+_CAMPAIGN_ID = "campaign-i61-r22"
+_SESSION_ID = "live_eval_fixture_session_non_auth_v1"
+_SESSION_DIR = "evidence/fixtures/live_eval/session_dir"
+_EVIDENCE_REF = "eval-evidence-i61-r22"
+
+
+def _metrics() -> dict[str, object]:
+    return compute_metrics([])
+
+
+def _session() -> dict[str, object]:
+    return {"session_dir": _SESSION_DIR}
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_named_lane_identity_join_is_registered_and_reachable() -> None:
+    assert CONTRACT_ID == "i61_live_eval_named_lane_identity_join_v1"
+    assert R8_CONTRACT_ID == "live_session_eval_identity_envelope_v1"
+    assert I61_NAMED_LANE_IDENTITY_JOIN_REGISTERED is True
+    assert is_i61_named_lane_identity_join_registered() is True
+    assert LIVE_CONTRACT_SURFACES == ("metrics", "session")
+
+
+def test_named_metrics_producer_attaches_identity() -> None:
+    result = parse_live_session_metrics_with_identity_join_v1(
+        _metrics(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.experiment_identity_id == _PACKAGE_N_SHA256
+    assert is_package_n_sha256_canonical_id(result.join.experiment_identity_id) is True
+    assert result.join.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["SESSION"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.contract["total_fills"] == 0
+    assert "experiment_identity_id" not in result.contract
+    assert result.join.experiment_identity_id != _SESSION_DIR
+
+
+def test_declared_absence_for_alias_run_campaign_session_evidence_content_hash() -> None:
+    result = parse_live_session_metrics_with_identity_join_v1(
+        _metrics(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.plane_presence["ALIAS"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["RUN"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["CAMPAIGN"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["SESSION"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["EVIDENCE"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["CONTENT_HASH"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.legacy_alias_md5_12 is None
+    assert result.join.run_id is None
+    assert result.join.campaign_id is None
+    assert result.join.session_id is None
+    assert result.join.content_sha256 is None
+
+
+def test_present_sidecars_are_joined_and_not_identity() -> None:
+    result = parse_live_session_metrics_with_identity_join_v1(
+        _metrics(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        run_id=_RUN_ID,
+        campaign_id=_CAMPAIGN_ID,
+        session_id=_SESSION_ID,
+        legacy_alias_md5_12=_MD5_12,
+        content_sha256=_CONTENT_SHA256,
+        evidence_ref=_EVIDENCE_REF,
+    )
+    assert result.join.plane_presence["RUN"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["CAMPAIGN"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["SESSION"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["ALIAS"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["CONTENT_HASH"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["EVIDENCE"] == PlanePresence.PRESENT.value
+    assert result.join.run_id == _RUN_ID
+    assert result.join.campaign_id == _CAMPAIGN_ID
+    assert result.join.session_id == _SESSION_ID
+    assert result.join.legacy_alias_md5_12 == _MD5_12
+    assert result.join.content_sha256 == _CONTENT_SHA256
+    assert result.join.evidence_ref == _EVIDENCE_REF
+    assert result.join.experiment_identity_id != _RUN_ID
+    assert result.join.experiment_identity_id != _CAMPAIGN_ID
+    assert result.join.experiment_identity_id != _SESSION_ID
+    assert result.join.experiment_identity_id != _MD5_12
+    assert result.join.experiment_identity_id != _CONTENT_SHA256
+    assert result.join.experiment_identity_id != _EVIDENCE_REF
+
+
+def test_session_dir_named_lane_does_not_populate_session_plane() -> None:
+    result = parse_live_session_dir_with_identity_join_v1(
+        _session(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.experiment_identity_id == _PACKAGE_N_SHA256
+    assert result.join.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["SESSION"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.session_id is None
+    assert result.contract["session_dir"] == _SESSION_DIR
+    assert result.join.experiment_identity_id != _SESSION_DIR
+
+
+def test_session_dir_with_explicit_session_id_keeps_planes_distinct() -> None:
+    result = parse_live_session_dir_with_identity_join_v1(
+        _session(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        session_id=_SESSION_ID,
+    )
+    assert result.join.session_id == _SESSION_ID
+    assert result.join.plane_presence["SESSION"] == PlanePresence.PRESENT.value
+    assert result.join.experiment_identity_id != _SESSION_ID
+    assert result.join.experiment_identity_id != _SESSION_DIR
+    assert result.contract["session_dir"] == _SESSION_DIR
+
+
+def test_fill_metrics_still_compute_without_identity() -> None:
+    fill = Fill(
+        ts=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        symbol="ETH-USD",
+        side="buy",
+        qty=1.0,
+        fill_price=100.0,
+    )
+    metrics = compute_metrics([fill])
+    assert metrics["total_fills"] == 1
+    assert "experiment_identity_id" not in metrics
+    assert set(fill.__dataclass_fields__) == {"ts", "symbol", "side", "qty", "fill_price"}
+    result = parse_live_session_metrics_with_identity_join_v1(
+        metrics,
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.experiment_identity_id == _PACKAGE_N_SHA256
+    assert result.contract["total_fills"] == 1
+    assert "experiment_identity_id" not in result.contract
+
+
+def test_implicit_absence_of_identity_rejected() -> None:
+    with pytest.raises(I61LiveEvalNamedLaneIdentityJoinError, match="implicit absence rejected"):
+        parse_live_session_metrics_with_identity_join_v1(_metrics())
+
+
+def test_noncanonical_id_substitution_rejected() -> None:
+    with pytest.raises(I61LiveEvalNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        parse_live_session_metrics_with_identity_join_v1(
+            _metrics(),
+            experiment_identity_id=_RUN_ID,
+        )
+    with pytest.raises(I61LiveEvalNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        parse_live_session_metrics_with_identity_join_v1(
+            _metrics(),
+            experiment_identity_id=_MD5_12,
+        )
+    with pytest.raises(I61LiveEvalNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        parse_live_session_metrics_with_identity_join_v1(
+            _metrics(),
+            experiment_identity_id=_MD5_32,
+        )
+    with pytest.raises(I61LiveEvalNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        parse_live_session_metrics_with_identity_join_v1(
+            _metrics(),
+            experiment_identity_id=_SESSION_DIR,
+        )
+    with pytest.raises(I61LiveEvalNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        parse_live_session_metrics_with_identity_join_v1(
+            _metrics(),
+            experiment_identity_id=_SESSION_ID,
+        )
+
+
+def test_session_dir_and_session_id_must_not_substitute_identity() -> None:
+    with pytest.raises(I61LiveEvalNamedLaneIdentityJoinError, match="cross-plane substitution"):
+        parse_live_session_dir_with_identity_join_v1(
+            _session(),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            session_id=_PACKAGE_N_SHA256,
+        )
+    with pytest.raises(I61LiveEvalNamedLaneIdentityJoinError, match="cross-plane substitution"):
+        parse_live_session_dir_with_identity_join_v1(
+            _session(),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            session_id=_SESSION_DIR,
+        )
+    with pytest.raises(I61LiveEvalNamedLaneIdentityJoinError, match="cross-plane substitution"):
+        parse_live_session_metrics_with_identity_join_v1(
+            _metrics(),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            run_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_identity_inside_live_payload_rejected() -> None:
+    live = _metrics()
+    live["experiment_identity_id"] = _PACKAGE_N_SHA256
+    with pytest.raises(I61LiveEvalNamedLaneIdentityJoinError, match="noncanonical ID substitution"):
+        join_i61_named_lane_identity_v1(
+            live,
+            surface="metrics",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_conflicting_identity_rejected() -> None:
+    with pytest.raises(I61LiveEvalNamedLaneIdentityJoinError, match="conflicting"):
+        parse_live_session_metrics_with_identity_join_v1(
+            _metrics(),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            historical_provenance={"experiment_identity_id": _OTHER_SHA256},
+        )
+    with pytest.raises(I61LiveEvalNamedLaneIdentityJoinError, match="conflicting"):
+        parse_live_session_dir_with_identity_join_v1(
+            _session(),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            session_dir="evidence/fixtures/live_eval/other_session",
+        )
+
+
+def test_ambiguous_join_rejected() -> None:
+    with pytest.raises(I61LiveEvalNamedLaneIdentityJoinError, match="ambiguous join rejected"):
+        join_i61_named_lane_identity_v1(
+            [_metrics(), copy.deepcopy(_metrics())],
+            surface="metrics",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_malformed_plane_data_rejected() -> None:
+    with pytest.raises(I61LiveEvalNamedLaneIdentityJoinError, match="malformed plane data"):
+        join_i61_named_lane_identity_v1(
+            "not-an-object",  # type: ignore[arg-type]
+            surface="metrics",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+    with pytest.raises(I61LiveEvalNamedLaneIdentityJoinError, match="malformed plane data"):
+        parse_live_session_metrics_with_identity_join_v1(
+            _metrics(),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            session_id="   ",
+        )
+    mutated = _metrics()
+    mutated.pop("total_fills")
+    with pytest.raises(I61LiveEvalNamedLaneIdentityJoinError, match="malformed plane data"):
+        parse_live_session_metrics_with_identity_join_v1(
+            mutated,
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+    with pytest.raises(I61LiveEvalNamedLaneIdentityJoinError, match="malformed plane data"):
+        parse_live_session_dir_with_identity_join_v1(
+            {"session_dir": "nopath"},
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_cross_lane_substitution_rejected() -> None:
+    live = _metrics()
+    live["I56"] = {"capsule_id": "default.capsule"}
+    with pytest.raises(I61LiveEvalNamedLaneIdentityJoinError, match="cross-lane substitution"):
+        join_i61_named_lane_identity_v1(
+            live,
+            surface="metrics",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_cross_plane_substitution_rejected() -> None:
+    live = _metrics()
+    live["plane_presence"] = {"IDENTITY": "PRESENT"}
+    with pytest.raises(I61LiveEvalNamedLaneIdentityJoinError, match="cross-plane substitution"):
+        join_i61_named_lane_identity_v1(
+            live,
+            surface="metrics",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+    live_fill = _metrics()
+    live_fill["fill_price"] = 50000.0
+    with pytest.raises(I61LiveEvalNamedLaneIdentityJoinError, match="cross-plane substitution"):
+        join_i61_named_lane_identity_v1(
+            live_fill,
+            surface="metrics",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+    live_fills = _metrics()
+    live_fills["fills"] = []
+    with pytest.raises(I61LiveEvalNamedLaneIdentityJoinError, match="cross-plane substitution"):
+        join_i61_named_lane_identity_v1(
+            live_fills,
+            surface="metrics",
+            experiment_identity_id=_PACKAGE_N_SHA256,
+        )
+
+
+def test_join_is_deterministic() -> None:
+    first = parse_live_session_metrics_with_identity_join_v1(
+        _metrics(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        session_id=_SESSION_ID,
+        content_sha256=_CONTENT_SHA256,
+    ).join.to_canonical_mapping()
+    second = parse_live_session_metrics_with_identity_join_v1(
+        _metrics(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        session_id=_SESSION_ID,
+        content_sha256=_CONTENT_SHA256,
+    ).join.to_canonical_mapping()
+    assert first == second
+
+
+def test_named_lane_does_not_mutate_inputs() -> None:
+    raw = _metrics()
+    snapshot = copy.deepcopy(raw)
+    result = parse_live_session_metrics_with_identity_join_v1(
+        raw,
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        historical_provenance={"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID},
+    )
+    raw["total_fills"] = 99
+    assert result.contract["total_fills"] == snapshot["total_fills"]
+    assert dict(raw) != snapshot
+
+
+def test_legacy_experiment_id_and_run_id_remain_non_authoritative() -> None:
+    result = parse_live_session_metrics_with_identity_join_v1(
+        _metrics(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        run_id=_RUN_ID,
+        historical_provenance={"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID},
+    )
+    assert result.join.experiment_identity_id == _PACKAGE_N_SHA256
+    assert result.join.experiment_identity_id != _RUN_ID
+    assert result.join.run_id == _RUN_ID
+    assert dict(result.join.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+
+
+def test_runtime_invariants_remain_unauthorized() -> None:
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+
+
+def test_named_lane_producer_is_hooked_and_forbidden_surfaces_are_not() -> None:
+    join_modules = _imported_modules(JOIN_PATH)
+    assert "src.live_eval.i61_live_eval_join_attachment_v1" in join_modules
+    assert "src.live_eval.live_session_eval" not in join_modules
+    assert "src.live_eval.live_session_io" not in join_modules
+    eval_modules = _imported_modules(EVAL_PATH)
+    assert _JOIN_MODULE in eval_modules
+    assert not any(
+        mod == "src.execution" or mod.startswith("src.execution.") for mod in eval_modules
+    )
+    assert not any(
+        "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in eval_modules
+    )
+    assert "src.analytics.explorer" not in eval_modules
+    assert "src.ingress.capsules.evidence_capsule" not in eval_modules
+    assert "src.experiments.base" not in eval_modules
+    assert not any(
+        mod == "src.execution" or mod.startswith("src.execution.") for mod in join_modules
+    )
+    join_source = JOIN_PATH.read_text(encoding="utf-8")
+    assert "write_text" not in join_source
+    assert "open(" not in join_source
+    assert "Path(" not in join_source
+    assert "compute_metrics" not in join_source
+    assert "read_fills_csv" not in join_source
+    assert "class Fill" not in join_source
+    eval_source = EVAL_PATH.read_text(encoding="utf-8")
+    assert "experiment_identity_id" not in eval_source
+    assert "i61_live_eval_live_contract_join_v1" not in eval_source
+    assert "class Fill:" in eval_source
+    init_source = INIT_PATH.read_text(encoding="utf-8")
+    io_source = IO_PATH.read_text(encoding="utf-8")
+    cli_source = CLI_PATH.read_text(encoding="utf-8")
+    attachment_source = ATTACHMENT_PATH.read_text(encoding="utf-8")
+    r15_source = R15_PATH.read_text(encoding="utf-8")
+    assert "i61_live_eval_named_lane_identity_join_v1" not in init_source
+    assert "i61_live_eval_named_lane_identity_join_v1" not in io_source
+    assert "i61_live_eval_named_lane_identity_join_v1" not in cli_source
+    assert "i61_live_eval_named_lane_identity_join_v1" not in attachment_source
+    assert "i61_live_eval_named_lane_identity_join_v1" not in r15_source
+    assert _PACKAGE_N_SHA256 not in eval_source
+    assert "experiment_identity_id" not in cli_source

--- a/tests/ops/test_i17_paper_shadow_join_attachment_v1.py
+++ b/tests/ops/test_i17_paper_shadow_join_attachment_v1.py
@@ -1,0 +1,238 @@
+"""U-I82-R5 tests for dormant I17 paper-shadow join attachment."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import uuid
+from pathlib import Path
+
+import pytest
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+)
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.i17_paper_shadow_join_attachment_v1 import (
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    I17PaperShadowJoinAttachmentError,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    attach_i17_paper_shadow_join_v1,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ATTACHMENT_PATH = (
+    REPO_ROOT
+    / "src"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+    / "i17_paper_shadow_join_attachment_v1.py"
+)
+
+_PACKAGE_N_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r5-package-n").hexdigest()
+_OTHER_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r5-other").hexdigest()
+_CONTENT_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r5-content").hexdigest()
+_MD5_12 = "abcdef012345"
+_MD5_32 = "d41d8cd98f00b204e9800998ecf8427e"
+_RUN_ID = str(uuid.uuid4())
+_SESSION_ID = "pso_fixture_session_non_auth_v1"
+_GIT_SHA = "cd1bd6fa40d664c22b3f6abeef3cc00cdda72688"
+
+
+def _i17_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "experiment_identity_id": _PACKAGE_N_SHA256,
+        "session_id": _SESSION_ID,
+        "evidence_root": "evidence/fixtures/paper_shadow_observation_non_authoritative_v1",
+        "config_identity": "config/ops/integrated_paper_shadow_observation_session_v1.toml",
+        "code_identity": "src/ops/integrated_paper_shadow_observation_session_v1/",
+        "expected_repository_sha": _GIT_SHA,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_canonical_package_n_sha256_happy_path() -> None:
+    record = attach_i17_paper_shadow_join_v1(_i17_payload())
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.session_id == _SESSION_ID
+    assert record.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert record.plane_presence["SESSION"] == PlanePresence.PRESENT.value
+    assert record.plane_presence["EVIDENCE"] == PlanePresence.PRESENT.value
+    assert record.experiment_identity_id != _SESSION_ID
+    assert is_package_n_sha256_canonical_id(record.experiment_identity_id) is True
+
+
+def test_alias_run_campaign_absent_declared_by_default() -> None:
+    record = attach_i17_paper_shadow_join_v1(_i17_payload())
+    assert record.plane_presence["ALIAS"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["RUN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["CAMPAIGN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.legacy_alias_md5_12 is None
+    assert record.run_id is None
+    assert record.campaign_id is None
+
+
+def test_content_hash_absent_declared_without_explicit_sha256() -> None:
+    record = attach_i17_paper_shadow_join_v1(_i17_payload())
+    assert record.plane_presence["CONTENT_HASH"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.content_sha256 is None
+
+
+def test_explicit_content_sha256_is_content_hash_not_identity() -> None:
+    record = attach_i17_paper_shadow_join_v1(_i17_payload(content_sha256=_CONTENT_SHA256))
+    assert record.plane_presence["CONTENT_HASH"] == PlanePresence.PRESENT.value
+    assert record.content_sha256 == _CONTENT_SHA256
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.content_sha256 != record.experiment_identity_id
+
+
+def test_missing_identity_rejected() -> None:
+    with pytest.raises(I17PaperShadowJoinAttachmentError, match="IDENTITY missing"):
+        attach_i17_paper_shadow_join_v1({"session_id": _SESSION_ID})
+
+
+def test_missing_session_id_rejected() -> None:
+    with pytest.raises(I17PaperShadowJoinAttachmentError, match="SESSION missing"):
+        attach_i17_paper_shadow_join_v1({"experiment_identity_id": _PACKAGE_N_SHA256})
+
+
+def test_uuid_run_id_as_identity_rejected() -> None:
+    assert is_package_n_sha256_canonical_id(_RUN_ID) is False
+    with pytest.raises(I17PaperShadowJoinAttachmentError, match="Package-N SHA256"):
+        attach_i17_paper_shadow_join_v1(
+            _i17_payload(experiment_identity_id=_RUN_ID, run_id=_RUN_ID)
+        )
+
+
+def test_legacy_experiment_id_as_identity_rejected() -> None:
+    with pytest.raises(I17PaperShadowJoinAttachmentError, match="forbidden I17 join field"):
+        attach_i17_paper_shadow_join_v1(_i17_payload(experiment_id=_RUN_ID))
+
+
+def test_md5_as_identity_rejected() -> None:
+    with pytest.raises(I17PaperShadowJoinAttachmentError, match="Package-N SHA256"):
+        attach_i17_paper_shadow_join_v1(_i17_payload(experiment_identity_id=_MD5_12))
+    with pytest.raises(I17PaperShadowJoinAttachmentError, match="Package-N SHA256"):
+        attach_i17_paper_shadow_join_v1(_i17_payload(experiment_identity_id=_MD5_32))
+
+
+def test_git_sha_as_identity_rejected() -> None:
+    with pytest.raises(I17PaperShadowJoinAttachmentError, match="Package-N SHA256"):
+        attach_i17_paper_shadow_join_v1(_i17_payload(experiment_identity_id=_GIT_SHA))
+
+
+def test_session_id_must_not_substitute_identity() -> None:
+    with pytest.raises(I17PaperShadowJoinAttachmentError, match="must not substitute"):
+        attach_i17_paper_shadow_join_v1(_i17_payload(session_id=_PACKAGE_N_SHA256))
+
+
+def test_expected_repository_sha_must_not_substitute_identity() -> None:
+    with pytest.raises(I17PaperShadowJoinAttachmentError, match="must not substitute"):
+        attach_i17_paper_shadow_join_v1(_i17_payload(expected_repository_sha=_PACKAGE_N_SHA256))
+
+
+def test_campaign_id_extra_forbid_rejected() -> None:
+    with pytest.raises(I17PaperShadowJoinAttachmentError, match="forbidden I17 join field"):
+        attach_i17_paper_shadow_join_v1(_i17_payload(campaign_id="cap11-campaign"))
+
+
+def test_conflicting_content_hash_values_rejected() -> None:
+    with pytest.raises(I17PaperShadowJoinAttachmentError, match="conflicting CONTENT_HASH"):
+        attach_i17_paper_shadow_join_v1(
+            _i17_payload(content_sha256=_CONTENT_SHA256, scope_digest=_OTHER_SHA256)
+        )
+
+
+def test_conflicting_evidence_values_rejected() -> None:
+    with pytest.raises(I17PaperShadowJoinAttachmentError, match="conflicting EVIDENCE"):
+        attach_i17_paper_shadow_join_v1(
+            _i17_payload(evidence_ref="evidence/a", evidence_root="evidence/b")
+        )
+
+
+def test_conflicting_identity_values_rejected() -> None:
+    with pytest.raises(I17PaperShadowJoinAttachmentError, match="forbidden I17 join field"):
+        attach_i17_paper_shadow_join_v1(_i17_payload(ref_id=_OTHER_SHA256))
+    with pytest.raises(I17PaperShadowJoinAttachmentError, match="conflicting identities"):
+        attach_i17_paper_shadow_join_v1(
+            _i17_payload(historical_provenance={"experiment_identity_id": _OTHER_SHA256})
+        )
+
+
+def test_join_is_deterministic() -> None:
+    payload = _i17_payload(content_sha256=_CONTENT_SHA256)
+    first = attach_i17_paper_shadow_join_v1(payload).to_canonical_mapping()
+    second = attach_i17_paper_shadow_join_v1(copy.deepcopy(payload)).to_canonical_mapping()
+    assert first == second
+
+
+def test_attachment_does_not_mutate_inputs() -> None:
+    payload = _i17_payload(
+        historical_provenance={"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID}
+    )
+    snapshot = copy.deepcopy(payload)
+    record = attach_i17_paper_shadow_join_v1(payload)
+    payload["session_id"] = "MUTATED"
+    payload["historical_provenance"]["legacy_experiment_id"] = "MUTATED"  # type: ignore[index]
+    assert record.session_id == snapshot["session_id"]
+    assert dict(record.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+    assert payload != snapshot
+
+
+def test_historical_provenance_non_authoritative() -> None:
+    payload = _i17_payload(
+        historical_provenance={"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID}
+    )
+    record = attach_i17_paper_shadow_join_v1(payload)
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.experiment_identity_id != _RUN_ID
+    assert dict(record.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+
+
+def test_runtime_invariants_remain_unauthorized() -> None:
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_no_runtime_registration_or_forbidden_imports() -> None:
+    modules = _imported_modules(ATTACHMENT_PATH)
+    assert not any(mod == "src.execution" or mod.startswith("src.execution.") for mod in modules)
+    assert not any(
+        "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in modules
+    )
+    assert (
+        "src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.preregistration_contract_v1"
+        not in modules
+    )
+    assert (
+        "src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.operator_go_contract_v1"
+        not in modules
+    )
+    assert (
+        "src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.authorization_artifact_v1"
+        not in modules
+    )
+    assert "src.experiments.base" not in modules
+    source = ATTACHMENT_PATH.read_text(encoding="utf-8")
+    assert "open(" not in source
+    assert "validate_preregistration_contract_v1" not in source
+    assert "build_authorization_artifact_v1" not in source

--- a/tests/ops/test_i17_paper_shadow_live_contract_join_v1.py
+++ b/tests/ops/test_i17_paper_shadow_live_contract_join_v1.py
@@ -1,0 +1,401 @@
+"""U-I82-R12 tests for dormant I17 live-contract join registration."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+)
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.authorization_artifact_v1 import (
+    build_authorization_artifact_v1,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.i17_paper_shadow_live_contract_join_v1 import (
+    CONTRACT_ID,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    I17_LIVE_CONTRACT_REGISTERED,
+    I17PaperShadowLiveContractJoinError,
+    LIVE_CONTRACT_SURFACES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    is_i17_live_contract_registered,
+    register_i17_live_contract_join_v1,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.operator_go_contract_v1 import (
+    load_operator_go_contract_dict_v1,
+    parse_operator_go_contract_v1,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.preregistration_contract_v1 import (
+    load_preregistration_contract_dict_v1,
+    parse_preregistration_contract_v1,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REGISTRATION_PATH = (
+    REPO_ROOT
+    / "src"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+    / "i17_paper_shadow_live_contract_join_v1.py"
+)
+ATTACHMENT_PATH = (
+    REPO_ROOT
+    / "src"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+    / "i17_paper_shadow_join_attachment_v1.py"
+)
+PREREG_PATH = (
+    REPO_ROOT
+    / "src"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+    / "preregistration_contract_v1.py"
+)
+GO_PATH = (
+    REPO_ROOT
+    / "src"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+    / "operator_go_contract_v1.py"
+)
+ARTIFACT_PATH = (
+    REPO_ROOT
+    / "src"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+    / "authorization_artifact_v1.py"
+)
+INIT_PATH = (
+    REPO_ROOT
+    / "src"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+    / "__init__.py"
+)
+FIX = (
+    REPO_ROOT
+    / "tests"
+    / "fixtures"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+)
+
+_PACKAGE_N_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r12-package-n").hexdigest()
+_OTHER_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r12-other").hexdigest()
+_CONTENT_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r12-content").hexdigest()
+_MD5_12 = "abcdef012345"
+_MD5_32 = "d41d8cd98f00b204e9800998ecf8427e"
+_RUN_ID = str(uuid.uuid4())
+_GIT_SHA = "cd1bd6fa40d664c22b3f6abeef3cc00cdda72688"
+_LIVE_CONTRACT_FILES = (PREREG_PATH, GO_PATH, ARTIFACT_PATH, INIT_PATH, ATTACHMENT_PATH)
+
+
+def _prereg() -> dict[str, object]:
+    return load_preregistration_contract_dict_v1(
+        FIX / "preregistration_valid_non_authoritative.json"
+    )
+
+
+def _go() -> dict[str, object]:
+    raw = load_operator_go_contract_dict_v1(FIX / "operator_go_valid_non_authoritative.json")
+    if "session_execution_authorized" not in raw:
+        raw["session_execution_authorized"] = False
+    return raw
+
+
+def _artifact() -> dict[str, object]:
+    prereg = parse_preregistration_contract_v1(_prereg())
+    go = parse_operator_go_contract_v1(_go())
+    material = "GO_PSO_SESSION_PREREG_V1_" + "FIXTURE_NON_AUTHORITATIVE_" + "MATERIAL_9F3A"
+    built = build_authorization_artifact_v1(
+        prereg=prereg,
+        go=go,
+        confirm_token=material,
+        authorization_id="auth_fixture_v1",
+        now_unix=1_700_000_000.0,
+    )
+    assert built.ok and built.artifact is not None
+    return built.artifact.to_dict()
+
+
+def _envelope(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "experiment_identity_id": _PACKAGE_N_SHA256,
+        "preregistration": _prereg(),
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_live_contract_registration_flag_is_reachable() -> None:
+    assert CONTRACT_ID == "i17_paper_shadow_live_contract_join_v1"
+    assert I17_LIVE_CONTRACT_REGISTERED is True
+    assert is_i17_live_contract_registered() is True
+    assert LIVE_CONTRACT_SURFACES == (
+        "preregistration",
+        "operator_go",
+        "authorization_artifact",
+    )
+
+
+def test_canonical_package_n_sha256_present_join_from_prereg() -> None:
+    record = register_i17_live_contract_join_v1(_envelope())
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert is_package_n_sha256_canonical_id(record.experiment_identity_id) is True
+    assert record.session_id == "pso_fixture_session_non_auth_v1"
+    assert record.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert record.plane_presence["SESSION"] == PlanePresence.PRESENT.value
+    assert record.plane_presence["EVIDENCE"] == PlanePresence.PRESENT.value
+    assert record.experiment_identity_id != record.session_id
+
+
+def test_declared_absence_for_alias_run_campaign_content_hash() -> None:
+    record = register_i17_live_contract_join_v1(_envelope())
+    assert record.plane_presence["ALIAS"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["RUN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["CAMPAIGN"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["CONTENT_HASH"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.legacy_alias_md5_12 is None
+    assert record.run_id is None
+    assert record.campaign_id is None
+    assert record.content_sha256 is None
+
+
+def test_operator_go_present_join_uses_explicit_scope_digest_as_content_hash() -> None:
+    record = register_i17_live_contract_join_v1(
+        {
+            "experiment_identity_id": _PACKAGE_N_SHA256,
+            "operator_go": _go(),
+        }
+    )
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.session_id == "pso_fixture_session_non_auth_v1"
+    assert record.plane_presence["SESSION"] == PlanePresence.PRESENT.value
+    assert record.plane_presence["EVIDENCE"] == PlanePresence.ABSENT_DECLARED.value
+    assert record.plane_presence["CONTENT_HASH"] == PlanePresence.PRESENT.value
+    assert record.content_sha256 == _go()["scope_digest"]
+    assert record.content_sha256 != record.experiment_identity_id
+
+
+def test_authorization_artifact_present_join() -> None:
+    artifact = _artifact()
+    record = register_i17_live_contract_join_v1(
+        {
+            "experiment_identity_id": _PACKAGE_N_SHA256,
+            "authorization_artifact": artifact,
+        }
+    )
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.session_id == artifact["session_id"]
+    assert record.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert record.plane_presence["SESSION"] == PlanePresence.PRESENT.value
+
+
+def test_explicit_declared_run_and_alias_remain_non_authoritative() -> None:
+    record = register_i17_live_contract_join_v1(
+        _envelope(run_id=_RUN_ID, legacy_alias_md5_12=_MD5_12)
+    )
+    assert record.run_id == _RUN_ID
+    assert record.legacy_alias_md5_12 == _MD5_12
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.experiment_identity_id != _RUN_ID
+    assert record.experiment_identity_id != _MD5_12
+
+
+def test_implicit_absence_of_identity_rejected() -> None:
+    with pytest.raises(I17PaperShadowLiveContractJoinError, match="implicit absence rejected"):
+        register_i17_live_contract_join_v1({"preregistration": _prereg()})
+
+
+def test_implicit_absence_of_live_surface_rejected() -> None:
+    with pytest.raises(I17PaperShadowLiveContractJoinError, match="implicit absence rejected"):
+        register_i17_live_contract_join_v1({"experiment_identity_id": _PACKAGE_N_SHA256})
+
+
+def test_noncanonical_id_substitution_rejected() -> None:
+    with pytest.raises(I17PaperShadowLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i17_live_contract_join_v1(_envelope(experiment_identity_id=_RUN_ID))
+    with pytest.raises(I17PaperShadowLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i17_live_contract_join_v1(_envelope(experiment_identity_id=_MD5_12))
+    with pytest.raises(I17PaperShadowLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i17_live_contract_join_v1(_envelope(experiment_identity_id=_MD5_32))
+    with pytest.raises(I17PaperShadowLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i17_live_contract_join_v1(_envelope(experiment_identity_id=_GIT_SHA))
+
+
+def test_legacy_experiment_id_and_session_id_on_envelope_rejected() -> None:
+    with pytest.raises(I17PaperShadowLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i17_live_contract_join_v1(_envelope(experiment_id=_RUN_ID))
+    with pytest.raises(I17PaperShadowLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i17_live_contract_join_v1(_envelope(session_id="pso_fixture_session_non_auth_v1"))
+
+
+def test_conflicting_identity_rejected() -> None:
+    with pytest.raises(I17PaperShadowLiveContractJoinError, match="conflicting"):
+        register_i17_live_contract_join_v1(
+            _envelope(historical_provenance={"experiment_identity_id": _OTHER_SHA256})
+        )
+    with pytest.raises(I17PaperShadowLiveContractJoinError, match="conflicting"):
+        register_i17_live_contract_join_v1(_envelope(evidence_ref="evidence/other"))
+
+
+def test_ambiguous_join_rejected() -> None:
+    with pytest.raises(I17PaperShadowLiveContractJoinError, match="ambiguous join rejected"):
+        register_i17_live_contract_join_v1(
+            {
+                "experiment_identity_id": _PACKAGE_N_SHA256,
+                "preregistration": _prereg(),
+                "operator_go": _go(),
+            }
+        )
+    with pytest.raises(I17PaperShadowLiveContractJoinError, match="ambiguous join rejected"):
+        register_i17_live_contract_join_v1(
+            {
+                "experiment_identity_id": _PACKAGE_N_SHA256,
+                "preregistration": [_prereg(), copy.deepcopy(_prereg())],
+            }
+        )
+
+
+def test_malformed_plane_data_rejected() -> None:
+    with pytest.raises(I17PaperShadowLiveContractJoinError, match="malformed plane data"):
+        register_i17_live_contract_join_v1("not-an-object")  # type: ignore[arg-type]
+    with pytest.raises(I17PaperShadowLiveContractJoinError, match="malformed plane data"):
+        register_i17_live_contract_join_v1(
+            {"experiment_identity_id": _PACKAGE_N_SHA256, "preregistration": "bad"}
+        )
+    mutated = _prereg()
+    mutated.pop("session_id")
+    with pytest.raises(I17PaperShadowLiveContractJoinError, match="malformed plane data"):
+        register_i17_live_contract_join_v1(_envelope(preregistration=mutated))
+
+
+def test_cross_plane_substitution_rejected() -> None:
+    with pytest.raises(I17PaperShadowLiveContractJoinError, match="cross-plane substitution"):
+        register_i17_live_contract_join_v1(_envelope(plane_presence={"IDENTITY": "PRESENT"}))
+    live = _prereg()
+    live["session_id"] = _PACKAGE_N_SHA256
+    with pytest.raises(I17PaperShadowLiveContractJoinError, match="cross-plane substitution"):
+        register_i17_live_contract_join_v1(_envelope(preregistration=live))
+
+
+def test_cross_lane_substitution_rejected() -> None:
+    with pytest.raises(I17PaperShadowLiveContractJoinError, match="cross-lane substitution"):
+        register_i17_live_contract_join_v1(_envelope(I52={"slice_id": "slice-a"}))
+    i52_as_prereg = {
+        "experiment_identity_id": _PACKAGE_N_SHA256,
+        "slice_id": "slice-a",
+        "relative_dir": "out/ops/levelup/slice-a",
+    }
+    with pytest.raises(I17PaperShadowLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i17_live_contract_join_v1(
+            {
+                "experiment_identity_id": _PACKAGE_N_SHA256,
+                "preregistration": i52_as_prereg,
+            }
+        )
+
+
+def test_identity_inside_live_payload_rejected() -> None:
+    live = _prereg()
+    live["experiment_identity_id"] = _PACKAGE_N_SHA256
+    with pytest.raises(I17PaperShadowLiveContractJoinError, match="noncanonical ID substitution"):
+        register_i17_live_contract_join_v1(_envelope(preregistration=live))
+
+
+def test_join_is_deterministic() -> None:
+    payload = _envelope(content_sha256=_CONTENT_SHA256)
+    first = register_i17_live_contract_join_v1(payload).to_canonical_mapping()
+    second = register_i17_live_contract_join_v1(copy.deepcopy(payload)).to_canonical_mapping()
+    assert first == second
+
+
+def test_registration_does_not_mutate_inputs() -> None:
+    payload = _envelope(historical_provenance={"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID})
+    snapshot = copy.deepcopy(payload)
+    record = register_i17_live_contract_join_v1(payload)
+    payload["experiment_identity_id"] = "MUTATED"
+    payload["preregistration"]["session_id"] = "MUTATED"  # type: ignore[index]
+    payload["historical_provenance"]["legacy_experiment_id"] = "MUTATED"  # type: ignore[index]
+    assert record.experiment_identity_id == snapshot["experiment_identity_id"]
+    assert record.session_id == snapshot["preregistration"]["session_id"]  # type: ignore[index]
+    assert dict(record.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+    assert payload != snapshot
+
+
+def test_legacy_experiment_id_and_run_id_remain_non_authoritative() -> None:
+    payload = _envelope(
+        run_id=_RUN_ID,
+        historical_provenance={"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID},
+    )
+    record = register_i17_live_contract_join_v1(payload)
+    assert record.experiment_identity_id == _PACKAGE_N_SHA256
+    assert record.experiment_identity_id != _RUN_ID
+    assert record.run_id == _RUN_ID
+    assert dict(record.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+
+
+def test_runtime_invariants_remain_unauthorized() -> None:
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_no_cap72_execution_hook_or_persistence() -> None:
+    modules = _imported_modules(REGISTRATION_PATH)
+    assert not any(mod == "src.execution" or mod.startswith("src.execution.") for mod in modules)
+    assert not any(
+        "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in modules
+    )
+    assert "src.experiments.base" not in modules
+    assert "src.ingress.capsules.evidence_capsule" not in modules
+    assert "src.levelup.v0_models" not in modules
+    assert "src.live_eval.live_session_eval" not in modules
+    assert "src.analytics.explorer" not in modules
+    assert (
+        "src.ops.paper_shadow_observation_operator_go_session_preregistration_v1"
+        ".preregistration_contract_v1"
+        in modules
+        or "src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.preregistration_contract_v1"
+        in modules
+    )
+    source = REGISTRATION_PATH.read_text(encoding="utf-8")
+    assert "open(" not in source
+    assert "write_text" not in source
+    assert "Path(" not in source
+    assert "build_authorization_artifact_v1" not in source
+    assert "load_preregistration_contract_dict_v1" not in source
+
+
+def test_live_contracts_remain_unhooked() -> None:
+    for path in _LIVE_CONTRACT_FILES:
+        source = path.read_text(encoding="utf-8")
+        assert "register_i17_live_contract_join_v1" not in source
+        assert "i17_paper_shadow_live_contract_join_v1" not in source
+    prereg = json.dumps(_prereg())
+    assert "experiment_identity_id" not in prereg
+    assert _PACKAGE_N_SHA256 not in PREREG_PATH.read_text(encoding="utf-8")

--- a/tests/ops/test_i17_paper_shadow_named_lane_identity_join_v1.py
+++ b/tests/ops/test_i17_paper_shadow_named_lane_identity_join_v1.py
@@ -1,0 +1,469 @@
+"""U-I82-R19 tests for I17 named-lane IDENTITY join on prereg/GO/artifact."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import json
+import uuid
+from pathlib import Path
+
+import pytest
+
+from src.experiments.cross_lane_identity_join_v1 import (
+    PlanePresence,
+    is_package_n_sha256_canonical_id,
+)
+from src.ops.config_truth_alignment_contract_v1 import (
+    MULTI_FUTURE_RUNTIME_AUTHORIZED as CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.authorization_artifact_v1 import (
+    build_authorization_artifact_v1,
+    parse_authorization_artifact_with_identity_join_v1,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.i17_paper_shadow_join_attachment_v1 import (
+    CONTRACT_ID as R5_CONTRACT_ID,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.i17_paper_shadow_named_lane_identity_join_v1 import (
+    CONTRACT_ID,
+    CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS,
+    I17_NAMED_LANE_IDENTITY_JOIN_REGISTERED,
+    I17PaperShadowNamedLaneIdentityJoinError,
+    LIVE_CONTRACT_SURFACES,
+    MULTI_FUTURE_RUNTIME_AUTHORIZED,
+    SECOND_EXECUTION_AUTHORITY_AUTHORIZED,
+    is_i17_named_lane_identity_join_registered,
+    join_i17_named_lane_identity_v1,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.operator_go_contract_v1 import (
+    load_operator_go_contract_dict_v1,
+    parse_operator_go_contract_v1,
+    parse_operator_go_contract_with_identity_join_v1,
+)
+from src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.preregistration_contract_v1 import (
+    load_preregistration_contract_dict_v1,
+    parse_preregistration_contract_v1,
+    parse_preregistration_contract_with_identity_join_v1,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+JOIN_PATH = (
+    REPO_ROOT
+    / "src"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+    / "i17_paper_shadow_named_lane_identity_join_v1.py"
+)
+ATTACHMENT_PATH = (
+    REPO_ROOT
+    / "src"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+    / "i17_paper_shadow_join_attachment_v1.py"
+)
+PREREG_PATH = (
+    REPO_ROOT
+    / "src"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+    / "preregistration_contract_v1.py"
+)
+GO_PATH = (
+    REPO_ROOT
+    / "src"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+    / "operator_go_contract_v1.py"
+)
+ARTIFACT_PATH = (
+    REPO_ROOT
+    / "src"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+    / "authorization_artifact_v1.py"
+)
+INIT_PATH = (
+    REPO_ROOT
+    / "src"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+    / "__init__.py"
+)
+R12_PATH = (
+    REPO_ROOT
+    / "src"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+    / "i17_paper_shadow_live_contract_join_v1.py"
+)
+FIX = (
+    REPO_ROOT
+    / "tests"
+    / "fixtures"
+    / "ops"
+    / "paper_shadow_observation_operator_go_session_preregistration_v1"
+)
+_NAMED_LANE_FILES = (PREREG_PATH, GO_PATH, ARTIFACT_PATH)
+
+_PACKAGE_N_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r19-package-n").hexdigest()
+_OTHER_SHA256 = hashlib.sha256(b"peak-trade-u-i82-r19-other").hexdigest()
+_MD5_12 = "abcdef012345"
+_MD5_32 = "d41d8cd98f00b204e9800998ecf8427e"
+_RUN_ID = str(uuid.uuid4())
+_GIT_SHA = "cd1bd6fa40d664c22b3f6abeef3cc00cdda72688"
+_JOIN_MODULE = (
+    "src.ops.paper_shadow_observation_operator_go_session_preregistration_v1"
+    ".i17_paper_shadow_named_lane_identity_join_v1"
+)
+
+
+def _prereg() -> dict[str, object]:
+    return load_preregistration_contract_dict_v1(
+        FIX / "preregistration_valid_non_authoritative.json"
+    )
+
+
+def _go() -> dict[str, object]:
+    raw = load_operator_go_contract_dict_v1(FIX / "operator_go_valid_non_authoritative.json")
+    if "session_execution_authorized" not in raw:
+        raw["session_execution_authorized"] = False
+    return raw
+
+
+def _artifact() -> dict[str, object]:
+    prereg = parse_preregistration_contract_v1(_prereg())
+    go = parse_operator_go_contract_v1(_go())
+    material = "GO_PSO_SESSION_PREREG_V1_" + "FIXTURE_NON_AUTHORITATIVE_" + "MATERIAL_9F3A"
+    built = build_authorization_artifact_v1(
+        prereg=prereg,
+        go=go,
+        confirm_token=material,
+        authorization_id="auth_fixture_v1",
+        now_unix=1_700_000_000.0,
+    )
+    assert built.ok and built.artifact is not None
+    return built.artifact.to_dict()
+
+
+def _imported_modules(path: Path) -> set[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return modules
+
+
+def test_named_lane_identity_join_is_registered_and_reachable() -> None:
+    assert CONTRACT_ID == "i17_paper_shadow_named_lane_identity_join_v1"
+    assert R5_CONTRACT_ID == "i17_paper_shadow_join_attachment_v1"
+    assert I17_NAMED_LANE_IDENTITY_JOIN_REGISTERED is True
+    assert is_i17_named_lane_identity_join_registered() is True
+    assert LIVE_CONTRACT_SURFACES == (
+        "preregistration",
+        "operator_go",
+        "authorization_artifact",
+    )
+
+
+def test_named_prereg_producer_attaches_identity() -> None:
+    result = parse_preregistration_contract_with_identity_join_v1(
+        _prereg(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.experiment_identity_id == _PACKAGE_N_SHA256
+    assert is_package_n_sha256_canonical_id(result.join.experiment_identity_id) is True
+    assert result.join.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["SESSION"] == PlanePresence.PRESENT.value
+    assert result.join.session_id == result.contract.session_id
+    assert result.join.experiment_identity_id != result.contract.session_id
+    assert "experiment_identity_id" not in result.contract.to_dict()
+
+
+def test_declared_absence_for_alias_run_campaign_on_named_lane() -> None:
+    result = parse_preregistration_contract_with_identity_join_v1(
+        _prereg(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.plane_presence["ALIAS"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["RUN"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.plane_presence["CAMPAIGN"] == PlanePresence.ABSENT_DECLARED.value
+    assert result.join.legacy_alias_md5_12 is None
+    assert result.join.run_id is None
+    assert result.join.campaign_id is None
+
+
+def test_prereg_evidence_and_content_hash_are_joined() -> None:
+    result = parse_preregistration_contract_with_identity_join_v1(
+        _prereg(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.plane_presence["EVIDENCE"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["CONTENT_HASH"] == PlanePresence.PRESENT.value
+    assert result.join.evidence_ref == result.contract.evidence_root
+    assert result.join.content_sha256 == result.contract.scope_digest()
+    assert result.join.content_sha256 != result.join.experiment_identity_id
+
+
+def test_present_run_and_alias_sidecars_are_not_identity() -> None:
+    result = parse_preregistration_contract_with_identity_join_v1(
+        _prereg(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        run_id=_RUN_ID,
+        legacy_alias_md5_12=_MD5_12,
+    )
+    assert result.join.plane_presence["RUN"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["ALIAS"] == PlanePresence.PRESENT.value
+    assert result.join.run_id == _RUN_ID
+    assert result.join.legacy_alias_md5_12 == _MD5_12
+    assert result.join.experiment_identity_id != _RUN_ID
+    assert result.join.experiment_identity_id != _MD5_12
+
+
+def test_operator_go_named_lane_attaches_identity() -> None:
+    result = parse_operator_go_contract_with_identity_join_v1(
+        _go(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.experiment_identity_id == _PACKAGE_N_SHA256
+    assert result.join.session_id == result.contract.session_id
+    assert result.join.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["SESSION"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["CONTENT_HASH"] == PlanePresence.PRESENT.value
+    assert result.join.content_sha256 == result.contract.scope_digest
+    assert "experiment_identity_id" not in result.contract.to_dict()
+
+
+def test_authorization_artifact_named_lane_attaches_identity() -> None:
+    artifact = _artifact()
+    result = parse_authorization_artifact_with_identity_join_v1(
+        artifact,
+        experiment_identity_id=_PACKAGE_N_SHA256,
+    )
+    assert result.join.experiment_identity_id == _PACKAGE_N_SHA256
+    assert result.join.session_id == result.artifact.session_id
+    assert result.join.plane_presence["IDENTITY"] == PlanePresence.PRESENT.value
+    assert result.join.plane_presence["SESSION"] == PlanePresence.PRESENT.value
+    assert "experiment_identity_id" not in result.artifact.to_dict()
+
+
+def test_existing_parse_still_accepts_identity_free_schema() -> None:
+    contract = parse_preregistration_contract_v1(_prereg())
+    go = parse_operator_go_contract_v1(_go())
+    assert "experiment_identity_id" not in contract.to_dict()
+    assert "experiment_identity_id" not in go.to_dict()
+    assert contract.session_id == "pso_fixture_session_non_auth_v1"
+
+
+def test_implicit_absence_of_identity_rejected() -> None:
+    with pytest.raises(I17PaperShadowNamedLaneIdentityJoinError, match="implicit absence rejected"):
+        parse_preregistration_contract_with_identity_join_v1(
+            _prereg(),
+            experiment_identity_id=None,  # type: ignore[arg-type]
+        )
+
+
+def test_noncanonical_id_substitution_rejected() -> None:
+    with pytest.raises(
+        I17PaperShadowNamedLaneIdentityJoinError, match="noncanonical ID substitution"
+    ):
+        parse_preregistration_contract_with_identity_join_v1(
+            _prereg(),
+            experiment_identity_id=_RUN_ID,
+        )
+    with pytest.raises(
+        I17PaperShadowNamedLaneIdentityJoinError, match="noncanonical ID substitution"
+    ):
+        parse_preregistration_contract_with_identity_join_v1(
+            _prereg(),
+            experiment_identity_id=_MD5_12,
+        )
+    with pytest.raises(
+        I17PaperShadowNamedLaneIdentityJoinError, match="noncanonical ID substitution"
+    ):
+        parse_preregistration_contract_with_identity_join_v1(
+            _prereg(),
+            experiment_identity_id=_MD5_32,
+        )
+    with pytest.raises(
+        I17PaperShadowNamedLaneIdentityJoinError, match="noncanonical ID substitution"
+    ):
+        parse_preregistration_contract_with_identity_join_v1(
+            _prereg(),
+            experiment_identity_id=_GIT_SHA,
+        )
+
+
+def test_session_id_must_not_substitute_identity() -> None:
+    live = parse_preregistration_contract_v1(_prereg()).to_dict()
+    live["session_id"] = _PACKAGE_N_SHA256
+    with pytest.raises(I17PaperShadowNamedLaneIdentityJoinError, match="cross-plane substitution"):
+        join_i17_named_lane_identity_v1(
+            live,
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            surface="preregistration",
+        )
+
+
+def test_identity_inside_live_payload_rejected() -> None:
+    live = parse_preregistration_contract_v1(_prereg()).to_dict()
+    live["experiment_identity_id"] = _PACKAGE_N_SHA256
+    with pytest.raises(
+        I17PaperShadowNamedLaneIdentityJoinError, match="noncanonical ID substitution"
+    ):
+        join_i17_named_lane_identity_v1(
+            live,
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            surface="preregistration",
+        )
+
+
+def test_conflicting_identity_rejected() -> None:
+    with pytest.raises(I17PaperShadowNamedLaneIdentityJoinError, match="conflicting"):
+        parse_preregistration_contract_with_identity_join_v1(
+            _prereg(),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            historical_provenance={"experiment_identity_id": _OTHER_SHA256},
+        )
+
+
+def test_cross_lane_substitution_rejected() -> None:
+    live = parse_preregistration_contract_v1(_prereg()).to_dict()
+    live["I52"] = {"slice_id": "slice-a"}
+    with pytest.raises(I17PaperShadowNamedLaneIdentityJoinError, match="cross-lane substitution"):
+        join_i17_named_lane_identity_v1(
+            live,
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            surface="preregistration",
+        )
+
+
+def test_cross_plane_substitution_rejected() -> None:
+    live = parse_preregistration_contract_v1(_prereg()).to_dict()
+    live["plane_presence"] = {"IDENTITY": "PRESENT"}
+    with pytest.raises(I17PaperShadowNamedLaneIdentityJoinError, match="cross-plane substitution"):
+        join_i17_named_lane_identity_v1(
+            live,
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            surface="preregistration",
+        )
+
+
+def test_malformed_plane_data_rejected() -> None:
+    with pytest.raises(I17PaperShadowNamedLaneIdentityJoinError, match="malformed plane data"):
+        join_i17_named_lane_identity_v1(
+            "not-an-object",  # type: ignore[arg-type]
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            surface="preregistration",
+        )
+    with pytest.raises(I17PaperShadowNamedLaneIdentityJoinError, match="malformed plane data"):
+        parse_preregistration_contract_with_identity_join_v1(
+            _prereg(),
+            experiment_identity_id=_PACKAGE_N_SHA256,
+            run_id="   ",
+        )
+
+
+def test_join_is_deterministic() -> None:
+    first = parse_preregistration_contract_with_identity_join_v1(
+        _prereg(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        run_id=_RUN_ID,
+    ).join.to_canonical_mapping()
+    second = parse_preregistration_contract_with_identity_join_v1(
+        _prereg(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        run_id=_RUN_ID,
+    ).join.to_canonical_mapping()
+    assert first == second
+
+
+def test_named_lane_does_not_mutate_inputs() -> None:
+    raw = _prereg()
+    snapshot = copy.deepcopy(raw)
+    result = parse_preregistration_contract_with_identity_join_v1(
+        raw,
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        historical_provenance={"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID},
+    )
+    raw["session_id"] = "MUTATED"
+    assert result.contract.session_id == snapshot["session_id"]
+    assert dict(raw) != snapshot
+
+
+def test_legacy_experiment_id_and_run_id_remain_non_authoritative() -> None:
+    result = parse_preregistration_contract_with_identity_join_v1(
+        _prereg(),
+        experiment_identity_id=_PACKAGE_N_SHA256,
+        run_id=_RUN_ID,
+        historical_provenance={"legacy_experiment_id": _RUN_ID, "run_id": _RUN_ID},
+    )
+    assert result.join.experiment_identity_id == _PACKAGE_N_SHA256
+    assert result.join.experiment_identity_id != _RUN_ID
+    assert result.join.run_id == _RUN_ID
+    assert dict(result.join.historical_provenance)["legacy_experiment_id"] == _RUN_ID
+
+
+def test_known_fields_still_forbid_identity_on_persisted_schema() -> None:
+    live = _prereg()
+    live["experiment_identity_id"] = _PACKAGE_N_SHA256
+    with pytest.raises(Exception, match="PREREG_UNKNOWN_FIELDS"):
+        parse_preregistration_contract_v1(live)
+    go = _go()
+    go["experiment_identity_id"] = _PACKAGE_N_SHA256
+    with pytest.raises(Exception, match="GO_UNKNOWN_FIELDS"):
+        parse_operator_go_contract_v1(go)
+
+
+def test_runtime_invariants_remain_unauthorized() -> None:
+    assert MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert SECOND_EXECUTION_AUTHORITY_AUTHORIZED is False
+    assert CONFIG_MULTI_FUTURE_RUNTIME_AUTHORIZED is False
+    assert CURRENT_EFFECTIVE_MAX_CONCURRENT_POSITIONS == 1
+
+
+def test_named_lane_producer_is_hooked_and_forbidden_surfaces_are_not() -> None:
+    join_modules = _imported_modules(JOIN_PATH)
+    assert (
+        "src.ops.paper_shadow_observation_operator_go_session_preregistration_v1"
+        ".i17_paper_shadow_join_attachment_v1"
+        in join_modules
+        or "src.ops.paper_shadow_observation_operator_go_session_preregistration_v1.i17_paper_shadow_join_attachment_v1"
+        in join_modules
+    )
+    for path in _NAMED_LANE_FILES:
+        modules = _imported_modules(path)
+        assert _JOIN_MODULE in modules or (
+            "src.ops.paper_shadow_observation_operator_go_session_preregistration_v1"
+            ".i17_paper_shadow_named_lane_identity_join_v1" in modules
+        )
+        assert not any(
+            mod == "src.execution" or mod.startswith("src.execution.") for mod in modules
+        )
+        assert not any(
+            "single_future_stateful_no_order_runtime_activation_v1" in mod for mod in modules
+        )
+        assert "src.analytics.explorer" not in modules
+        assert "src.ingress.capsules.evidence_capsule" not in modules
+        assert "src.levelup.v0_models" not in modules
+        assert "src.live_eval.live_session_eval" not in modules
+        assert "src.experiments.base" not in modules
+    assert not any(
+        mod == "src.execution" or mod.startswith("src.execution.") for mod in join_modules
+    )
+    join_source = JOIN_PATH.read_text(encoding="utf-8")
+    assert "write_text" not in join_source
+    assert "open(" not in join_source
+    assert "Path(" not in join_source
+    init_source = INIT_PATH.read_text(encoding="utf-8")
+    assert "i17_paper_shadow_named_lane_identity_join_v1" not in init_source
+    attachment_source = ATTACHMENT_PATH.read_text(encoding="utf-8")
+    assert "i17_paper_shadow_named_lane_identity_join_v1" not in attachment_source
+    r12_source = R12_PATH.read_text(encoding="utf-8")
+    assert "i17_paper_shadow_named_lane_identity_join_v1" not in r12_source
+    fixture = json.dumps(_prereg())
+    assert "experiment_identity_id" not in fixture
+    assert _PACKAGE_N_SHA256 not in PREREG_PATH.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- EG-I82-JOIN is **CLOSED_PROVEN**: 6 real live owners × 7 named lanes = **42/42** edges proven as one end-to-end graph.
- Canonical join key is **Package-N SHA256 only**. `experiment_id`, `run_id`, aliases, and other legacy/operational IDs never replace IDENTITY.
- Proof is a **full live-owner graph traversal** of registered parse/join contracts (`src/experiments/eg_i82_end_to_end_live_owner_graph_attestation_v1.py`), not a static `PROVEN=true` flag aggregation. The **fail-closed negative matrix** remains required (missing edge, wrong join key, identity conflict, RUN/ALIAS as IDENTITY, synthetic identity, implicit absence, cross-lane/plane, extra/duplicate edge).
- Historical readability is preserved (I52 `extra="forbid"`, I61 Fill/`compute_metrics`, I65 `_row_to_summary`). Trading logic, runtime activation, network, orders, migration, and backfill are unchanged (`NONE` / `false`).
- Master Runbook §5.8 records this closeout as non-activating SSOT. Map of Truth §8.2 is a navigation pointer only (no EG-I82 semantics). **This PR does not activate a successor phase**, Cap 7.2 expansion, Testnet, Live, credentials, or orders.

## Test plan

- [x] Focused R24 graph suite: `tests/experiments/test_eg_i82_end_to_end_live_owner_graph_attestation_v1.py` — **20/20 PASS**
- [x] Relevant R4–R24/I82 regression (38 files) — **697/697 PASS**
- [x] Selector `PR_BOUNDED_FULL` path-equivalent targets — **1009/1009 PASS** (37.81s)
- [x] Ruff format `--check` + ruff check on staged Python — PASS
- [x] Staged scope fail-closed: 54 I82 package files + 2 canonical docs; **0** out-of-package files
- [ ] GitHub Required Checks on this PR (confirmation layer; no merge until Owner merge GO)

```text
EG_I82_JOIN_STATUS=CLOSED_PROVEN
EXPECTED_EDGE_COUNT=42
PACKAGE_N_SHA256_ONLY_JOIN_KEY=true
STATIC_FLAG_AGGREGATION_ONLY=false
TRADING_LOGIC_MUTATION=false
RUNTIME_MUTATION=false
NETWORK_EFFECT=NONE
ORDER_EFFECT=NONE
MIGRATION_EXECUTED=false
BACKFILL_EXECUTED=false
SUCCESSOR_PHASE_AUTHORIZED=false
MERGED=false
```


Made with [Cursor](https://cursor.com)