### PR TITLE
docs(11.13.5): persist operational funding-policy decision template without a formula body

### DIFF
--- a/docs/governance/PEAK_TRADE_MAP_OF_TRUTH.md
+++ b/docs/governance/PEAK_TRADE_MAP_OF_TRUTH.md
@@ -297,7 +297,8 @@ Ergänzende Owner-/Wiring-Hinweise (keine parallele Trading-SSOT):
 | [`docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md`](../runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md) §11.13.5.M | SSOT PR `#5906` persistence closeout + tracker retirement preparation (`PERSISTENCE_REMEDIATION_PR_MERGED=true`; `OWNER_MERGE_GO_FOR_POST_K_PERSISTENCE_REMEDIATION_PR_STATUS=CONSUMED_CLOSED`; tracker `RETIRED_CLOSED_NONAUTHORITATIVE` `AUTHORITY=NONE` retained; `CANARY_OPERATIONAL_MINIMUM_PROVEN=false`; `FUNDING_AMOUNT_PROVEN=false`; I44&#47;G16 `INSUFFICIENT_EVIDENCE`; `LIVE_AUTHORIZED=false`; not funded; not execute; historical next pointer superseded by §11.13.5.N; PR `#5907` squash-merged `27ceae911`) |
 | [`docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md`](../runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md) §11.13.5.N | SSOT `OWNER_GO_FOR_NEW_FUNDING` evaluation fail-closed (`FUNDING_AMOUNT_PROVEN=false`; `RECOMMENDED_BOUNDED_CANARY_FUNDING_AMOUNT_PROVEN=false`; snapshot IM floor is not operational amount; I44&#47;G16 `INSUFFICIENT_EVIDENCE`; `LIVE_AUTHORIZED=false`; no money movement; not execute; historical next pointer superseded by §11.13.5.O; PR `#5908` squash-merged `2c55d81dd`) |
 | [`docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md`](../runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md) §11.13.5.O | SSOT operational funding-amount evidence fail-closed (`AUTHORIZED_SCOPE=EVIDENCE_ONLY`; `FUNDING_AMOUNT_PROVEN=false`; no GET refresh; no max-avail-size; I44&#47;G16 `INSUFFICIENT_EVIDENCE`; `LIVE_AUTHORIZED=false`; no money movement; not execute; historical next pointer superseded by §11.13.5.P; PR `#5909` squash-merged `8c36b48bd`) |
-| [`docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md`](../runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md) §11.13.5.P | SSOT operational funding-formula ratification fail-closed (`AUTHORIZED_SCOPE=RATIFICATION_ONLY`; `FORMULA_BODY_SUPPLIED_IN_GO=false`; `OWNER_RATIFIED_OPERATIONAL_FORMULA_PRESENT=false`; `FUNDING_AMOUNT_PROVEN=false`; I44&#47;G16 `INSUFFICIENT_EVIDENCE`; `LIVE_AUTHORIZED=false`; no money movement; not execute) |
+| [`docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md`](../runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md) §11.13.5.P | SSOT operational funding-formula ratification fail-closed (`AUTHORIZED_SCOPE=RATIFICATION_ONLY`; `FORMULA_BODY_SUPPLIED_IN_GO=false`; `OWNER_RATIFIED_OPERATIONAL_FORMULA_PRESENT=false`; `FUNDING_AMOUNT_PROVEN=false`; I44&#47;G16 `INSUFFICIENT_EVIDENCE`; `LIVE_AUTHORIZED=false`; no money movement; not execute; historical next pointer superseded by §11.13.5.Q; PR `#5910` squash-merged `736e7e21e`) |
+| [`docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md`](../runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md) §11.13.5.Q | SSOT operational funding-policy decision template (`AUTHORIZED_SCOPE=POLICY_SPEC_ONLY`; template unfilled; `FORMULA_BODY_STATUS=ABSENT`; `FUNDING_AMOUNT_PROVEN=false`; nine §11.13.5.N blockers remain open; GET evidence GO not granted; I44&#47;G16 `INSUFFICIENT_EVIDENCE`; `LIVE_AUTHORIZED=false`; no money movement; not execute) |
 | [`evidence&#47;ops&#47;section_11_13_5_live_canary_forensic_reconciliation_v1&#47;20260812T120000Z&#47;`](../../evidence/ops/section_11_13_5_live_canary_forensic_reconciliation_v1/20260812T120000Z/) | Owner §11.13.5 sealed forensic classification + authoring evidence (derived; non-SSOT; no productive network; writes&#47;orders=0; `MANIFEST_VERIFY_RC=0`; Live unauthorized) |
 | [`evidence&#47;ops&#47;section_11_13_5_b_pr_5879_squash_merge_and_pre_canary_readiness_v1&#47;20260812T123500Z&#47;`](../../evidence/ops/section_11_13_5_b_pr_5879_squash_merge_and_pre_canary_readiness_v1/20260812T123500Z/) | Owner §11.13.5.B PR `#5879` squash-merge closeout + pre-Canary dependency resolution (derived; non-SSOT; no execute; `MANIFEST_VERIFY_RC=0`) |
 | [`evidence&#47;ops&#47;section_11_13_5_live_canary_trade_capability_attestation_v1&#47;20260812T135723Z&#47;`](../../evidence/ops/section_11_13_5_live_canary_trade_capability_attestation_v1/20260812T135723Z/) | Owner §11.13.5.C trade-key attestation proven evidence (derived; non-SSOT; no secret values; no orders; `MANIFEST_VERIFY_RC=0`) |
@@ -574,6 +575,7 @@ SECTION_11_13_5_M_PR_5906_PERSISTENCE_CLOSEOUT_BOUND=true
 SECTION_11_13_5_N_FUNDING_AMOUNT_EVALUATION_BOUND=true
 SECTION_11_13_5_O_OPERATIONAL_FUNDING_EVIDENCE_BOUND=true
 SECTION_11_13_5_P_OPERATIONAL_FORMULA_RATIFICATION_BOUND=true
+SECTION_11_13_5_Q_OPERATIONAL_FUNDING_POLICY_SPEC_BOUND=true
 PRODUCTIVE_CANARY_SURFACE_MERGED_TO_ORIGIN_MAIN=true
 PR_5879_MERGE_COMMIT_SHA=b3dadd86d6821882c8184bd1f6f8e207cbc4af43
 PR_5902_SQUASH_MERGE_SHA=4adb0af23181cd9a8c032bbb57d3b189413a4226
@@ -582,6 +584,7 @@ PR_5906_SQUASH_MERGE_SHA=bc59e1e331588ab7e727c6909baa69e8a00d93da
 PR_5907_SQUASH_MERGE_SHA=27ceae9115de0ae8db196ce8417730f328c5e251
 PR_5908_SQUASH_MERGE_SHA=2c55d81dd25f7bab41a63c89ad05d8635b3eda6f
 PR_5909_SQUASH_MERGE_SHA=8c36b48bd4410459f6cbe4aaaa94a2ce3ca8a6e8
+PR_5910_SQUASH_MERGE_SHA=736e7e21e215ce23bdade697c67393b5685bbde4
 OWNER_MERGE_GO_FOR_BOUNDED_POST_401_REMEDIATION_PR_STATUS=DONE_MERGED
 OWNER_MERGE_GO_FOR_POST_K_PERSISTENCE_REMEDIATION_PR_STATUS=CONSUMED_CLOSED
 LIVE_CANARY_MINIMUM_EXPOSURE_EXECUTED=false
@@ -642,11 +645,13 @@ OWNER_GO_SECTION_11_13_5_EEA_XPERP_310404_REBIND_PREPARATION_STATUS=CONSUMED_MER
 OWNER_GO_FOR_NEW_FUNDING_STATUS=CONSUMED_EVALUATION_ONLY_AMOUNT_UNPROVEN
 OWNER_GO_REQUIRED_FOR_OPERATIONAL_CANARY_FUNDING_AMOUNT_EVIDENCE_STATUS=CONSUMED_EVIDENCE_ONLY_AMOUNT_UNPROVEN
 OWNER_GO_REQUIRED_TO_RATIFY_OPERATIONAL_FUNDING_FORMULA_STATUS=CONSUMED_RATIFICATION_ONLY_FORMULA_ABSENT
+OWNER_GO_BUILD_OPERATIONAL_FUNDING_POLICY_SPEC_ONLY_STATUS=CONSUMED_POLICY_SPEC_ONLY_TEMPLATE_UNFILLED
+OWNER_GO_REQUIRED_FOR_BOUNDED_OPERATIONAL_FUNDING_GET_EVIDENCE_STATUS=NOT_GRANTED
 NEW_CANARY_OWNER_GO_GRANTED=false
 LIVE_AUTHORIZED=false
 EARLIEST_UNRESOLVED_DEPENDENCY=CANARY_OPERATIONAL_MINIMUM_UNPROVEN_THEN_SEPARATE_NEW_EXECUTE_GO
 EARLIEST_UNRESOLVED_SECTION_POINTER=SECTION_11_13_5_LIVE_CANARY_MINIMUM_EXPOSURE
-NEXT_CANONICAL_STEP_POINTER=OWNER_GO_REQUIRED_TO_SUPPLY_OPERATIONAL_FUNDING_FORMULA
+NEXT_CANONICAL_STEP_POINTER=OWNER_FILL_OPERATIONAL_FUNDING_POLICY_DECISIONS_THEN_SEPARATE_BOUNDED_GET_EVIDENCE_GO
 SECTION_11_13_2_PACKAGE_POINTER=src&#47;ops&#47;section_11_13_2_live_private_read_only_v1&#47;
 SECTION_11_13_2_PROOF_EVIDENCE_POINTER=evidence&#47;ops&#47;section_11_13_2_live_private_read_only_proven_v1&#47;20260811T170310Z&#47;
 SECTION_11_13_3_PACKAGE_POINTER=src&#47;ops&#47;section_11_13_3_live_shadow_with_exchange_reconciliation_v1&#47;

--- a/docs/ops/specs/SECTION_11_13_5_LIVE_CANARY_MINIMUM_EXPOSURE_V1.md
+++ b/docs/ops/specs/SECTION_11_13_5_LIVE_CANARY_MINIMUM_EXPOSURE_V1.md
@@ -83,13 +83,14 @@ execute, order submit, account mutation, Cap 11.9 activation, clearing of
 
 ## Next steps
 
-Current SSOT: Master Runbook §11.13.5.P. Historical O-era next steps
-below are superseded for the current ratification-only formula
-fail-closed persist. Historical N-era next steps remain historical for
-the funding-amount evaluation. Historical M-era next steps remain
-historical for the persistence closeout. Historical L-era next steps
-remain historical for the GET bind. Historical J-era next steps remain
-historical for the rejected SWAP oneshot.
+Current SSOT: Master Runbook §11.13.5.Q. Historical P-era next steps
+below are superseded for the current policy-spec-only template persist.
+Historical O-era next steps remain historical for the evidence-only
+funding-amount fail-closed persist. Historical N-era next steps remain
+historical for the funding-amount evaluation. Historical M-era next
+steps remain historical for the persistence closeout. Historical L-era
+next steps remain historical for the GET bind. Historical J-era next
+steps remain historical for the rejected SWAP oneshot.
 
 1. Historical first canary POST HTTP 401 remains
    `UNPROVEN_FAIL_CLOSED` (no proven incident body). Do not rewrite it
@@ -137,7 +138,15 @@ historical for the rejected SWAP oneshot.
     granted `RATIFICATION_ONLY` and is consumed. No formula body was
     supplied. `OWNER_RATIFIED_OPERATIONAL_FORMULA_PRESENT=false`.
     `FUNDING_AMOUNT_PROVEN=false`.
-11. Next canonical step is
-    `OWNER_GO_REQUIRED_TO_SUPPLY_OPERATIONAL_FUNDING_FORMULA`, then a
-    **separate** new execute GO if granted. This spec does not
+11. `OWNER_GO_BUILD_OPERATIONAL_FUNDING_POLICY_SPEC_ONLY` persisted the
+    Owner decision template as `POLICY_SPEC_ONLY`. All nine policy
+    fields remain `UNRESOLVED_OWNER_DECISION_REQUIRED`. This is **not**
+    a formula body, **not** formula ratification, **not** a GET-GO,
+    **not** a funding-GO, and **not** a Canary-execute-GO.
+    `FUNDING_AMOUNT_PROVEN=false`.
+12. Next canonical step is
+    `OWNER_FILL_OPERATIONAL_FUNDING_POLICY_DECISIONS_THEN_SEPARATE_BOUNDED_GET_EVIDENCE_GO`.
+    `OWNER_GO_REQUIRED_FOR_BOUNDED_OPERATIONAL_FUNDING_GET_EVIDENCE` is
+    **not** granted. Later formula instantiation, formula ratification,
+    funding, and execute remain separate. This spec does not
     authorize execute, funding, GET refresh, or general Live unlock.

--- a/docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md
+++ b/docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md
@@ -11220,16 +11220,198 @@ Live vs Demo identity remains strictly separated. Map of Truth
 ``` text
 CODE_OWNER=src&#47;ops&#47;section_11_13_5_live_canary_minimum_exposure_v1&#47;
 CURRENT_CANONICAL_NEXT_STEP_AUTHORITY=SECTION_11_13_5
-CANONICAL_NEXT_STEP=OWNER_GO_REQUIRED_TO_SUPPLY_OPERATIONAL_FUNDING_FORMULA
-EARLIEST_UNRESOLVED_DEPENDENCY=CANARY_OPERATIONAL_MINIMUM_UNPROVEN_THEN_SEPARATE_NEW_EXECUTE_GO
+CANONICAL_NEXT_STEP=SUPERSEDED_BY_SECTION_11_13_5_Q
+EARLIEST_UNRESOLVED_DEPENDENCY=SUPERSEDED_BY_SECTION_11_13_5_Q
 EARLIEST_UNRESOLVED_SECTION_POINTER=SECTION_11_13_5_LIVE_CANARY_MINIMUM_EXPOSURE
 ```
 
 Hard stop. This ratification GO is consumed and must not be reused for
 money movement, GET refresh, execute, or as a substitute formula body.
 `OWNER_GO_LIVE_CANARY_MINIMUM_EXPOSURE` remains `CONSUMED`. Cap &#47;
-Capability 11.9 remains fixture-only. No funding. No execute. No merge
-of this ratification persist without a separate `OWNER_MERGE_GO`.
+Capability 11.9 remains fixture-only. The P-era next pointer
+`OWNER_GO_REQUIRED_TO_SUPPLY_OPERATIONAL_FUNDING_FORMULA` is **not**
+granted and **not** consumed here; it is superseded as immediate next
+by §11.13.5.Q below and remains a later formula-supply step. No funding
+executed. No execute.
+
+### 11.13.5.Q Operational funding-policy decision template (BOUND; POLICY-SPEC-ONLY; TEMPLATE UNFILLED; FORMULA ABSENT; NOT FUNDED; NOT EXECUTE)
+
+Owner-GO `OWNER_GO_BUILD_OPERATIONAL_FUNDING_POLICY_SPEC_ONLY`
+(one-shot; now **CONSUMED**) authorized **policy-spec persistence
+only**: the Owner operational-funding decision grammar &#47; blank
+template for §11.13.5.N&#47;O&#47;P, plus the fail-closed authority
+sequence. Bound scope:
+
+``` text
+AUTHORIZED_SCOPE=POLICY_SPEC_ONLY
+FUNDING_EXECUTION_AUTHORIZED=false
+EXTERNAL_MONEY_MOVEMENT_AUTHORIZED=false
+TRADING_POST_AUTHORIZED=false
+CANARY_EXECUTE_AUTHORIZED=false
+LIVE_AUTHORIZED=false
+GENERAL_LIVE_UNLOCKED=false
+NETWORK_SESSION_AUTHORIZED=false
+CREDENTIAL_ACCESS_AUTHORIZED=false
+GET_ONLY_REFRESH_AUTHORIZED=false
+FORMULA_BODY_SUPPLIED_IN_GO=false
+NUMERIC_COEFFICIENTS_AUTHORIZED=false
+```
+
+This does **not** authorize deposit, transfer, withdrawal, convert,
+buy&#47;sell, Trading-POST, Canary execute, orders, positions,
+set-leverage mutation, API-key &#47; account mutation, a productive
+OKX GET refresh, max-avail-size GET, inventing or rounding a funding
+amount, inventing fee&#47;slippage&#47;MM&#47;haircut parameters,
+promoting snapshot IM to an operational formula, filling this template
+with numbers, treating a filled template as formula ratification,
+I44 &#47; G16 upgrade, general Live unlock, Multi-Future, Double Play &#47;
+Master V2 changes, or merge without a separate `OWNER_MERGE_GO`.
+
+This template is **not** an operational funding formula. Filling it is
+**not** formula ratification. It is **not** a GET-GO, **not** a
+funding-GO, and **not** a Canary-execute-GO.
+`OWNER_GO_REQUIRED_FOR_BOUNDED_OPERATIONAL_FUNDING_GET_EVIDENCE` is
+documented below and is **not** granted here.
+
+``` text
+CURRENT_PHASE=SECTION_11_13_5_Q_OPERATIONAL_FUNDING_POLICY_SPEC
+OWNER_GO=OWNER_GO_BUILD_OPERATIONAL_FUNDING_POLICY_SPEC_ONLY
+OWNER_GO_STATUS=CONSUMED
+OWNER_GO_SCOPE=POLICY_SPEC_ONLY
+POLICY_SPEC_STATUS=TEMPLATE_PERSISTED_UNFILLED
+FORMULA_BODY_STATUS=ABSENT
+BASELINE_ORIGIN_MAIN_SHA=736e7e21e215ce23bdade697c67393b5685bbde4
+PR_5910_STATUS=SQUASH_MERGED
+PR_5910_MERGE_SHA=736e7e21e215ce23bdade697c67393b5685bbde4
+CANARY_INSTRUMENT=BTC-USD_UM_XPERP-310404
+SETTLEMENT_ACCOUNT_TRUTH=USDC
+SET_ACCOUNT_LEVERAGE=3
+SNAPSHOT_THEORETICAL_IM_FORMULA=markPx * ctVal * qty / SET_ACCOUNT_LEVERAGE
+SNAPSHOT_THEORETICAL_INITIAL_MARGIN_USDC=2.101456666666666666666666667
+SNAPSHOT_IM_ROLE=FLOOR_ONLY_NOT_OPERATIONAL_FORMULA
+SNAPSHOT_IM_FORMULA_RATIFIED_AS_OPERATIONAL=false
+OWNER_SUPPLIED_OPERATIONAL_FORMULA_BODY=NONE
+OWNER_RATIFIED_OPERATIONAL_FORMULA_PRESENT=false
+F_OWNER_OPERATOR=UNRESOLVED
+MINIMUM_THEORETICAL_INITIAL_MARGIN_PROVEN=true
+SNAPSHOT_THEORETICAL_FUNDING_FLOOR_PROVEN=true
+CANARY_OPERATIONAL_MINIMUM_PROVEN=false
+RECOMMENDED_BOUNDED_CANARY_FUNDING_AMOUNT_PROVEN=false
+FUNDING_AMOUNT_PROVEN=false
+PROVEN_FUNDING_AMOUNT=NONE
+PROVEN_FUNDING_AMOUNT_UNIT=NONE
+SNAPSHOT_FLOOR_IS_NOT_OPERATIONAL_FUNDING_AMOUNT=true
+NEW_VENUE_GET_COLLECTED=false
+MAX_AVAIL_SIZE_GET_COLLECTED=false
+MARKPX_REFRESH_COLLECTED=false
+I44_FUTURES_FUNDING_ECONOMICS_STATUS=INSUFFICIENT_EVIDENCE
+G16_FUNDING_PROOF_STATUS=INSUFFICIENT_EVIDENCE
+FUNDING_EXECUTED=false
+EXTERNAL_MONEY_MOVEMENT=false
+CANARY_EXECUTED=false
+TRADING_POSTS=0
+ACCOUNT_MUTATION=false
+CREDENTIAL_MUTATION=false
+TRADING_LOGIC_CHANGED=false
+MASTER_V2_CHANGED=false
+DOUBLE_PLAY_CHANGED=false
+RUNTIME_AUTHORITY_EXPANDED=false
+LIVE_AUTHORIZED=false
+GENERAL_LIVE_UNLOCKED=false
+NEW_EXECUTE_GO_REQUIRED=true
+FUNDING_GO_AND_EXECUTE_GO_COLLAPSED=false
+GET_EVIDENCE_GO_GRANTED_BY_THIS_POLICY_SPEC=false
+EXECUTE_AUTHORIZED_BY_THIS_POLICY_SPEC_GO=false
+ORDER_EFFECT=NONE
+ACCOUNT_MUTATION_EFFECT=NONE
+FUNDING_EFFECT=NONE
+SECRET_VALUE_ACCESS=NONE
+```
+
+Owner decision template (blank; `UNRESOLVED` &#47;
+`OWNER_DECISION_REQUIRED`; no numeric coefficients):
+
+``` text
+OWNER_OPERATIONAL_FUNDING_POLICY_DECISIONS
+F_OWNER_COMPOSITION=UNRESOLVED_OWNER_DECISION_REQUIRED
+FEE_RESERVE_POLICY=UNRESOLVED_OWNER_DECISION_REQUIRED
+SLIPPAGE_RESERVE_POLICY=UNRESOLVED_OWNER_DECISION_REQUIRED
+MM_LIQ_BUFFER_POLICY=UNRESOLVED_OWNER_DECISION_REQUIRED
+VENUE_MIN_AVAIL_EQ_FORMULA_ROLE=UNRESOLVED_OWNER_DECISION_REQUIRED
+FUNDING_RATE_RESERVE_POLICY=UNRESOLVED_OWNER_DECISION_REQUIRED
+USD_USDC_HAIRCUT_POLICY=UNRESOLVED_OWNER_DECISION_REQUIRED
+OPERATIONAL_ROUNDING_POLICY=UNRESOLVED_OWNER_DECISION_REQUIRED
+MARKPX_AND_METADATA_FRESHNESS_BINDING_POLICY=UNRESOLVED_OWNER_DECISION_REQUIRED
+```
+
+Forbidden in this template and in any later fill of it under this
+section:
+
+``` text
+NO_FEE_BUFFER_BPS
+NO_SLIPPAGE_BPS
+NO_HAIRCUT_BPS
+NO_PADDED_USDC_AMOUNT
+NO_USD_EQUALS_USDC_ASSUMPTION
+NO_I44_G16_AS_CANARY_CAPITAL_RESERVE
+NO_SNAPSHOT_IM_PROMOTION
+NO_NUMERIC_COEFFICIENT_INVENTION
+```
+
+Fail-closed authority sequence (do not collapse):
+
+``` text
+1_POLICY_SPEC_OWNER_DECISION_GRAMMAR
+2_SEPARATE_OWNER_GO_REQUIRED_FOR_BOUNDED_OPERATIONAL_FUNDING_GET_EVIDENCE
+3_FRESH_GET_ONLY_EVIDENCE
+4_FORMULA_INSTANTIATION
+5_SEPARATE_OWNER_RATIFICATION_OF_EXACT_FORMULA_BODY
+6_SEPARATE_FUNDING_AUTHORIZATION
+7_SEPARATE_CANARY_EXECUTE_AUTHORIZATION
+```
+
+Step 2 token `OWNER_GO_REQUIRED_FOR_BOUNDED_OPERATIONAL_FUNDING_GET_EVIDENCE`
+is **proposed only** and **not granted**. Fresh productive GET evidence
+remains a later authority step. Snapshot IM
+`2.101456666666666666666666667` USDC remains
+`FLOOR_ONLY_NOT_OPERATIONAL_FORMULA` and must not be rounded, padded, or
+promoted. I44 &#47; Master G16 remain `INSUFFICIENT_EVIDENCE` and must
+not be used as a canary capital reserve.
+
+Still missing (unchanged; none closed by this policy-spec persist):
+
+1. Owner-supplied operational formula body distinct from snapshot IM.
+2. Positive fee-reserve policy.
+3. Proven slippage &#47; spread buffer policy.
+4. Proven maintenance-margin &#47; liquidation buffer. Public `imr=0.02`
+   remains a tier limit.
+5. Venue-native max-avail-size &#47; min-available-equity GET for one
+   contract. Requires a **separate** scoped GET-only GO plus
+   credentials; not authorized here.
+6. Fresh productive markPx GET refresh. Requires a **separate** scoped
+   GET-only GO; not authorized here.
+7. I44 &#47; Master G16 remains `INSUFFICIENT_EVIDENCE`.
+8. Public USD versus account USDC haircut policy.
+9. `totalEq=0` still does not prove deposit size.
+
+Live vs Demo identity remains strictly separated. Map of Truth
+`CANONICAL_ACTIVE_INSTRUMENT=BTC-USD_UM_XPERP-310328` remains the
+§11.12.8 Demo campaign binding and is **not** retargeted.
+
+``` text
+CODE_OWNER=src&#47;ops&#47;section_11_13_5_live_canary_minimum_exposure_v1&#47;
+CURRENT_CANONICAL_NEXT_STEP_AUTHORITY=SECTION_11_13_5
+CANONICAL_NEXT_STEP=OWNER_FILL_OPERATIONAL_FUNDING_POLICY_DECISIONS_THEN_SEPARATE_BOUNDED_GET_EVIDENCE_GO
+EARLIEST_UNRESOLVED_DEPENDENCY=CANARY_OPERATIONAL_MINIMUM_UNPROVEN_THEN_SEPARATE_NEW_EXECUTE_GO
+EARLIEST_UNRESOLVED_SECTION_POINTER=SECTION_11_13_5_LIVE_CANARY_MINIMUM_EXPOSURE
+```
+
+Hard stop. This policy-spec GO is consumed and must not be reused for
+money movement, GET refresh, execute, formula ratification, or as a
+substitute formula body. `OWNER_GO_LIVE_CANARY_MINIMUM_EXPOSURE`
+remains `CONSUMED`. Cap &#47; Capability 11.9 remains fixture-only. No
+funding. No execute. No merge of this policy-spec persist without a
+separate `OWNER_MERGE_GO`.
 
 ## 11.14 Live order and economic evidence ladder
 

--- a/docs/runbooks/operations/PEAK_TRADE_PERSISTENCE_REMEDIATION_TRACKER.md
+++ b/docs/runbooks/operations/PEAK_TRADE_PERSISTENCE_REMEDIATION_TRACKER.md
@@ -92,13 +92,14 @@ All GAP items are `CLOSED_CANONICALLY_PERSISTED` by squash-merge
 **retained** on HEAD for audit. It is **not** deleted: the original
 delete-after-closeout-on-`origin&#47;main` rule is not satisfied at
 closeout authoring time, and historical pointer chains still name this
-path. Canonical authority remains SSOT §11.13.5.P. The O-era pointer
-`OWNER_GO_REQUIRED_TO_RATIFY_OPERATIONAL_FUNDING_FORMULA` is consumed as
-ratification-only with no Owner-supplied formula body. Snapshot
-theoretical IM is not an operational funding amount.
+path. Canonical authority remains SSOT §11.13.5.Q. The P-era pointer
+`OWNER_GO_REQUIRED_TO_SUPPLY_OPERATIONAL_FUNDING_FORMULA` is not granted
+and not consumed; it remains a later formula-supply step after Owner
+policy fill and a separate GET-evidence GO. Snapshot theoretical IM is
+not an operational funding amount.
 
 ```text
-CANONICAL_NEXT_STEP=OWNER_GO_REQUIRED_TO_SUPPLY_OPERATIONAL_FUNDING_FORMULA
+CANONICAL_NEXT_STEP=OWNER_FILL_OPERATIONAL_FUNDING_POLICY_DECISIONS_THEN_SEPARATE_BOUNDED_GET_EVIDENCE_GO
 EARLIEST_UNRESOLVED_DEPENDENCY=CANARY_OPERATIONAL_MINIMUM_UNPROVEN_THEN_SEPARATE_NEW_EXECUTE_GO
 PERSISTENCE_REMEDIATION_PR_MERGED=true
 TRACKER_RETIREMENT_ALLOWED=true


### PR DESCRIPTION
## Summary
- Persist §11.13.5.Q as a bounded **POLICY_SPEC_ONLY** Owner decision template for the operational canary funding grammar.
- Template fields remain `UNRESOLVED_OWNER_DECISION_REQUIRED` with **no numeric coefficients** and **no operational formula body**.
- Fail-closed authority sequence is documented; `OWNER_GO_REQUIRED_FOR_BOUNDED_OPERATIONAL_FUNDING_GET_EVIDENCE` is **not granted**. The nine §11.13.5.N blockers remain open.

## Explicit non-authorization
- Not a formula ratification
- Not a GET-GO
- Not a funding-GO
- Not a Canary-execute-GO
- No OKX GET/POST, no set-leverage, no deposit/transfer/withdraw/convert
- Snapshot IM `2.101456666666666666666666667` USDC remains `FLOOR_ONLY_NOT_OPERATIONAL_FORMULA`
- I44/G16 remain `INSUFFICIENT_EVIDENCE` and must not be used as a canary capital reserve
- USD is not assumed equal to USDC

## Test plan
- [x] Canonical CI selector on exact docs diff → `NO_OP`
- [x] Docs token policy on the four changed Markdown files → PASS
- [x] Docs reference targets on the four changed Markdown files → PASS
- [ ] GitHub required checks (docs-only confirmation)
- Do **not** auto-merge
- Do **not** treat merge as GET, funding, or execute authorization


Made with [Cursor](https://cursor.com)