### PR TITLE
feat(cap11): reuse proven venue-native body builder in §11.13.5 canary

### DIFF
--- a/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/order_plan_v1.py
+++ b/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/order_plan_v1.py
@@ -12,6 +12,10 @@ from src.ops.okx_europe_adapter_lifecycle_contract_v0 import (
     CLIENT_ORDER_ID_MAX_LENGTH,
     build_client_order_id,
 )
+from src.ops.section_11_12_8_actual_productive_testnet_campaign_run_start_v1.okx_response_mapper_v1 import (
+    OkxResponseMapperError,
+    build_venue_native_order_body_v1,
+)
 from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.constants_v1 import (
     DEFAULT_INSTRUMENT_ID,
     DEFAULT_ORDER_TYPE,
@@ -179,15 +183,18 @@ def build_minimum_valid_canary_order_plan_v1(
     except LiveCanaryExposureError as exc:
         raise LiveCanaryOrderPlanError(f"UNSAFE_QUANTITY:{exc}") from exc
     clordid = serialize_canary_clordid_v1(owner_go=owner_go, origin_main_sha=origin_main_sha)
-    payload = {
-        "instId": instrument_id,
-        "tdMode": td_mode,
-        "side": str(side).lower(),
-        "ordType": "limit",
-        "sz": exposure.quantity,
-        "px": limit_px,
-        "clOrdId": clordid,
-    }
+    try:
+        payload = build_venue_native_order_body_v1(
+            client_order_id=clordid,
+            instrument=instrument_id,
+            order_type=DEFAULT_ORDER_TYPE,
+            side=side,
+            quantity=exposure.quantity,
+            td_mode=td_mode,
+            px=limit_px,
+        )
+    except OkxResponseMapperError as exc:
+        raise LiveCanaryOrderPlanError(f"VENUE_NATIVE_BODY:{exc}") from exc
     return CanaryOrderPlanV1(
         instrument_id=instrument_id,
         side=str(side).upper(),

--- a/tests/ops/test_section_11_13_5_canary_submit_transport_v1.py
+++ b/tests/ops/test_section_11_13_5_canary_submit_transport_v1.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import inspect
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from src.core.environment import LIVE_CONFIRM_TOKEN
+from src.ops.section_11_12_8_actual_productive_testnet_campaign_run_start_v1.okx_response_mapper_v1 import (
+    build_venue_native_order_body_v1,
+)
 from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.config_v1 import (
     example_incomplete_config_dict_v1,
     load_live_canary_config_v1,
@@ -170,6 +175,104 @@ def test_order_plan_rejects_quantity_above_min_sz() -> None:
             owner_go=OWNER_GO_EXECUTE,
             origin_main_sha=ORIGIN_SHA,
         )
+
+
+def test_order_plan_reuses_proven_venue_native_body_builder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel = {"sentinel": True}
+    calls: list[dict[str, Any]] = []
+
+    def _fake_builder(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(
+        "src.ops.section_11_13_5_live_canary_minimum_exposure_v1.order_plan_v1.build_venue_native_order_body_v1",
+        _fake_builder,
+    )
+    plan = build_minimum_valid_canary_order_plan_v1(
+        instruments_payload=INSTRUMENTS,
+        ticker_payload=TICKER,
+        owner_go=OWNER_GO_EXECUTE,
+        origin_main_sha=ORIGIN_SHA,
+    )
+    assert plan.venue_native_payload is sentinel
+    assert len(calls) == 1
+    assert calls[0]["client_order_id"] == plan.clordid
+    assert calls[0]["instrument"] == "BTC-USDT-SWAP"
+    assert calls[0]["order_type"] == "LIMIT"
+    assert calls[0]["side"] == "BUY"
+    assert calls[0]["quantity"] == plan.quantity == "0.01"
+    assert calls[0]["td_mode"] == "cross"
+    assert calls[0]["px"] == plan.limit_price
+    source = inspect.getsource(build_minimum_valid_canary_order_plan_v1)
+    assert "build_venue_native_order_body_v1(" in source
+    assert '"instId"' not in source
+    assert '"clOrdId"' not in source
+
+
+def test_order_plan_body_equals_proven_builder_contract() -> None:
+    plan = build_minimum_valid_canary_order_plan_v1(
+        instruments_payload=INSTRUMENTS,
+        ticker_payload=TICKER,
+        owner_go=OWNER_GO_EXECUTE,
+        origin_main_sha=ORIGIN_SHA,
+    )
+    expected = build_venue_native_order_body_v1(
+        client_order_id=plan.clordid,
+        instrument=plan.instrument_id,
+        order_type=plan.order_type,
+        side=plan.side,
+        quantity=plan.quantity,
+        td_mode=plan.td_mode,
+        px=plan.limit_price,
+    )
+    assert plan.venue_native_payload == expected
+    assert set(plan.venue_native_payload) == {
+        "instId",
+        "tdMode",
+        "side",
+        "ordType",
+        "sz",
+        "px",
+        "clOrdId",
+    }
+    assert plan.venue_native_payload["instId"] == "BTC-USDT-SWAP"
+    assert plan.venue_native_payload["tdMode"] == "cross"
+    assert plan.venue_native_payload["side"] == "buy"
+    assert plan.venue_native_payload["ordType"] == "limit"
+    assert plan.venue_native_payload["sz"] == "0.01"
+    assert plan.quantity == "0.01"
+    assert plan.venue_native_payload["px"] == plan.limit_price == "65000.1"
+    assert plan.venue_native_payload["clOrdId"] == plan.clordid
+    assert "posSide" not in plan.venue_native_payload
+    assert "posMode" not in plan.venue_native_payload
+    assert "reduceOnly" not in plan.venue_native_payload
+    assert "x-simulated-trading" not in plan.venue_native_payload
+
+
+def test_canary_submit_post_omits_pos_side_and_simulated_trading_header() -> None:
+    transport = _fake_transport()
+    result = run_canary_submit_transport_v1(**_transport_kwargs(transport=transport))
+    assert result["SIGNED_BODY_EQUALS_WIRE_BODY"] is True
+    posts = [c for c in transport.calls if c.method == "POST"]
+    assert len(posts) == 1
+    body = json.loads(posts[0].body_text)
+    assert "posSide" not in body
+    assert "posMode" not in body
+    header_keys = {str(k).lower() for k in posts[0].headers}
+    assert "x-simulated-trading" not in header_keys
+    expected = build_venue_native_order_body_v1(
+        client_order_id=body["clOrdId"],
+        instrument=body["instId"],
+        order_type=body["ordType"],
+        side=body["side"],
+        quantity=body["sz"],
+        td_mode=body["tdMode"],
+        px=body["px"],
+    )
+    assert body == expected
 
 
 def test_http_client_rejects_wrong_host_and_demo_and_ungated_post() -> None:


### PR DESCRIPTION
## Summary
- Bounded §11.13.5 canary-only wiring: `build_minimum_valid_canary_order_plan_v1` now calls the existing proven owner `build_venue_native_order_body_v1` instead of inlining the seven-field venue-native POST dict.
- Architectural wiring alignment only. No trading-logic, strategy, selection, risk, portfolio, multi-future, transport, signer, clOrdId, account, or instrument-binding change.
- Does **not** authorize execute/retry/live, does **not** merge automatically, and does **not** establish a 50124 root cause.

## Scope
`SECTION_11_13_5_CANARY_REUSE_PROVEN_VENUE_NATIVE_BODY_BUILDER`

Changed paths:
- `src/ops/section_11_13_5_live_canary_minimum_exposure_v1/order_plan_v1.py`
- `tests/ops/test_section_11_13_5_canary_submit_transport_v1.py`

## Explicit non-changes
- LIVE host remains `eea.okx.com`; no `x-simulated-trading`; no BoundOkx; no POST via §11.13.2/3/4 GET-only clients
- Canary urllib LIVE transport and `sign_okx_request_v1` reuse unchanged
- `LIVE_POSITION_MODE_STATUS=UNPROVEN` unchanged; no `posSide`/`posMode`
- `ROOT_CAUSE_PROVEN=false`; `50124_FIX_CLAIMED=false`

## Test plan
- [x] Focused canary tests (`test_section_11_13_5_canary_submit_transport_v1.py`, live canary minimum exposure, 50124 classification) — PASS
- [x] Focused testnet body-builder tests (`test_okx_accept_reject_and_wire_not_ack`, cancel-body instId, §11.12.8 execute-path unlock file) — PASS
- [x] Ruff format/check on changed files — PASS
- [x] `git diff --check` — PASS
- [x] Selector `PR_BOUNDED_FULL` targets — PASS
- [ ] GitHub required checks (confirmation only; no auto-merge)

## Owner follow-up
`NEXT_OWNER_DECISION=OWNER_MERGE_GO_FOR_THIS_BOUNDED_CANARY_WIRING_PR_IF_GREEN`

No execute. No retry. No merge without separate `OWNER_MERGE_GO`.


Made with [Cursor](https://cursor.com)