### PR TITLE
docs(11.13.5): fail-closed operational funding-amount evidence without money movement

### DIFF
--- a/docs/governance/PEAK_TRADE_MAP_OF_TRUTH.md
+++ b/docs/governance/PEAK_TRADE_MAP_OF_TRUTH.md
@@ -295,7 +295,8 @@ Ergänzende Owner-/Wiring-Hinweise (keine parallele Trading-SSOT):
 | [`docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md`](../runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md) §11.13.5.K | SSOT EEA XPerp 310404 canary rebind preparation (`CURRENT_PHASE=SECTION_11_13_5_EEA_XPERP_310404_REBIND_PREPARATION`; `NEW_CANARY_INSTRUMENT=BTC-USD_UM_XPERP-310404`; `NEW_CANARY_INST_TYPE=FUTURES`; `NEW_CANARY_RULE_TYPE=xperp`; `NEW_CANARY_SETTLEMENT_TRUTH=USDC`; `BTC_USDT_SWAP_STATUS=REJECTED_FOR_CURRENT_EEA_CANARY_PATH`; `DEMO_XPERP_310328_SEPARATED=true`; `REQUEST_BODY_OWNER=build_venue_native_order_body_v1`; `LIVE_AUTHORIZED=false`; not execute; not funded; not proven; historical next pointer superseded by §11.13.5.L; PR `#5905` merged `2caad4a2e`) |
 | [`docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md`](../runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md) §11.13.5.L | SSOT post-K GET bind (`SET_ACCOUNT_LEVERAGE=3`; snapshot theoretical IM floor `2.101456666666666666666666667` USDC at `markPx=63043.7`; `CANARY_OPERATIONAL_MINIMUM_PROVEN=false`; `TDMODE_GET_SETTING_PROVEN=true`; `TDMODE_LIVE_POST_PROVEN=false`; `LIVE_AUTHORIZED=false`; not funded; not execute; historical next pointer superseded by §11.13.5.M; PR `#5906` squash-merged `bc59e1e33`) |
 | [`docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md`](../runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md) §11.13.5.M | SSOT PR `#5906` persistence closeout + tracker retirement preparation (`PERSISTENCE_REMEDIATION_PR_MERGED=true`; `OWNER_MERGE_GO_FOR_POST_K_PERSISTENCE_REMEDIATION_PR_STATUS=CONSUMED_CLOSED`; tracker `RETIRED_CLOSED_NONAUTHORITATIVE` `AUTHORITY=NONE` retained; `CANARY_OPERATIONAL_MINIMUM_PROVEN=false`; `FUNDING_AMOUNT_PROVEN=false`; I44&#47;G16 `INSUFFICIENT_EVIDENCE`; `LIVE_AUTHORIZED=false`; not funded; not execute; historical next pointer superseded by §11.13.5.N; PR `#5907` squash-merged `27ceae911`) |
-| [`docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md`](../runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md) §11.13.5.N | SSOT `OWNER_GO_FOR_NEW_FUNDING` evaluation fail-closed (`FUNDING_AMOUNT_PROVEN=false`; `RECOMMENDED_BOUNDED_CANARY_FUNDING_AMOUNT_PROVEN=false`; snapshot IM floor is not operational amount; I44&#47;G16 `INSUFFICIENT_EVIDENCE`; `LIVE_AUTHORIZED=false`; no money movement; not execute) |
+| [`docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md`](../runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md) §11.13.5.N | SSOT `OWNER_GO_FOR_NEW_FUNDING` evaluation fail-closed (`FUNDING_AMOUNT_PROVEN=false`; `RECOMMENDED_BOUNDED_CANARY_FUNDING_AMOUNT_PROVEN=false`; snapshot IM floor is not operational amount; I44&#47;G16 `INSUFFICIENT_EVIDENCE`; `LIVE_AUTHORIZED=false`; no money movement; not execute; historical next pointer superseded by §11.13.5.O; PR `#5908` squash-merged `2c55d81dd`) |
+| [`docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md`](../runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md) §11.13.5.O | SSOT operational funding-amount evidence fail-closed (`AUTHORIZED_SCOPE=EVIDENCE_ONLY`; `FUNDING_AMOUNT_PROVEN=false`; no GET refresh; no max-avail-size; I44&#47;G16 `INSUFFICIENT_EVIDENCE`; `LIVE_AUTHORIZED=false`; no money movement; not execute) |
 | [`evidence&#47;ops&#47;section_11_13_5_live_canary_forensic_reconciliation_v1&#47;20260812T120000Z&#47;`](../../evidence/ops/section_11_13_5_live_canary_forensic_reconciliation_v1/20260812T120000Z/) | Owner §11.13.5 sealed forensic classification + authoring evidence (derived; non-SSOT; no productive network; writes&#47;orders=0; `MANIFEST_VERIFY_RC=0`; Live unauthorized) |
 | [`evidence&#47;ops&#47;section_11_13_5_b_pr_5879_squash_merge_and_pre_canary_readiness_v1&#47;20260812T123500Z&#47;`](../../evidence/ops/section_11_13_5_b_pr_5879_squash_merge_and_pre_canary_readiness_v1/20260812T123500Z/) | Owner §11.13.5.B PR `#5879` squash-merge closeout + pre-Canary dependency resolution (derived; non-SSOT; no execute; `MANIFEST_VERIFY_RC=0`) |
 | [`evidence&#47;ops&#47;section_11_13_5_live_canary_trade_capability_attestation_v1&#47;20260812T135723Z&#47;`](../../evidence/ops/section_11_13_5_live_canary_trade_capability_attestation_v1/20260812T135723Z/) | Owner §11.13.5.C trade-key attestation proven evidence (derived; non-SSOT; no secret values; no orders; `MANIFEST_VERIFY_RC=0`) |
@@ -570,12 +571,14 @@ SECTION_11_13_5_K_EEA_XPERP_310404_REBIND_PREPARATION_BOUND=true
 SECTION_11_13_5_L_POST_K_GET_BIND_BOUND=true
 SECTION_11_13_5_M_PR_5906_PERSISTENCE_CLOSEOUT_BOUND=true
 SECTION_11_13_5_N_FUNDING_AMOUNT_EVALUATION_BOUND=true
+SECTION_11_13_5_O_OPERATIONAL_FUNDING_EVIDENCE_BOUND=true
 PRODUCTIVE_CANARY_SURFACE_MERGED_TO_ORIGIN_MAIN=true
 PR_5879_MERGE_COMMIT_SHA=b3dadd86d6821882c8184bd1f6f8e207cbc4af43
 PR_5902_SQUASH_MERGE_SHA=4adb0af23181cd9a8c032bbb57d3b189413a4226
 PR_5905_SQUASH_MERGE_SHA=2caad4a2e68b89c788bb5a5b654a4f32fdba38c5
 PR_5906_SQUASH_MERGE_SHA=bc59e1e331588ab7e727c6909baa69e8a00d93da
 PR_5907_SQUASH_MERGE_SHA=27ceae9115de0ae8db196ce8417730f328c5e251
+PR_5908_SQUASH_MERGE_SHA=2c55d81dd25f7bab41a63c89ad05d8635b3eda6f
 OWNER_MERGE_GO_FOR_BOUNDED_POST_401_REMEDIATION_PR_STATUS=DONE_MERGED
 OWNER_MERGE_GO_FOR_POST_K_PERSISTENCE_REMEDIATION_PR_STATUS=CONSUMED_CLOSED
 LIVE_CANARY_MINIMUM_EXPOSURE_EXECUTED=false
@@ -634,11 +637,12 @@ OWNER_GO_SECTION_11_13_5_POST_HTTP_401_BOUNDED_REMEDIATION_PREPARATION_STATUS=CO
 OWNER_GO_SECTION_11_13_5_OKX_50124_MARKET_PERMISSION_REMEDIATION_AND_CLASSIFICATION_PREPARATION_STATUS=CONSUMED
 OWNER_GO_SECTION_11_13_5_EEA_XPERP_310404_REBIND_PREPARATION_STATUS=CONSUMED_MERGED
 OWNER_GO_FOR_NEW_FUNDING_STATUS=CONSUMED_EVALUATION_ONLY_AMOUNT_UNPROVEN
+OWNER_GO_REQUIRED_FOR_OPERATIONAL_CANARY_FUNDING_AMOUNT_EVIDENCE_STATUS=CONSUMED_EVIDENCE_ONLY_AMOUNT_UNPROVEN
 NEW_CANARY_OWNER_GO_GRANTED=false
 LIVE_AUTHORIZED=false
 EARLIEST_UNRESOLVED_DEPENDENCY=CANARY_OPERATIONAL_MINIMUM_UNPROVEN_THEN_SEPARATE_NEW_EXECUTE_GO
 EARLIEST_UNRESOLVED_SECTION_POINTER=SECTION_11_13_5_LIVE_CANARY_MINIMUM_EXPOSURE
-NEXT_CANONICAL_STEP_POINTER=OWNER_GO_REQUIRED_FOR_OPERATIONAL_CANARY_FUNDING_AMOUNT_EVIDENCE
+NEXT_CANONICAL_STEP_POINTER=OWNER_GO_REQUIRED_TO_RATIFY_OPERATIONAL_FUNDING_FORMULA
 SECTION_11_13_2_PACKAGE_POINTER=src&#47;ops&#47;section_11_13_2_live_private_read_only_v1&#47;
 SECTION_11_13_2_PROOF_EVIDENCE_POINTER=evidence&#47;ops&#47;section_11_13_2_live_private_read_only_proven_v1&#47;20260811T170310Z&#47;
 SECTION_11_13_3_PACKAGE_POINTER=src&#47;ops&#47;section_11_13_3_live_shadow_with_exchange_reconciliation_v1&#47;

--- a/docs/ops/specs/SECTION_11_13_5_LIVE_CANARY_MINIMUM_EXPOSURE_V1.md
+++ b/docs/ops/specs/SECTION_11_13_5_LIVE_CANARY_MINIMUM_EXPOSURE_V1.md
@@ -83,12 +83,12 @@ execute, order submit, account mutation, Cap 11.9 activation, clearing of
 
 ## Next steps
 
-Current SSOT: Master Runbook §11.13.5.N. Historical M-era next steps
-below are superseded for the current fail-closed funding-amount
-evaluation. Historical L-era next steps remain historical for the GET
-bind. Historical K-era next steps remain historical for the GET bind.
-Historical J-era next steps remain historical for the rejected SWAP
-oneshot.
+Current SSOT: Master Runbook §11.13.5.O. Historical N-era next steps
+below are superseded for the current evidence-only funding-amount
+fail-closed persist. Historical M-era next steps remain historical for
+the persistence closeout. Historical L-era next steps remain historical
+for the GET bind. Historical J-era next steps remain historical for the
+rejected SWAP oneshot.
 
 1. Historical first canary POST HTTP 401 remains
    `UNPROVEN_FAIL_CLOSED` (no proven incident body). Do not rewrite it
@@ -129,7 +129,10 @@ oneshot.
    funding amount. `FUNDING_AMOUNT_PROVEN=false`.
    `RECOMMENDED_BOUNDED_CANARY_FUNDING_AMOUNT_PROVEN=false`.
    `CANARY_OPERATIONAL_MINIMUM_PROVEN=false`.
-9. Next canonical step is
-   `OWNER_GO_REQUIRED_FOR_OPERATIONAL_CANARY_FUNDING_AMOUNT_EVIDENCE`,
-   then a **separate** new execute GO if granted. This spec does not
-   authorize execute, funding, or general Live unlock.
+9. `OWNER_GO_REQUIRED_FOR_OPERATIONAL_CANARY_FUNDING_AMOUNT_EVIDENCE`
+   was granted `EVIDENCE_ONLY` and is consumed. No GET refresh and no
+   max-avail-size were authorized. `FUNDING_AMOUNT_PROVEN=false`.
+10. Next canonical step is
+    `OWNER_GO_REQUIRED_TO_RATIFY_OPERATIONAL_FUNDING_FORMULA`, then a
+    **separate** new execute GO if granted. This spec does not
+    authorize execute, funding, GET refresh, or general Live unlock.

--- a/docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md
+++ b/docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md
@@ -10978,16 +10978,132 @@ Live vs Demo identity remains strictly separated. Map of Truth
 ``` text
 CODE_OWNER=src&#47;ops&#47;section_11_13_5_live_canary_minimum_exposure_v1&#47;
 CURRENT_CANONICAL_NEXT_STEP_AUTHORITY=SECTION_11_13_5
-CANONICAL_NEXT_STEP=OWNER_GO_REQUIRED_FOR_OPERATIONAL_CANARY_FUNDING_AMOUNT_EVIDENCE
-EARLIEST_UNRESOLVED_DEPENDENCY=CANARY_OPERATIONAL_MINIMUM_UNPROVEN_THEN_SEPARATE_NEW_EXECUTE_GO
+CANONICAL_NEXT_STEP=SUPERSEDED_BY_SECTION_11_13_5_O
+EARLIEST_UNRESOLVED_DEPENDENCY=SUPERSEDED_BY_SECTION_11_13_5_O
 EARLIEST_UNRESOLVED_SECTION_POINTER=SECTION_11_13_5_LIVE_CANARY_MINIMUM_EXPOSURE
 ```
 
 Hard stop. `OWNER_GO_FOR_NEW_FUNDING` is consumed as evaluation-only
 and must not be reused for money movement or execute.
 `OWNER_GO_LIVE_CANARY_MINIMUM_EXPOSURE` remains `CONSUMED`. Cap &#47;
+Capability 11.9 remains fixture-only. The N-era next pointer
+`OWNER_GO_REQUIRED_FOR_OPERATIONAL_CANARY_FUNDING_AMOUNT_EVIDENCE` is
+**consumed** as evidence-only by the granted Owner-GO of that name and
+is superseded by §11.13.5.O below. No funding executed. No execute.
+
+### 11.13.5.O Operational canary funding-amount evidence (BOUND; FAIL-CLOSED; EVIDENCE-ONLY; NOT FUNDED; NOT EXECUTE)
+
+Owner-GO `OWNER_GO_REQUIRED_FOR_OPERATIONAL_CANARY_FUNDING_AMOUNT_EVIDENCE`
+(one-shot; now **CONSUMED**) authorized **evidence-only** work against
+the still-unproven operational canary funding amount. Bound scope:
+
+``` text
+AUTHORIZED_SCOPE=EVIDENCE_ONLY
+FUNDING_EXECUTION_AUTHORIZED=false
+EXTERNAL_MONEY_MOVEMENT_AUTHORIZED=false
+TRADING_POST_AUTHORIZED=false
+CANARY_EXECUTE_AUTHORIZED=false
+LIVE_AUTHORIZED=false
+GENERAL_LIVE_UNLOCKED=false
+NETWORK_SESSION_AUTHORIZED=false
+CREDENTIAL_ACCESS_AUTHORIZED=false
+GET_ONLY_REFRESH_AUTHORIZED=false
+```
+
+This does **not** authorize deposit, transfer, withdrawal, convert,
+buy&#47;sell, Trading-POST, Canary execute, orders, positions,
+set-leverage mutation, API-key &#47; account mutation, a productive
+OKX GET refresh, max-avail-size GET, inventing or rounding a funding
+amount, I44 &#47; G16 upgrade, general Live unlock, Multi-Future,
+Double Play &#47; Master V2 changes, or merge without a separate
+`OWNER_MERGE_GO`.
+
+Under this scope the nine §11.13.5.N blockers remain open. No new
+venue evidence was collected. The sealed GET pack
+`20260816T033800Z` is unchanged and still proves only the snapshot
+theoretical IM floor.
+
+``` text
+CURRENT_PHASE=SECTION_11_13_5_O_OPERATIONAL_FUNDING_EVIDENCE_FAIL_CLOSED
+OWNER_GO=OWNER_GO_REQUIRED_FOR_OPERATIONAL_CANARY_FUNDING_AMOUNT_EVIDENCE
+OWNER_GO_STATUS=CONSUMED
+OWNER_GO_SCOPE=EVIDENCE_ONLY
+BASELINE_ORIGIN_MAIN_SHA=2c55d81dd25f7bab41a63c89ad05d8635b3eda6f
+PR_5908_STATUS=SQUASH_MERGED
+PR_5908_MERGE_SHA=2c55d81dd25f7bab41a63c89ad05d8635b3eda6f
+CANARY_INSTRUMENT=BTC-USD_UM_XPERP-310404
+SETTLEMENT_ACCOUNT_TRUTH=USDC
+SET_ACCOUNT_LEVERAGE=3
+SNAPSHOT_THEORETICAL_INITIAL_MARGIN_USDC=2.101456666666666666666666667
+MINIMUM_THEORETICAL_INITIAL_MARGIN_PROVEN=true
+SNAPSHOT_THEORETICAL_FUNDING_FLOOR_PROVEN=true
+CANARY_OPERATIONAL_MINIMUM_PROVEN=false
+RECOMMENDED_BOUNDED_CANARY_FUNDING_AMOUNT_PROVEN=false
+FUNDING_AMOUNT_PROVEN=false
+PROVEN_FUNDING_AMOUNT=NONE
+PROVEN_FUNDING_AMOUNT_UNIT=NONE
+SNAPSHOT_FLOOR_IS_NOT_OPERATIONAL_FUNDING_AMOUNT=true
+NEW_VENUE_GET_COLLECTED=false
+MAX_AVAIL_SIZE_GET_COLLECTED=false
+MARKPX_REFRESH_COLLECTED=false
+OWNER_RATIFIED_OPERATIONAL_FORMULA_PRESENT=false
+I44_FUTURES_FUNDING_ECONOMICS_STATUS=INSUFFICIENT_EVIDENCE
+G16_FUNDING_PROOF_STATUS=INSUFFICIENT_EVIDENCE
+FUNDING_EXECUTED=false
+EXTERNAL_MONEY_MOVEMENT=false
+CANARY_EXECUTED=false
+TRADING_POSTS=0
+ACCOUNT_MUTATION=false
+CREDENTIAL_MUTATION=false
+TRADING_LOGIC_CHANGED=false
+MASTER_V2_CHANGED=false
+DOUBLE_PLAY_CHANGED=false
+RUNTIME_AUTHORITY_EXPANDED=false
+LIVE_AUTHORIZED=false
+GENERAL_LIVE_UNLOCKED=false
+NEW_EXECUTE_GO_REQUIRED=true
+FUNDING_GO_AND_EXECUTE_GO_COLLAPSED=false
+EXECUTE_AUTHORIZED_BY_THIS_EVIDENCE_GO=false
+ORDER_EFFECT=NONE
+ACCOUNT_MUTATION_EFFECT=NONE
+FUNDING_EFFECT=NONE
+SECRET_VALUE_ACCESS=NONE
+```
+
+Still missing (unchanged; none closable under `EVIDENCE_ONLY` without
+network, credentials, or an Owner-supplied formula):
+
+1. Owner-ratified operational formula distinct from snapshot IM.
+2. Positive fee-reserve policy.
+3. Proven slippage &#47; spread buffer policy.
+4. Proven maintenance-margin &#47; liquidation buffer. Public `imr=0.02`
+   remains a tier limit.
+5. Venue-native max-avail-size &#47; min-available-equity GET for one
+   contract. Requires a **separate** scoped GET-only GO plus
+   credentials; not authorized here.
+6. Fresh productive markPx GET refresh. Requires a **separate** scoped
+   GET-only GO; not authorized here.
+7. I44 &#47; Master G16 remains `INSUFFICIENT_EVIDENCE`.
+8. Public USD versus account USDC haircut policy.
+9. `totalEq=0` still does not prove deposit size.
+
+Live vs Demo identity remains strictly separated. Map of Truth
+`CANONICAL_ACTIVE_INSTRUMENT=BTC-USD_UM_XPERP-310328` remains the
+§11.12.8 Demo campaign binding and is **not** retargeted.
+
+``` text
+CODE_OWNER=src&#47;ops&#47;section_11_13_5_live_canary_minimum_exposure_v1&#47;
+CURRENT_CANONICAL_NEXT_STEP_AUTHORITY=SECTION_11_13_5
+CANONICAL_NEXT_STEP=OWNER_GO_REQUIRED_TO_RATIFY_OPERATIONAL_FUNDING_FORMULA
+EARLIEST_UNRESOLVED_DEPENDENCY=CANARY_OPERATIONAL_MINIMUM_UNPROVEN_THEN_SEPARATE_NEW_EXECUTE_GO
+EARLIEST_UNRESOLVED_SECTION_POINTER=SECTION_11_13_5_LIVE_CANARY_MINIMUM_EXPOSURE
+```
+
+Hard stop. This evidence GO is consumed and must not be reused for
+money movement, GET refresh, or execute.
+`OWNER_GO_LIVE_CANARY_MINIMUM_EXPOSURE` remains `CONSUMED`. Cap &#47;
 Capability 11.9 remains fixture-only. No funding. No execute. No merge
-of this evaluation without a separate `OWNER_MERGE_GO`.
+of this evidence persist without a separate `OWNER_MERGE_GO`.
 
 ## 11.14 Live order and economic evidence ladder
 

--- a/docs/runbooks/operations/PEAK_TRADE_PERSISTENCE_REMEDIATION_TRACKER.md
+++ b/docs/runbooks/operations/PEAK_TRADE_PERSISTENCE_REMEDIATION_TRACKER.md
@@ -92,13 +92,13 @@ All GAP items are `CLOSED_CANONICALLY_PERSISTED` by squash-merge
 **retained** on HEAD for audit. It is **not** deleted: the original
 delete-after-closeout-on-`origin&#47;main` rule is not satisfied at
 closeout authoring time, and historical pointer chains still name this
-path. Canonical authority remains SSOT §11.13.5.N. The M-era pointer
-`OWNER_GO_REQUIRED_SEPARATE_FOR_NEW_FUNDING` is consumed as
-evaluation-only. Snapshot theoretical IM is not an operational funding
-amount.
+path. Canonical authority remains SSOT §11.13.5.O. The N-era pointer
+`OWNER_GO_REQUIRED_FOR_OPERATIONAL_CANARY_FUNDING_AMOUNT_EVIDENCE` is
+consumed as evidence-only. Snapshot theoretical IM is not an operational
+funding amount.
 
 ```text
-CANONICAL_NEXT_STEP=OWNER_GO_REQUIRED_FOR_OPERATIONAL_CANARY_FUNDING_AMOUNT_EVIDENCE
+CANONICAL_NEXT_STEP=OWNER_GO_REQUIRED_TO_RATIFY_OPERATIONAL_FUNDING_FORMULA
 EARLIEST_UNRESOLVED_DEPENDENCY=CANARY_OPERATIONAL_MINIMUM_UNPROVEN_THEN_SEPARATE_NEW_EXECUTE_GO
 PERSISTENCE_REMEDIATION_PR_MERGED=true
 TRACKER_RETIREMENT_ALLOWED=true


### PR DESCRIPTION
## Summary

Bounded §11.13.5.O persist of `OWNER_GO_REQUIRED_FOR_OPERATIONAL_CANARY_FUNDING_AMOUNT_EVIDENCE`. Scope was `EVIDENCE_ONLY`. **No money movement. No GET refresh. No execute.**

- Snapshot theoretical IM `2.101456666666666666666666667` USDC remains a **floor only**
- `FUNDING_AMOUNT_PROVEN=false`
- `RECOMMENDED_BOUNDED_CANARY_FUNDING_AMOUNT_PROVEN=false`
- `CANARY_OPERATIONAL_MINIMUM_PROVEN=false`
- Nine §11.13.5.N blockers remain open (formula, fee reserve, slippage, MM buffer, max-avail-size GET, markPx refresh, I44/G16, USD/USDC haircut, `totalEq=0`)
- I44 / Master G16 remains `INSUFFICIENT_EVIDENCE`
- No deposit, transfer, withdrawal, convert, buy/sell
- No Trading POST
- No Canary execute
- No account / credential / trading-logic mutation
- No productive OKX GET refresh and no max-avail-size GET
- `OWNER_GO_REQUIRED_FOR_OPERATIONAL_CANARY_FUNDING_AMOUNT_EVIDENCE` is `CONSUMED_EVIDENCE_ONLY_AMOUNT_UNPROVEN` and must not be reused
- Next pointer: `OWNER_GO_REQUIRED_TO_RATIFY_OPERATIONAL_FUNDING_FORMULA`
- Earliest unresolved dependency remains `CANARY_OPERATIONAL_MINIMUM_UNPROVEN_THEN_SEPARATE_NEW_EXECUTE_GO`
- Tracker remains `AUTHORITY=NONE` / `RETIRED_CLOSED_NONAUTHORITATIVE`

Do **not** squash-merge without a separate `OWNER_MERGE_GO`.

## Test plan

- [x] Canonical CI selector on exact final diff → `NO_OP` (`docs_workflow_or_static_contract_only`)
- [x] Docs token policy on changed Markdown → PASS
- [x] Docs reference targets `--changed --base origin/main` → PASS
- [x] Tracked-secret policy on PR files → PASS
- [ ] GitHub required checks after PR open (confirmation only; selector `NO_OP`)

Made with [Cursor](https://cursor.com)