### PR TITLE
docs(11.13.5): fail-closed operational formula instantiation without numeric reserve terms

### DIFF
--- a/docs/governance/PEAK_TRADE_MAP_OF_TRUTH.md
+++ b/docs/governance/PEAK_TRADE_MAP_OF_TRUTH.md
@@ -300,7 +300,8 @@ Ergänzende Owner-/Wiring-Hinweise (keine parallele Trading-SSOT):
 | [`docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md`](../runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md) §11.13.5.P | SSOT operational funding-formula ratification fail-closed (`AUTHORIZED_SCOPE=RATIFICATION_ONLY`; `FORMULA_BODY_SUPPLIED_IN_GO=false`; `OWNER_RATIFIED_OPERATIONAL_FORMULA_PRESENT=false`; `FUNDING_AMOUNT_PROVEN=false`; I44&#47;G16 `INSUFFICIENT_EVIDENCE`; `LIVE_AUTHORIZED=false`; no money movement; not execute; historical next pointer superseded by §11.13.5.Q; PR `#5910` squash-merged `736e7e21e`) |
 | [`docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md`](../runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md) §11.13.5.Q | SSOT operational funding-policy decision template (`AUTHORIZED_SCOPE=POLICY_SPEC_ONLY`; template unfilled; `FORMULA_BODY_STATUS=ABSENT`; `FUNDING_AMOUNT_PROVEN=false`; nine §11.13.5.N blockers remain open; GET evidence GO not granted; I44&#47;G16 `INSUFFICIENT_EVIDENCE`; `LIVE_AUTHORIZED=false`; no money movement; not execute; historical next pointer superseded by §11.13.5.R; PR `#5911` squash-merged `e0b3438ef`) |
 | [`docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md`](../runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md) §11.13.5.R | SSOT Owner operational funding-policy decisions (`AUTHORIZED_SCOPE=POLICY_GRAMMAR_FILL_ONLY`; `OWNER_POLICY_DECISIONS_STATUS=PERSISTED_POLICY_GRAMMAR_NOT_FORMULA_RATIFICATION`; `FORMULA_BODY_STATUS=ABSENT`; `NUMERIC_COEFFICIENTS_ADDED=false`; `FUNDING_AMOUNT_PROVEN=false`; nine §11.13.5.N blockers remain open; GET evidence GO not granted; I44&#47;G16 `INSUFFICIENT_EVIDENCE`; `LIVE_AUTHORIZED=false`; no money movement; not execute; historical next pointer superseded by §11.13.5.S; PR `#5912` squash-merged `b4dc3f1a5`) |
-| [`docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md`](../runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md) §11.13.5.S | SSOT bounded operational funding GET evidence (`AUTHORIZED_SCOPE=GET_ONLY_EVIDENCE`; fresh markPx `62986.2`; `FRESH_THEORETICAL_IM_FLOOR_USDC=2.09954` floor-only; `max-avail-size` `availBuy=0` `availSell=0`; `totalEq=0`; `FORMULA_BODY_STATUS=ABSENT`; `FUNDING_AMOUNT_PROVEN=false`; I44&#47;G16 `INSUFFICIENT_EVIDENCE`; `LIVE_AUTHORIZED=false`; no money movement; not execute) |
+| [`docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md`](../runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md) §11.13.5.S | SSOT bounded operational funding GET evidence (`AUTHORIZED_SCOPE=GET_ONLY_EVIDENCE`; fresh markPx `62986.2`; `FRESH_THEORETICAL_IM_FLOOR_USDC=2.09954` floor-only; `max-avail-size` `availBuy=0` `availSell=0`; `totalEq=0`; `FORMULA_BODY_STATUS=ABSENT`; `FUNDING_AMOUNT_PROVEN=false`; I44&#47;G16 `INSUFFICIENT_EVIDENCE`; `LIVE_AUTHORIZED=false`; no money movement; not execute; historical next pointer superseded by §11.13.5.T; PR `#5913` squash-merged `d96f8ec50`) |
+| [`docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md`](../runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md) §11.13.5.T | SSOT operational formula instantiation fail-closed (`AUTHORIZED_SCOPE=FORMULA_INSTANTIATION_ONLY`; `FORMULA_BODY_SUPPLIED_IN_GO=false`; `INSTANTIATION_EFFECT=NONE`; `FULL_FORMULA_INSTANTIATION=false`; `FORMULA_BODY_STATUS=ABSENT`; `NUMERIC_COEFFICIENTS_ADDED=false`; fresh IM floor `2.09954` USDC not operational amount; I44&#47;G16 `INSUFFICIENT_EVIDENCE`; `LIVE_AUTHORIZED=false`; no money movement; not execute) |
 | [`evidence&#47;ops&#47;section_11_13_5_live_canary_forensic_reconciliation_v1&#47;20260812T120000Z&#47;`](../../evidence/ops/section_11_13_5_live_canary_forensic_reconciliation_v1/20260812T120000Z/) | Owner §11.13.5 sealed forensic classification + authoring evidence (derived; non-SSOT; no productive network; writes&#47;orders=0; `MANIFEST_VERIFY_RC=0`; Live unauthorized) |
 | [`evidence&#47;ops&#47;section_11_13_5_b_pr_5879_squash_merge_and_pre_canary_readiness_v1&#47;20260812T123500Z&#47;`](../../evidence/ops/section_11_13_5_b_pr_5879_squash_merge_and_pre_canary_readiness_v1/20260812T123500Z/) | Owner §11.13.5.B PR `#5879` squash-merge closeout + pre-Canary dependency resolution (derived; non-SSOT; no execute; `MANIFEST_VERIFY_RC=0`) |
 | [`evidence&#47;ops&#47;section_11_13_5_live_canary_trade_capability_attestation_v1&#47;20260812T135723Z&#47;`](../../evidence/ops/section_11_13_5_live_canary_trade_capability_attestation_v1/20260812T135723Z/) | Owner §11.13.5.C trade-key attestation proven evidence (derived; non-SSOT; no secret values; no orders; `MANIFEST_VERIFY_RC=0`) |
@@ -581,6 +582,7 @@ SECTION_11_13_5_P_OPERATIONAL_FORMULA_RATIFICATION_BOUND=true
 SECTION_11_13_5_Q_OPERATIONAL_FUNDING_POLICY_SPEC_BOUND=true
 SECTION_11_13_5_R_OPERATIONAL_FUNDING_POLICY_DECISIONS_BOUND=true
 SECTION_11_13_5_S_OPERATIONAL_FUNDING_GET_EVIDENCE_BOUND=true
+SECTION_11_13_5_T_OPERATIONAL_FORMULA_INSTANTIATION_BOUND=true
 PRODUCTIVE_CANARY_SURFACE_MERGED_TO_ORIGIN_MAIN=true
 PR_5879_MERGE_COMMIT_SHA=b3dadd86d6821882c8184bd1f6f8e207cbc4af43
 PR_5902_SQUASH_MERGE_SHA=4adb0af23181cd9a8c032bbb57d3b189413a4226
@@ -592,6 +594,7 @@ PR_5909_SQUASH_MERGE_SHA=8c36b48bd4410459f6cbe4aaaa94a2ce3ca8a6e8
 PR_5910_SQUASH_MERGE_SHA=736e7e21e215ce23bdade697c67393b5685bbde4
 PR_5911_SQUASH_MERGE_SHA=e0b3438ef10e35e2b25461b8868f1db2324fa0a6
 PR_5912_SQUASH_MERGE_SHA=b4dc3f1a57f463e7a354bfe4c5709bc3a230a36f
+PR_5913_SQUASH_MERGE_SHA=d96f8ec50637f06b327dd882aa619464b87d9f91
 OWNER_MERGE_GO_FOR_BOUNDED_POST_401_REMEDIATION_PR_STATUS=DONE_MERGED
 OWNER_MERGE_GO_FOR_POST_K_PERSISTENCE_REMEDIATION_PR_STATUS=CONSUMED_CLOSED
 LIVE_CANARY_MINIMUM_EXPOSURE_EXECUTED=false
@@ -655,12 +658,13 @@ OWNER_GO_REQUIRED_TO_RATIFY_OPERATIONAL_FUNDING_FORMULA_STATUS=CONSUMED_RATIFICA
 OWNER_GO_BUILD_OPERATIONAL_FUNDING_POLICY_SPEC_ONLY_STATUS=CONSUMED_POLICY_SPEC_ONLY_TEMPLATE_UNFILLED
 OWNER_FILL_OPERATIONAL_FUNDING_POLICY_DECISIONS_STATUS=CONSUMED_POLICY_GRAMMAR_PERSISTED_NOT_FORMULA_RATIFICATION
 OWNER_GO_FOR_BOUNDED_OPERATIONAL_FUNDING_GET_EVIDENCE_STATUS=CONSUMED_GET_ONLY_EVIDENCE_AMOUNT_UNPROVEN
-OWNER_GO_REQUIRED_FOR_OPERATIONAL_FORMULA_INSTANTIATION_STATUS=NOT_GRANTED
+OWNER_GO_REQUIRED_FOR_OPERATIONAL_FORMULA_INSTANTIATION_STATUS=CONSUMED_INSTANTIATION_ONLY_FORMULA_ABSENT
+OWNER_GO_REQUIRED_TO_SUPPLY_NUMERIC_OPERATIONAL_RESERVE_TERMS_STATUS=NOT_GRANTED
 NEW_CANARY_OWNER_GO_GRANTED=false
 LIVE_AUTHORIZED=false
 EARLIEST_UNRESOLVED_DEPENDENCY=CANARY_OPERATIONAL_MINIMUM_UNPROVEN_THEN_SEPARATE_NEW_EXECUTE_GO
 EARLIEST_UNRESOLVED_SECTION_POINTER=SECTION_11_13_5_LIVE_CANARY_MINIMUM_EXPOSURE
-NEXT_CANONICAL_STEP_POINTER=OWNER_GO_REQUIRED_FOR_OPERATIONAL_FORMULA_INSTANTIATION
+NEXT_CANONICAL_STEP_POINTER=OWNER_GO_REQUIRED_TO_SUPPLY_NUMERIC_OPERATIONAL_RESERVE_TERMS
 SECTION_11_13_2_PACKAGE_POINTER=src&#47;ops&#47;section_11_13_2_live_private_read_only_v1&#47;
 SECTION_11_13_2_PROOF_EVIDENCE_POINTER=evidence&#47;ops&#47;section_11_13_2_live_private_read_only_proven_v1&#47;20260811T170310Z&#47;
 SECTION_11_13_3_PACKAGE_POINTER=src&#47;ops&#47;section_11_13_3_live_shadow_with_exchange_reconciliation_v1&#47;

--- a/docs/ops/specs/SECTION_11_13_5_LIVE_CANARY_MINIMUM_EXPOSURE_V1.md
+++ b/docs/ops/specs/SECTION_11_13_5_LIVE_CANARY_MINIMUM_EXPOSURE_V1.md
@@ -83,17 +83,18 @@ execute, order submit, account mutation, Cap 11.9 activation, clearing of
 
 ## Next steps
 
-Current SSOT: Master Runbook §11.13.5.S. Historical R-era next steps
-below are superseded for the current GET-only funding-evidence persist.
-Historical Q-era next steps remain historical for the policy-grammar
-fill persist. Historical P-era next steps remain historical for the
-ratification-only formula fail-closed persist. Historical O-era next
-steps remain historical for the evidence-only funding-amount fail-closed
-persist. Historical N-era next steps remain historical for the
-funding-amount evaluation. Historical M-era next steps remain historical
-for the persistence closeout. Historical L-era next steps remain
-historical for the GET bind. Historical J-era next steps remain
-historical for the rejected SWAP oneshot.
+Current SSOT: Master Runbook §11.13.5.T. Historical S-era next steps
+below are superseded for the current instantiation-only fail-closed
+persist. Historical R-era next steps remain historical for the GET-only
+funding-evidence persist. Historical Q-era next steps remain historical
+for the policy-grammar fill persist. Historical P-era next steps remain
+historical for the ratification-only formula fail-closed persist.
+Historical O-era next steps remain historical for the evidence-only
+funding-amount fail-closed persist. Historical N-era next steps remain
+historical for the funding-amount evaluation. Historical M-era next
+steps remain historical for the persistence closeout. Historical L-era
+next steps remain historical for the GET bind. Historical J-era next
+steps remain historical for the rejected SWAP oneshot.
 
 1. Historical first canary POST HTTP 401 remains
    `UNPROVEN_FAIL_CLOSED` (no proven incident body). Do not rewrite it
@@ -163,8 +164,16 @@ historical for the rejected SWAP oneshot.
     `FUNDING_AMOUNT_PROVEN=false`. This is **not** formula
     instantiation, **not** formula ratification, **not** a funding-GO,
     and **not** a Canary-execute-GO.
-14. Next canonical step is
-    `OWNER_GO_REQUIRED_FOR_OPERATIONAL_FORMULA_INSTANTIATION`.
+14. `OWNER_GO_REQUIRED_FOR_OPERATIONAL_FORMULA_INSTANTIATION` was
+    granted `FORMULA_INSTANTIATION_ONLY` and is consumed. No formula
+    body and no numeric reserve terms were supplied. Instantiation
+    effect is `NONE`. Fresh theoretical IM `2.09954` USDC remains a
+    floor only. `FULL_FORMULA_INSTANTIATION=false`.
+    `FORMULA_BODY_STATUS=ABSENT`. `FUNDING_AMOUNT_PROVEN=false`. This
+    is **not** formula ratification, **not** a funding-GO, and **not**
+    a Canary-execute-GO.
+15. Next canonical step is
+    `OWNER_GO_REQUIRED_TO_SUPPLY_NUMERIC_OPERATIONAL_RESERVE_TERMS`.
     That GO is **not** granted. Later formula ratification, funding, and
     execute remain separate. This spec does not authorize execute,
     funding, another GET, or general Live unlock.

--- a/docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md
+++ b/docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md
@@ -11898,17 +11898,229 @@ Live vs Demo identity remains strictly separated. Map of Truth
 ``` text
 CODE_OWNER=src&#47;ops&#47;section_11_13_5_live_canary_minimum_exposure_v1&#47;
 CURRENT_CANONICAL_NEXT_STEP_AUTHORITY=SECTION_11_13_5
-CANONICAL_NEXT_STEP=OWNER_GO_REQUIRED_FOR_OPERATIONAL_FORMULA_INSTANTIATION
-EARLIEST_UNRESOLVED_DEPENDENCY=CANARY_OPERATIONAL_MINIMUM_UNPROVEN_THEN_SEPARATE_NEW_EXECUTE_GO
+CANONICAL_NEXT_STEP=SUPERSEDED_BY_SECTION_11_13_5_T
+EARLIEST_UNRESOLVED_DEPENDENCY=SUPERSEDED_BY_SECTION_11_13_5_T
 EARLIEST_UNRESOLVED_SECTION_POINTER=SECTION_11_13_5_LIVE_CANARY_MINIMUM_EXPOSURE
 ```
 
 Hard stop. This GET-evidence GO is consumed and must not be reused for
 money movement, another GET, execute, formula instantiation, or formula
-ratification. `OWNER_GO_REQUIRED_FOR_OPERATIONAL_FORMULA_INSTANTIATION`
-is **not** granted. `OWNER_GO_LIVE_CANARY_MINIMUM_EXPOSURE` remains
+ratification. The S-era next pointer
+`OWNER_GO_REQUIRED_FOR_OPERATIONAL_FORMULA_INSTANTIATION` is
+**consumed** as instantiation-only by §11.13.5.T below. Numeric reserve
+terms, formula ratification, funding, and execute remain **not
+granted**. `OWNER_GO_LIVE_CANARY_MINIMUM_EXPOSURE` remains `CONSUMED`.
+Cap &#47; Capability 11.9 remains fixture-only. No funding. No execute.
+
+### 11.13.5.T Operational formula instantiation (BOUND; FAIL-CLOSED; INSTANTIATION-ONLY; FORMULA ABSENT; NOT FUNDED; NOT EXECUTE)
+
+Owner-GO `OWNER_GO_REQUIRED_FOR_OPERATIONAL_FORMULA_INSTANTIATION`
+(one-shot; now **CONSUMED**) authorized **instantiation-only** binding
+of the persisted §11.13.5.R conservative-cover composition grammar to
+the sealed §11.13.5.S GET pack. Bound scope:
+
+``` text
+AUTHORIZED_SCOPE=FORMULA_INSTANTIATION_ONLY
+FUNDING_EXECUTION_AUTHORIZED=false
+EXTERNAL_MONEY_MOVEMENT_AUTHORIZED=false
+TRADING_POST_AUTHORIZED=false
+CANARY_EXECUTE_AUTHORIZED=false
+LIVE_AUTHORIZED=false
+GENERAL_LIVE_UNLOCKED=false
+NETWORK_SESSION_AUTHORIZED=false
+CREDENTIAL_ACCESS_AUTHORIZED=false
+GET_ONLY_REFRESH_AUTHORIZED=false
+FORMULA_BODY_SUPPLIED_IN_GO=false
+NUMERIC_COEFFICIENTS_AUTHORIZED=false
+FORMULA_RATIFICATION_AUTHORIZED=false
+```
+
+This does **not** authorize deposit, transfer, withdrawal, convert,
+buy&#47;sell, Trading-POST, Canary execute, orders, positions,
+set-leverage mutation, API-key &#47; account mutation, a productive
+OKX GET refresh, inventing or rounding a funding amount, inventing
+fee&#47;slippage&#47;MM&#47;haircut numeric coefficients, promoting
+fresh theoretical IM to an operational formula, treating this
+instantiation attempt as formula ratification, I44 &#47; G16 upgrade,
+general Live unlock, Multi-Future, Double Play &#47; Master V2 changes,
+or merge without a separate `OWNER_MERGE_GO`.
+
+The granted GO contained **no** operational formula body and **no**
+numeric reserve terms. Instantiation therefore has **no effect**. Fresh
+theoretical IM `2.09954` USDC remains a floor only and is **not**
+promoted to an operational funding amount.
+
+Sealed GET pack (derived; non-SSOT; not mutated):
+
+`evidence&#47;ops&#47;section_11_13_5_operational_funding_get_evidence_v1&#47;20260816T060349Z&#47;`
+
+``` text
+CURRENT_PHASE=SECTION_11_13_5_T_OPERATIONAL_FORMULA_INSTANTIATION_FAIL_CLOSED
+OWNER_GO=OWNER_GO_REQUIRED_FOR_OPERATIONAL_FORMULA_INSTANTIATION
+OWNER_GO_STATUS=CONSUMED
+OWNER_GO_SCOPE=FORMULA_INSTANTIATION_ONLY
+INSTANTIATION_EFFECT=NONE
+FULL_FORMULA_INSTANTIATION=false
+FORMULA_BODY_STATUS=ABSENT
+NUMERIC_COEFFICIENTS_ADDED=false
+NUMERIC_COEFFICIENTS_INVENTED=false
+BASELINE_ORIGIN_MAIN_SHA=d96f8ec50637f06b327dd882aa619464b87d9f91
+PR_5913_STATUS=SQUASH_MERGED
+PR_5913_MERGE_SHA=d96f8ec50637f06b327dd882aa619464b87d9f91
+BOUND_GET_PACK=evidence&#47;ops&#47;section_11_13_5_operational_funding_get_evidence_v1&#47;20260816T060349Z&#47;
+CANARY_INSTRUMENT=BTC-USD_UM_XPERP-310404
+SETTLEMENT_ACCOUNT_TRUTH=USDC
+PUBLIC_SETTLE_CCY=USD
+ACCOUNT_SETTLE_CCY=USDC
+SET_ACCOUNT_LEVERAGE=3
+CTVAL=0.0001
+MIN_SZ=1
+LOT_SZ=1
+TICK_SZ=0.1
+PRICE_REFERENCE_TYPE=markPx
+PRICE_REFERENCE=62986.2
+FRESH_THEORETICAL_IM_FORMULA=markPx * ctVal * qty / SET_ACCOUNT_LEVERAGE
+FRESH_THEORETICAL_IM_FLOOR_USDC=2.09954
+FRESH_THEORETICAL_IM_ROLE=IM_FRESH_FLOOR_ONLY_NOT_OPERATIONAL_FUNDING_AMOUNT
+IM_FRESH_TERM_STATUS=BOUND_AS_MANDATORY_FLOOR_NOT_AMOUNT
+F_OWNER_COMPOSITION=CONSERVATIVE_COVER_COMPOSITION_OPERATOR
+F_OWNER_COMPOSITION_STATUS=PERSISTED_POLICY_GRAMMAR_UNINSTANTIATED
+FEE_RESERVE_TERM_STATUS=UNINSTANTIATED_REBATE_CONVENTION_NOT_POSITIVE_RESERVE
+SLIPPAGE_RESERVE_TERM_STATUS=UNINSTANTIATED_BID_ASK_COLLECTED_NOT_OPERATIVE_POLICY
+MM_LIQ_BUFFER_TERM_STATUS=UNINSTANTIATED_PUBLIC_TIER_LIMIT_NOT_ACCOUNT_EFFECTIVE
+VENUE_MIN_AVAIL_EQ_TERM_STATUS=NO_EXPLICIT_FLOOR_AMOUNT_NOT_ADDITIVE
+FUNDING_RATE_RESERVE_TERM_STATUS=EXCLUDED_UNRESOLVED_AND_NOT_USABLE
+USD_USDC_HAIRCUT_TERM_STATUS=UNINSTANTIATED_STRICT_UNIT_SEPARATION
+OPERATIONAL_ROUNDING_TERM_STATUS=NOT_APPLIED_FULL_INSTANTIATION_ABSENT
+OWNER_SUPPLIED_OPERATIONAL_FORMULA_BODY=NONE
+OWNER_RATIFIED_OPERATIONAL_FORMULA_PRESENT=false
+MAX_AVAIL_BUY=0
+MAX_AVAIL_SELL=0
+QTY_ONE_VENUE_ADMISSIBLE=false
+VENUE_MIN_EQUITY_FIELD=ABSENT
+FEE_TAKER_USDC=-0.0005
+FEE_MAKER_USDC=-0.0002
+FEE_GET_CLASSIFICATION=OKX_REBATE_CONVENTION_NOT_POSITIVE_RESERVE_POLICY
+PUBLIC_TIER_IMR=0.02
+PUBLIC_TIER_CLASSIFICATION=TIER_LIMIT_NOT_ACCOUNT_EFFECTIVE_IMR
+TICKER_BID_ASK_ROLE=COLLECTED_NOT_OPERATIVE_POLICY
+TOTAL_EQ=0
+MINIMUM_THEORETICAL_INITIAL_MARGIN_PROVEN=true
+CANARY_OPERATIONAL_MINIMUM_PROVEN=false
+RECOMMENDED_BOUNDED_CANARY_FUNDING_AMOUNT_PROVEN=false
+FUNDING_AMOUNT_PROVEN=false
+PROVEN_FUNDING_AMOUNT=NONE
+I44_FUTURES_FUNDING_ECONOMICS_STATUS=INSUFFICIENT_EVIDENCE
+G16_FUNDING_PROOF_STATUS=INSUFFICIENT_EVIDENCE
+FUNDING_EXECUTED=false
+EXTERNAL_MONEY_MOVEMENT=false
+CANARY_EXECUTED=false
+TRADING_POSTS=0
+ACCOUNT_MUTATION=false
+CREDENTIAL_MUTATION=false
+TRADING_LOGIC_CHANGED=false
+MASTER_V2_CHANGED=false
+DOUBLE_PLAY_CHANGED=false
+RUNTIME_AUTHORITY_EXPANDED=false
+LIVE_AUTHORIZED=false
+GENERAL_LIVE_UNLOCKED=false
+NEW_EXECUTE_GO_REQUIRED=true
+FUNDING_GO_AND_EXECUTE_GO_COLLAPSED=false
+FORMULA_RATIFICATION_AUTHORIZED_BY_THIS_INSTANTIATION_GO=false
+EXECUTE_AUTHORIZED_BY_THIS_INSTANTIATION_GO=false
+ORDER_EFFECT=NONE
+ACCOUNT_MUTATION_EFFECT=NONE
+FUNDING_EFFECT=NONE
+SECRET_VALUE_ACCESS=NONE
+```
+
+Term-by-term instantiation against §11.13.5.R grammar and sealed GET
+facts (no invented coefficients):
+
+``` text
+IM_FRESH=2.09954_USDC_MANDATORY_FLOOR_NOT_OPERATIONAL_AMOUNT
+FEE_RESERVE=UNINSTANTIATED_SIGNED_REBATE_VALUES_MUST_NOT_BE_USED_AS_CREDIT
+SLIPPAGE_RESERVE=UNINSTANTIATED_NO_NUMERIC_BPS_OR_MULTIPLIERS
+MM_LIQ_BUFFER=UNINSTANTIATED_NO_LIQUIDATION_DISTANCE_COEFFICIENT
+VENUE_MIN_AVAIL_EQ=ADMISSIBILITY_CONSTRAINT_NO_EXPLICIT_MIN_EQUITY_FIELD
+FUNDING_RATE_RESERVE=CANONICAL_EXCLUSION_UNRESOLVED_AND_NOT_USABLE
+USD_USDC_HAIRCUT=UNINSTANTIATED_NO_IMPLICIT_ONE_TO_ONE
+ROUNDING=FORBIDDEN_UNTIL_FULL_FORMULA_INSTANTIATION
+COMPOSITION_COMPLETE=false
+```
+
+`FUNDING_RATE_RESERVE` is the only term with an explicit canonical
+exclusion (`UNRESOLVED_AND_NOT_USABLE` while I44 &#47; G16 remain
+`INSUFFICIENT_EVIDENCE`). Fee, slippage, maintenance&#47;liquidation
+buffer, and USD&#47;USDC haircut remain required positive &#47;
+conversion terms and may **not** be treated as zero. Conservative-cover
+composition therefore cannot complete without Owner-supplied numeric
+reserve terms.
+
+Still missing (none closable under `FORMULA_INSTANTIATION_ONLY`
+without invented coefficients, a new GET, or a formula body in this GO):
+
+1. Owner-supplied operational formula body distinct from theoretical IM.
+   This consumed instantiation GO did **not** supply one. Conservative-
+   cover composition grammar remains uninstantiated as a numeric body.
+2. Positive fee-reserve remains uninstantiated. Fresh GET
+   `takerUSDC=-0.0005` &#47; `makerUSDC=-0.0002` remains OKX rebate
+   convention, not a positive reserve. No `FEE_BUFFER_BPS`.
+3. Proven slippage &#47; spread buffer remains uninstantiated. Fresh
+   bid&#47;ask remain `COLLECTED_NOT_OPERATIVE_POLICY`. No numeric bps
+   or multipliers.
+4. Proven maintenance-margin &#47; liquidation buffer remains
+   uninstantiated. Public `imr=0.02` remains a tier limit. No
+   liquidation-distance coefficient.
+5. Venue-native max-avail-size GET remains **collected**. Qty=1 is
+   **not** venue-admissible at `availBuy=0` &#47; `availSell=0` against
+   `totalEq=0`. No explicit min-equity field. Role remains
+   `ADMISSIBILITY_CONSTRAINT_AND_POSSIBLE_FLOOR`, not an additive
+   funding amount.
+6. Fresh productive markPx GET remains **collected**
+   (`markPx=62986.2`). Fresh theoretical IM is still not an operational
+   funding amount.
+7. I44 &#47; Master G16 remains `INSUFFICIENT_EVIDENCE`.
+   `FUNDING_RATE_RESERVE=UNRESOLVED_AND_NOT_USABLE`. This step does not
+   close I44 &#47; G16.
+8. Public USD versus account USDC haircut &#47; conversion term remains
+   uninstantiated. Units stay strictly distinct.
+9. `totalEq=0` still does not prove deposit size. Rounding remains
+   forbidden until after full formula instantiation. No padded USDC
+   amount is invented.
+
+Fail-closed authority sequence (do not collapse; step 4 now consumed
+as instantiation-only with no numeric body):
+
+``` text
+1_POLICY_SPEC_OWNER_DECISION_GRAMMAR_PERSISTED
+2_SEPARATE_OWNER_GO_REQUIRED_FOR_BOUNDED_OPERATIONAL_FUNDING_GET_EVIDENCE
+3_FRESH_GET_ONLY_EVIDENCE
+4_FORMULA_INSTANTIATION
+5_SEPARATE_OWNER_RATIFICATION_OF_EXACT_FORMULA_BODY
+6_SEPARATE_FUNDING_AUTHORIZATION
+7_SEPARATE_CANARY_EXECUTE_AUTHORIZATION
+```
+
+Live vs Demo identity remains strictly separated. Map of Truth
+`CANONICAL_ACTIVE_INSTRUMENT=BTC-USD_UM_XPERP-310328` remains the
+§11.12.8 Demo campaign binding and is **not** retargeted.
+
+``` text
+CODE_OWNER=src&#47;ops&#47;section_11_13_5_live_canary_minimum_exposure_v1&#47;
+CURRENT_CANONICAL_NEXT_STEP_AUTHORITY=SECTION_11_13_5
+CANONICAL_NEXT_STEP=OWNER_GO_REQUIRED_TO_SUPPLY_NUMERIC_OPERATIONAL_RESERVE_TERMS
+EARLIEST_UNRESOLVED_DEPENDENCY=CANARY_OPERATIONAL_MINIMUM_UNPROVEN_THEN_SEPARATE_NEW_EXECUTE_GO
+EARLIEST_UNRESOLVED_SECTION_POINTER=SECTION_11_13_5_LIVE_CANARY_MINIMUM_EXPOSURE
+```
+
+Hard stop. This instantiation GO is consumed and must not be reused for
+money movement, GET refresh, execute, formula ratification, or as a
+substitute formula body. `OWNER_GO_REQUIRED_TO_SUPPLY_NUMERIC_OPERATIONAL_RESERVE_TERMS`
+is **not** granted. Later formula ratification, funding, and execute
+remain separate. `OWNER_GO_LIVE_CANARY_MINIMUM_EXPOSURE` remains
 `CONSUMED`. Cap &#47; Capability 11.9 remains fixture-only. No funding.
-No execute. No merge of this GET-evidence persist without a separate
+No execute. No merge of this instantiation persist without a separate
 `OWNER_MERGE_GO`.
 
 ## 11.14 Live order and economic evidence ladder

--- a/docs/runbooks/operations/PEAK_TRADE_PERSISTENCE_REMEDIATION_TRACKER.md
+++ b/docs/runbooks/operations/PEAK_TRADE_PERSISTENCE_REMEDIATION_TRACKER.md
@@ -92,13 +92,14 @@ All GAP items are `CLOSED_CANONICALLY_PERSISTED` by squash-merge
 **retained** on HEAD for audit. It is **not** deleted: the original
 delete-after-closeout-on-`origin&#47;main` rule is not satisfied at
 closeout authoring time, and historical pointer chains still name this
-path. Canonical authority remains SSOT §11.13.5.S. The R-era pointer
-`OWNER_GO_REQUIRED_FOR_BOUNDED_OPERATIONAL_FUNDING_GET_EVIDENCE` is
-consumed as GET-only evidence; formula instantiation remains not
-granted. Fresh theoretical IM is not an operational funding amount.
+path. Canonical authority remains SSOT §11.13.5.T. The S-era pointer
+`OWNER_GO_REQUIRED_FOR_OPERATIONAL_FORMULA_INSTANTIATION` is consumed
+as instantiation-only with no numeric body; numeric reserve terms
+remain not granted. Fresh theoretical IM is not an operational funding
+amount.
 
 ```text
-CANONICAL_NEXT_STEP=OWNER_GO_REQUIRED_FOR_OPERATIONAL_FORMULA_INSTANTIATION
+CANONICAL_NEXT_STEP=OWNER_GO_REQUIRED_TO_SUPPLY_NUMERIC_OPERATIONAL_RESERVE_TERMS
 EARLIEST_UNRESOLVED_DEPENDENCY=CANARY_OPERATIONAL_MINIMUM_UNPROVEN_THEN_SEPARATE_NEW_EXECUTE_GO
 PERSISTENCE_REMEDIATION_PR_MERGED=true
 TRACKER_RETIREMENT_ALLOWED=true


### PR DESCRIPTION
## Summary
- Consume `OWNER_GO_REQUIRED_FOR_OPERATIONAL_FORMULA_INSTANTIATION` as instantiation-only against sealed GET pack `20260816T060349Z` and persisted §11.13.5.R conservative-cover grammar.
- Bind §11.13.5.T fail-closed: `INSTANTIATION_EFFECT=NONE`, `FULL_FORMULA_INSTANTIATION=false`, `FORMULA_BODY_STATUS=ABSENT`. Fresh theoretical IM `2.09954` USDC remains a floor only. Required positive fee/slippage/MM/haircut terms stay uninstantiated; no coefficients invented.
- Do **not** ratify an operational formula, do **not** prove a funding amount, do **not** fund, do **not** execute. `FUNDING_AMOUNT_PROVEN=false`, `LIVE_AUTHORIZED=false`. Next pointer `OWNER_GO_REQUIRED_TO_SUPPLY_NUMERIC_OPERATIONAL_RESERVE_TERMS` is **not** granted.

## Test plan
- [x] Docs token policy on changed Markdown (`uv run python scripts/ops/validate_docs_token_policy.py --base origin/main`)
- [x] Docs reference targets (`./scripts/ops/verify_docs_reference_targets.sh --changed --base origin/main`)
- [x] Canonical CI selector on exact intended files → `NO_OP` (`docs_workflow_or_static_contract_only`)
- [x] Timing proof not required (`TIMING_PROOF_NOT_REQUIRED_JUSTIFIED`; selector `NO_OP`)
- [ ] GitHub required checks (confirmation only; do not merge without a later `OWNER_MERGE_GO`)


Made with [Cursor](https://cursor.com)