### PR TITLE
research: add canonical experiment identity v1

### DIFF
--- a/docs/ops/specs/CANONICAL_EXPERIMENT_IDENTITY_V1.md
+++ b/docs/ops/specs/CANONICAL_EXPERIMENT_IDENTITY_V1.md
@@ -1,0 +1,66 @@
+# Canonical Experiment Identity v1
+
+Contract for Peak_Trade Phase 1 Canonical Experiment Identity.
+
+```text
+SCHEMA_VERSION=canonical_experiment_identity_v1
+IDENTITY_DOMAIN=peak_trade.canonical_experiment_identity.v1
+EXPERIMENT_IDENTITY_HAS_RUNTIME_AUTHORITY=false
+```
+
+Owner: `src&#47;experiments&#47;canonical_experiment_identity_v1.py`
+
+Package N `src&#47;experiments&#47;experiment_identity_manifest_v1.py` remains an incomplete historical projection. This contract does not reinterpret existing Package N identity hashes.
+
+## Canonicalization
+
+- Mappings are key-sorted before hashing.
+- Sets and frozensets are sorted; lists keep caller order.
+- Digest envelopes bind `schema_version`, `digest_domain`, and `digest_algorithm`.
+- Dictionary insertion order and local path walk order are not identity inputs.
+
+## Critical inputs
+
+A `COMPLETE` identity requires explicit bindings for:
+
+- `git_sha` plus `working_tree_status=CLEAN`
+- `strategy_identity`
+- `strategy_params` (stored only as `strategy_params_digest`)
+- `dataset_digest`
+- `feature_pipeline_digest`
+- `fee_model_digest`, `slippage_model_digest`, `funding_model_digest`
+- `risk_policy_digest`
+- `portfolio_digest`
+- `split_policy_digest`
+- `seed` as an explicit int
+- reproducibility environment (`python_version`, `python_implementation`)
+
+`cost_model_digest` is derived from the three cost component digests. No silent fee, slippage, funding, dataset, risk, split, or seed defaults.
+
+If a required research input is not yet canonically representable, callers must not invent a value. Missing or `UNKNOWN`/`UNAVAILABLE` inputs fail closed and never yield `COMPLETE`.
+
+## Fail-closed behavior
+
+Missing critical digest, missing seed, dirty tree, secret keys, non-finite floats, or extra host-identifying environment keys raise `CanonicalExperimentIdentityError`. Incomplete records are not emitted.
+
+## Dirty-tree behavior
+
+`inspect_code_provenance_v1` records `HEAD` plus porcelain path status. A dirty tree cannot produce `COMPLETE` identity and cannot be treated as the same clean `git_sha` state.
+
+## Secret handling
+
+Known credential field names (`api_key`, `token`, `password`, `confirm_token`, and related) are rejected before serialization and are never logged as values.
+
+## `parent_lineage_ref`
+
+- Root experiment: `kind=ROOT` and `parent_lineage_ref=null`.
+- Child experiment: `kind=PARENT_BOUND` and an explicit parent reference.
+- Root and parent-bound records are deterministically distinct.
+
+## Authority
+
+```text
+EXPERIMENT_IDENTITY_HAS_RUNTIME_AUTHORITY=false
+```
+
+Identity is research metadata and evidence only. It does not write `config&#47;live_overrides`, enable, arm, fund, submit orders, mint or use confirm tokens, authorize canary, or promote to live.

--- a/docs/ops/specs/CANONICAL_EXPERIMENT_IDENTITY_V1.md
+++ b/docs/ops/specs/CANONICAL_EXPERIMENT_IDENTITY_V1.md
@@ -34,8 +34,16 @@ A `COMPLETE` identity requires explicit bindings for:
 - `split_policy_digest`
 - `seed` as an explicit int
 - reproducibility environment (`python_version`, `python_implementation`)
+- canonical trading decision core:
+  - `market_context_contract_digest`
+  - `bull_bear_logic_digest`
+  - `state_switch_logic_digest`
+  - `survival_logic_digest`
+  - `suitability_logic_digest`
+  - `double_play_logic_digest`
+  - `entry_position_exit_logic_digest`
 
-`cost_model_digest` is derived from the three cost component digests. No silent fee, slippage, funding, dataset, risk, split, or seed defaults.
+`cost_model_digest` is derived from the three cost component digests. `trading_decision_core_digest` is derived from the seven core-logic component digests. No silent fee, slippage, funding, dataset, risk, split, seed, or core-logic defaults.
 
 If a required research input is not yet canonically representable, callers must not invent a value. Missing or `UNKNOWN`/`UNAVAILABLE` inputs fail closed and never yield `COMPLETE`.
 
@@ -63,4 +71,13 @@ Known credential field names (`api_key`, `token`, `password`, `confirm_token`, a
 EXPERIMENT_IDENTITY_HAS_RUNTIME_AUTHORITY=false
 ```
 
-Identity is research metadata and evidence only. It does not write `config&#47;live_overrides`, enable, arm, fund, submit orders, mint or use confirm tokens, authorize canary, or promote to live.
+Identity is research metadata and evidence only. It does not write live-override runtime configuration, enable, arm, fund, submit orders, mint or use confirm tokens, authorize canary, or promote to live.
+
+Binding the canonical trading decision core does not grant Learning the right to mutate or replace productive trading logic.
+
+```text
+LEARNING_MAY_RESEARCH_CORE_LOGIC_CHANGES=true
+LEARNING_MAY_AUTONOMOUSLY_REPLACE_CORE_LOGIC=false
+SELF_LEARNING_MUST_LEARN_FROM_CANONICAL_TRADING_DECISION_PATH=true
+CANONICAL_TRADING_DECISION_CORE_BOUND=true
+```

--- a/src/experiments/canonical_experiment_identity_v1.py
+++ b/src/experiments/canonical_experiment_identity_v1.py
@@ -1,0 +1,550 @@
+"""Phase 1 Canonical Experiment Identity v1 (research metadata only).
+
+This contract binds every COMPLETE research/backtest experiment to explicit
+critical inputs. It has no runtime, order, live, funding, canary, or config
+write authority.
+
+Package N ``experiment_identity_manifest_v1`` remains an incomplete historical
+projection and is not reinterpreted by this schema.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+import subprocess
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Final, Mapping, Sequence
+
+from src.meta.learning_loop.contract_safety_v1 import (
+    compute_content_sha256,
+    deterministic_json_dumps,
+    is_valid_sha256_hex,
+)
+
+SCHEMA_VERSION: Final[str] = "canonical_experiment_identity_v1"
+IDENTITY_DOMAIN: Final[str] = "peak_trade.canonical_experiment_identity.v1"
+DIGEST_ALGORITHM: Final[str] = "sha256"
+COMPLETENESS_COMPLETE: Final[str] = "COMPLETE"
+WORKING_TREE_CLEAN: Final[str] = "CLEAN"
+WORKING_TREE_DIRTY: Final[str] = "DIRTY"
+PARENT_KIND_ROOT: Final[str] = "ROOT"
+PARENT_KIND_PARENT_BOUND: Final[str] = "PARENT_BOUND"
+EXPERIMENT_IDENTITY_HAS_RUNTIME_AUTHORITY: Final[bool] = False
+RUNTIME_AUTHORITY_IMPACT: Final[str] = "NONE"
+
+_GIT_SHA1_RE = re.compile(r"^[0-9a-f]{40}$")
+_SECRET_KEY_TOKEN_RE = re.compile(
+    r"(api[_-]?key|api[_-]?secret|secret|password|passwd|token|credential|"
+    r"private[_-]?key|access[_-]?key|secret[_-]?key|passphrase|confirm[_-]?token|"
+    r"bearer|authorization)",
+    re.IGNORECASE,
+)
+_UNAVAILABLE_TOKENS = frozenset(
+    {
+        "",
+        "unknown",
+        "unavailable",
+        "n/a",
+        "na",
+        "none",
+        "null",
+        "implicit",
+        "default",
+    }
+)
+_ENVIRONMENT_ALLOWED_KEYS = frozenset(
+    {
+        "python_version",
+        "python_implementation",
+    }
+)
+_CRITICAL_DIGEST_FIELDS = (
+    "dataset_digest",
+    "feature_pipeline_digest",
+    "fee_model_digest",
+    "slippage_model_digest",
+    "funding_model_digest",
+    "risk_policy_digest",
+    "portfolio_digest",
+    "split_policy_digest",
+)
+_DIGEST_DOMAINS: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "strategy_identity": f"{IDENTITY_DOMAIN}.strategy_identity",
+        "strategy_params": f"{IDENTITY_DOMAIN}.strategy_params",
+        "dataset": f"{IDENTITY_DOMAIN}.dataset",
+        "feature_pipeline": f"{IDENTITY_DOMAIN}.feature_pipeline",
+        "fee_model": f"{IDENTITY_DOMAIN}.fee_model",
+        "slippage_model": f"{IDENTITY_DOMAIN}.slippage_model",
+        "funding_model": f"{IDENTITY_DOMAIN}.funding_model",
+        "cost_model": f"{IDENTITY_DOMAIN}.cost_model",
+        "risk_policy": f"{IDENTITY_DOMAIN}.risk_policy",
+        "portfolio": f"{IDENTITY_DOMAIN}.portfolio",
+        "split_policy": f"{IDENTITY_DOMAIN}.split_policy",
+        "environment": f"{IDENTITY_DOMAIN}.environment",
+        "identity": f"{IDENTITY_DOMAIN}.identity",
+        "dirty_paths": f"{IDENTITY_DOMAIN}.dirty_paths",
+    }
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CanonicalExperimentIdentityError(ValueError):
+    """Fail-closed Canonical Experiment Identity v1 error."""
+
+
+@dataclass(frozen=True)
+class CanonicalCodeProvenanceV1:
+    git_sha: str
+    working_tree_status: str
+    dirty_paths_digest: str | None = None
+
+
+@dataclass(frozen=True)
+class CanonicalExperimentIdentityRequestV1:
+    git_sha: str
+    working_tree_status: str
+    strategy_identity: str
+    strategy_params: Mapping[str, Any]
+    dataset_digest: str
+    feature_pipeline_digest: str
+    fee_model_digest: str
+    slippage_model_digest: str
+    funding_model_digest: str
+    risk_policy_digest: str
+    portfolio_digest: str
+    split_policy_digest: str
+    seed: int
+    environment: Mapping[str, Any]
+    parent_lineage_ref: str | None = None
+    dirty_paths_digest: str | None = None
+
+
+def digest_domain_name(component: str) -> str:
+    try:
+        return _DIGEST_DOMAINS[component]
+    except KeyError as exc:
+        raise CanonicalExperimentIdentityError(
+            f"unknown digest domain component: {component}"
+        ) from exc
+
+
+def domain_separated_digest(component: str, payload: Mapping[str, Any]) -> str:
+    envelope = {
+        "digest_algorithm": DIGEST_ALGORITHM,
+        "digest_domain": digest_domain_name(component),
+        "payload": canonicalize_value(payload),
+        "schema_version": SCHEMA_VERSION,
+    }
+    return compute_content_sha256(envelope)
+
+
+def canonicalize_value(value: Any, *, path: str = "$") -> Any:
+    _reject_secret_key_path(path)
+    if isinstance(value, Mapping):
+        return canonicalize_mapping(value, path=path)
+    if isinstance(value, (set, frozenset)):
+        canonical_items = [canonicalize_value(item, path=f"{path}[]") for item in value]
+        return sorted(canonical_items, key=_stable_sort_key)
+    if isinstance(value, tuple):
+        return [canonicalize_value(item, path=f"{path}[]") for item in value]
+    if isinstance(value, list):
+        return [canonicalize_value(item, path=f"{path}[]") for item in value]
+    if isinstance(value, Enum):
+        return canonicalize_value(value.value, path=path)
+    if isinstance(value, bool) or value is None:
+        return value
+    if isinstance(value, int):
+        return int(value)
+    if isinstance(value, float):
+        if value != value or value in {float("inf"), float("-inf")}:
+            raise CanonicalExperimentIdentityError(
+                f"non-finite float is forbidden in identity canonicalization: {path}"
+            )
+        return json.loads(json.dumps(value))
+    if isinstance(value, str):
+        return value
+    raise CanonicalExperimentIdentityError(
+        f"unsupported type for identity canonicalization at {path}: {type(value)!r}"
+    )
+
+
+def canonicalize_mapping(payload: Mapping[str, Any], *, path: str = "$") -> dict[str, Any]:
+    if not isinstance(payload, Mapping):
+        raise CanonicalExperimentIdentityError(f"expected mapping at {path}")
+    canonical: dict[str, Any] = {}
+    for key in sorted((str(item) for item in payload.keys())):
+        _reject_secret_key(key, path=f"{path}.{key}")
+        canonical[key] = canonicalize_value(payload[key], path=f"{path}.{key}")
+    return canonical
+
+
+def _reject_secret_key(key: str, *, path: str) -> None:
+    if _SECRET_KEY_TOKEN_RE.search(str(key)):
+        raise CanonicalExperimentIdentityError(
+            f"secret or credential field is forbidden in identity payload: {path}"
+        )
+
+
+def _reject_secret_key_path(path: str) -> None:
+    for segment in str(path).split("."):
+        token = segment[:-2] if segment.endswith("[]") else segment
+        if token and token != "$" and _SECRET_KEY_TOKEN_RE.search(token):
+            raise CanonicalExperimentIdentityError(
+                f"secret or credential field is forbidden in identity payload: {path}"
+            )
+
+
+def _stable_sort_key(value: Any) -> str:
+    if isinstance(value, (str, bytes)) or not isinstance(value, (Mapping, Sequence)):
+        return repr(value)
+    return deterministic_json_dumps(value)
+
+
+def _require_git_sha(value: str) -> str:
+    if not isinstance(value, str) or not _GIT_SHA1_RE.fullmatch(value):
+        raise CanonicalExperimentIdentityError(
+            "git_sha must be a 40-char lowercase git SHA-1 hex string"
+        )
+    return value
+
+
+def _require_sha256_digest(field_name: str, value: Any) -> str:
+    if not isinstance(value, str):
+        raise CanonicalExperimentIdentityError(
+            f"{field_name} missing; COMPLETE identity is forbidden (fail-closed)"
+        )
+    lowered = value.strip().lower()
+    if lowered in _UNAVAILABLE_TOKENS:
+        raise CanonicalExperimentIdentityError(
+            f"{field_name} is unavailable; COMPLETE identity is forbidden (fail-closed)"
+        )
+    if not is_valid_sha256_hex(value):
+        raise CanonicalExperimentIdentityError(
+            f"{field_name} must be 64-char lowercase sha256 hex (fail-closed)"
+        )
+    return value
+
+
+def _require_seed(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise CanonicalExperimentIdentityError(
+            "seed must be an explicit int; implicit or random seed is forbidden"
+        )
+    return int(value)
+
+
+def _require_strategy_identity(value: Any) -> str:
+    if (
+        not isinstance(value, str)
+        or not value.strip()
+        or value.strip().lower() in _UNAVAILABLE_TOKENS
+    ):
+        raise CanonicalExperimentIdentityError(
+            "strategy_identity missing; COMPLETE identity is forbidden (fail-closed)"
+        )
+    return value.strip()
+
+
+def _require_clean_tree(status: Any, dirty_paths_digest: Any) -> None:
+    if status == WORKING_TREE_DIRTY:
+        raise CanonicalExperimentIdentityError(
+            "DIRTY_TREE_PROVENANCE_FAIL_CLOSED: dirty code cannot produce COMPLETE identity"
+        )
+    if status != WORKING_TREE_CLEAN:
+        raise CanonicalExperimentIdentityError("working_tree_status must be CLEAN or DIRTY")
+    if dirty_paths_digest is not None:
+        raise CanonicalExperimentIdentityError(
+            "dirty_paths_digest must be null when working_tree_status is CLEAN"
+        )
+
+
+def _parent_lineage_block(parent_lineage_ref: str | None) -> dict[str, Any]:
+    if parent_lineage_ref is None:
+        return {
+            "kind": PARENT_KIND_ROOT,
+            "parent_lineage_ref": None,
+        }
+    if not isinstance(parent_lineage_ref, str) or not parent_lineage_ref.strip():
+        raise CanonicalExperimentIdentityError(
+            "parent_lineage_ref must be a non-empty string or null for ROOT"
+        )
+    if parent_lineage_ref.strip().lower() in _UNAVAILABLE_TOKENS:
+        raise CanonicalExperimentIdentityError(
+            "parent_lineage_ref cannot use implicit unavailable tokens"
+        )
+    return {
+        "kind": PARENT_KIND_PARENT_BOUND,
+        "parent_lineage_ref": parent_lineage_ref,
+    }
+
+
+def _environment_snapshot(environment: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(environment, Mapping):
+        raise CanonicalExperimentIdentityError("environment must be a mapping")
+    extra = set(str(key) for key in environment.keys()) - _ENVIRONMENT_ALLOWED_KEYS
+    if extra:
+        raise CanonicalExperimentIdentityError(
+            "environment contains non-reproducibility keys that would make "
+            f"identical experiments diverge: {sorted(extra)}"
+        )
+    missing = sorted(_ENVIRONMENT_ALLOWED_KEYS - set(str(key) for key in environment.keys()))
+    if missing:
+        raise CanonicalExperimentIdentityError(
+            f"environment missing required reproducibility keys: {missing}"
+        )
+    snapshot = canonicalize_mapping(environment)
+    for key in _ENVIRONMENT_ALLOWED_KEYS:
+        value = snapshot.get(key)
+        if (
+            not isinstance(value, str)
+            or not value.strip()
+            or value.strip().lower() in _UNAVAILABLE_TOKENS
+        ):
+            raise CanonicalExperimentIdentityError(
+                f"environment.{key} must be an explicit non-empty string"
+            )
+    snapshot["identity_schema_version"] = SCHEMA_VERSION
+    return snapshot
+
+
+def _freeze(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({str(key): _freeze(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return [_freeze(item) for item in value]
+    return value
+
+
+def _plain_mapping(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _plain_mapping(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_plain_mapping(item) for item in value]
+    return value
+
+
+def _log_identity_built(record: Mapping[str, Any]) -> None:
+    _LOGGER.info(
+        "canonical_experiment_identity_v1 built completeness=%s identity_digest=%s git_sha=%s strategy_identity=%s runtime_authority=%s",
+        record.get("completeness"),
+        record.get("identity_digest"),
+        record.get("git_sha"),
+        record.get("strategy_identity"),
+        record.get("experiment_identity_has_runtime_authority"),
+    )
+
+
+def inspect_code_provenance_v1(repo_root: Path | str) -> CanonicalCodeProvenanceV1:
+    root = Path(repo_root)
+    if not root.is_dir():
+        raise CanonicalExperimentIdentityError(f"repo_root is not a directory: {root}")
+    try:
+        git_sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        porcelain = subprocess.run(
+            ["git", "status", "--porcelain=v1", "--untracked-files=all"],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise CanonicalExperimentIdentityError(
+            "DIRTY_TREE_PROVENANCE_FAIL_CLOSED: git provenance inspect failed"
+        ) from exc
+    git_sha = _require_git_sha(git_sha)
+    lines = sorted(line.replace("\\", "/") for line in porcelain.splitlines() if line.strip())
+    if not lines:
+        return CanonicalCodeProvenanceV1(
+            git_sha=git_sha,
+            working_tree_status=WORKING_TREE_CLEAN,
+            dirty_paths_digest=None,
+        )
+    dirty_digest = domain_separated_digest("dirty_paths", {"lines": lines})
+    return CanonicalCodeProvenanceV1(
+        git_sha=git_sha,
+        working_tree_status=WORKING_TREE_DIRTY,
+        dirty_paths_digest=dirty_digest,
+    )
+
+
+def build_canonical_experiment_identity_v1(
+    request: CanonicalExperimentIdentityRequestV1,
+) -> Mapping[str, Any]:
+    _require_clean_tree(request.working_tree_status, request.dirty_paths_digest)
+    git_sha = _require_git_sha(request.git_sha)
+    strategy_identity = _require_strategy_identity(request.strategy_identity)
+    seed = _require_seed(request.seed)
+    bound_digests = {
+        field_name: _require_sha256_digest(field_name, getattr(request, field_name))
+        for field_name in _CRITICAL_DIGEST_FIELDS
+    }
+    strategy_params = canonicalize_mapping(request.strategy_params)
+    environment = _environment_snapshot(request.environment)
+    parent_lineage = _parent_lineage_block(request.parent_lineage_ref)
+
+    strategy_identity_digest = domain_separated_digest(
+        "strategy_identity", {"strategy_identity": strategy_identity}
+    )
+    strategy_params_digest = domain_separated_digest("strategy_params", strategy_params)
+    dataset_digest = domain_separated_digest(
+        "dataset", {"source_digest": bound_digests["dataset_digest"]}
+    )
+    feature_pipeline_digest = domain_separated_digest(
+        "feature_pipeline", {"source_digest": bound_digests["feature_pipeline_digest"]}
+    )
+    fee_model_digest = domain_separated_digest(
+        "fee_model", {"source_digest": bound_digests["fee_model_digest"]}
+    )
+    slippage_model_digest = domain_separated_digest(
+        "slippage_model", {"source_digest": bound_digests["slippage_model_digest"]}
+    )
+    funding_model_digest = domain_separated_digest(
+        "funding_model", {"source_digest": bound_digests["funding_model_digest"]}
+    )
+    cost_model_digest = domain_separated_digest(
+        "cost_model",
+        {
+            "fee_model_digest": fee_model_digest,
+            "funding_model_digest": funding_model_digest,
+            "slippage_model_digest": slippage_model_digest,
+        },
+    )
+    risk_policy_digest = domain_separated_digest(
+        "risk_policy", {"source_digest": bound_digests["risk_policy_digest"]}
+    )
+    portfolio_digest = domain_separated_digest(
+        "portfolio", {"source_digest": bound_digests["portfolio_digest"]}
+    )
+    split_policy_digest = domain_separated_digest(
+        "split_policy", {"source_digest": bound_digests["split_policy_digest"]}
+    )
+    environment_digest = domain_separated_digest("environment", environment)
+
+    identity_body = {
+        "completeness": COMPLETENESS_COMPLETE,
+        "cost_model_digest": cost_model_digest,
+        "dataset_digest": dataset_digest,
+        "digest_algorithm": DIGEST_ALGORITHM,
+        "environment": environment,
+        "environment_digest": environment_digest,
+        "experiment_identity_has_runtime_authority": EXPERIMENT_IDENTITY_HAS_RUNTIME_AUTHORITY,
+        "feature_pipeline_digest": feature_pipeline_digest,
+        "fee_model_digest": fee_model_digest,
+        "funding_model_digest": funding_model_digest,
+        "git_sha": git_sha,
+        "identity_domain": IDENTITY_DOMAIN,
+        "parent_lineage": parent_lineage,
+        "portfolio_digest": portfolio_digest,
+        "risk_policy_digest": risk_policy_digest,
+        "runtime_authority_impact": RUNTIME_AUTHORITY_IMPACT,
+        "schema_version": SCHEMA_VERSION,
+        "seed": seed,
+        "slippage_model_digest": slippage_model_digest,
+        "split_policy_digest": split_policy_digest,
+        "strategy_identity": strategy_identity,
+        "strategy_identity_digest": strategy_identity_digest,
+        "strategy_params_digest": strategy_params_digest,
+        "working_tree_status": WORKING_TREE_CLEAN,
+    }
+    identity_digest = domain_separated_digest("identity", identity_body)
+    record = dict(identity_body)
+    record["identity_digest"] = identity_digest
+    record["integrity"] = {
+        "content_sha256": compute_content_sha256(
+            {key: value for key, value in record.items() if key != "integrity"}
+        )
+    }
+    validate_canonical_experiment_identity_v1(record)
+    frozen = _freeze(record)
+    _log_identity_built(record)
+    return frozen
+
+
+def validate_canonical_experiment_identity_v1(record: Mapping[str, Any]) -> None:
+    if not isinstance(record, Mapping):
+        raise CanonicalExperimentIdentityError("identity record must be a mapping")
+    record = _plain_mapping(record)
+    if record.get("schema_version") != SCHEMA_VERSION:
+        raise CanonicalExperimentIdentityError("schema_version mismatch")
+    if record.get("identity_domain") != IDENTITY_DOMAIN:
+        raise CanonicalExperimentIdentityError("identity_domain mismatch")
+    if record.get("completeness") != COMPLETENESS_COMPLETE:
+        raise CanonicalExperimentIdentityError("non-COMPLETE identity records are forbidden")
+    if record.get("experiment_identity_has_runtime_authority") is not False:
+        raise CanonicalExperimentIdentityError(
+            "experiment_identity_has_runtime_authority must be false"
+        )
+    if record.get("runtime_authority_impact") != RUNTIME_AUTHORITY_IMPACT:
+        raise CanonicalExperimentIdentityError("runtime_authority_impact must be NONE")
+    if record.get("working_tree_status") != WORKING_TREE_CLEAN:
+        raise CanonicalExperimentIdentityError(
+            "DIRTY_TREE_PROVENANCE_FAIL_CLOSED: COMPLETE identity requires CLEAN tree"
+        )
+    _require_git_sha(str(record.get("git_sha") or ""))
+    _require_seed(record.get("seed"))
+    parent_lineage = record.get("parent_lineage")
+    if not isinstance(parent_lineage, Mapping):
+        raise CanonicalExperimentIdentityError("parent_lineage must be a mapping")
+    kind = parent_lineage.get("kind")
+    parent_ref = parent_lineage.get("parent_lineage_ref")
+    if kind == PARENT_KIND_ROOT:
+        if parent_ref is not None:
+            raise CanonicalExperimentIdentityError("ROOT parent_lineage_ref must be null")
+    elif kind == PARENT_KIND_PARENT_BOUND:
+        if not isinstance(parent_ref, str) or not parent_ref.strip():
+            raise CanonicalExperimentIdentityError(
+                "PARENT_BOUND parent_lineage_ref must be a non-empty string"
+            )
+    else:
+        raise CanonicalExperimentIdentityError("parent_lineage.kind is invalid")
+
+    identity_body = {
+        key: record[key] for key in record if key not in {"identity_digest", "integrity"}
+    }
+    expected_identity_digest = domain_separated_digest("identity", identity_body)
+    if record.get("identity_digest") != expected_identity_digest:
+        raise CanonicalExperimentIdentityError("identity_digest mismatch")
+    expected_integrity = compute_content_sha256(
+        {key: value for key, value in record.items() if key != "integrity"}
+    )
+    integrity = record.get("integrity")
+    if not isinstance(integrity, Mapping) or integrity.get("content_sha256") != expected_integrity:
+        raise CanonicalExperimentIdentityError("integrity.content_sha256 mismatch")
+
+
+__all__ = [
+    "COMPLETENESS_COMPLETE",
+    "CanonicalCodeProvenanceV1",
+    "CanonicalExperimentIdentityError",
+    "CanonicalExperimentIdentityRequestV1",
+    "DIGEST_ALGORITHM",
+    "EXPERIMENT_IDENTITY_HAS_RUNTIME_AUTHORITY",
+    "IDENTITY_DOMAIN",
+    "PARENT_KIND_PARENT_BOUND",
+    "PARENT_KIND_ROOT",
+    "RUNTIME_AUTHORITY_IMPACT",
+    "SCHEMA_VERSION",
+    "WORKING_TREE_CLEAN",
+    "WORKING_TREE_DIRTY",
+    "build_canonical_experiment_identity_v1",
+    "canonicalize_mapping",
+    "canonicalize_value",
+    "digest_domain_name",
+    "domain_separated_digest",
+    "inspect_code_provenance_v1",
+    "validate_canonical_experiment_identity_v1",
+]

--- a/src/experiments/canonical_experiment_identity_v1.py
+++ b/src/experiments/canonical_experiment_identity_v1.py
@@ -37,6 +37,20 @@ PARENT_KIND_ROOT: Final[str] = "ROOT"
 PARENT_KIND_PARENT_BOUND: Final[str] = "PARENT_BOUND"
 EXPERIMENT_IDENTITY_HAS_RUNTIME_AUTHORITY: Final[bool] = False
 RUNTIME_AUTHORITY_IMPACT: Final[str] = "NONE"
+SELF_LEARNING_MUST_LEARN_FROM_CANONICAL_TRADING_DECISION_PATH: Final[bool] = True
+LEARNING_MAY_RESEARCH_CORE_LOGIC_CHANGES: Final[bool] = True
+LEARNING_MAY_AUTONOMOUSLY_REPLACE_CORE_LOGIC: Final[bool] = False
+CANONICAL_TRADING_DECISION_CORE_BOUND: Final[bool] = True
+
+_TRADING_DECISION_CORE_COMPONENTS: Final[tuple[str, ...]] = (
+    "market_context_contract",
+    "bull_bear_logic",
+    "state_switch_logic",
+    "survival_logic",
+    "suitability_logic",
+    "double_play_logic",
+    "entry_position_exit_logic",
+)
 
 _GIT_SHA1_RE = re.compile(r"^[0-9a-f]{40}$")
 _SECRET_KEY_TOKEN_RE = re.compile(
@@ -73,6 +87,7 @@ _CRITICAL_DIGEST_FIELDS = (
     "risk_policy_digest",
     "portfolio_digest",
     "split_policy_digest",
+    *(f"{component}_digest" for component in _TRADING_DECISION_CORE_COMPONENTS),
 )
 _DIGEST_DOMAINS: Final[Mapping[str, str]] = MappingProxyType(
     {
@@ -87,6 +102,14 @@ _DIGEST_DOMAINS: Final[Mapping[str, str]] = MappingProxyType(
         "risk_policy": f"{IDENTITY_DOMAIN}.risk_policy",
         "portfolio": f"{IDENTITY_DOMAIN}.portfolio",
         "split_policy": f"{IDENTITY_DOMAIN}.split_policy",
+        "market_context_contract": f"{IDENTITY_DOMAIN}.market_context_contract",
+        "bull_bear_logic": f"{IDENTITY_DOMAIN}.bull_bear_logic",
+        "state_switch_logic": f"{IDENTITY_DOMAIN}.state_switch_logic",
+        "survival_logic": f"{IDENTITY_DOMAIN}.survival_logic",
+        "suitability_logic": f"{IDENTITY_DOMAIN}.suitability_logic",
+        "double_play_logic": f"{IDENTITY_DOMAIN}.double_play_logic",
+        "entry_position_exit_logic": f"{IDENTITY_DOMAIN}.entry_position_exit_logic",
+        "trading_decision_core": f"{IDENTITY_DOMAIN}.trading_decision_core",
         "environment": f"{IDENTITY_DOMAIN}.environment",
         "identity": f"{IDENTITY_DOMAIN}.identity",
         "dirty_paths": f"{IDENTITY_DOMAIN}.dirty_paths",
@@ -121,6 +144,13 @@ class CanonicalExperimentIdentityRequestV1:
     risk_policy_digest: str
     portfolio_digest: str
     split_policy_digest: str
+    market_context_contract_digest: str
+    bull_bear_logic_digest: str
+    state_switch_logic_digest: str
+    survival_logic_digest: str
+    suitability_logic_digest: str
+    double_play_logic_digest: str
+    entry_position_exit_logic_digest: str
     seed: int
     environment: Mapping[str, Any]
     parent_lineage_ref: str | None = None
@@ -144,6 +174,25 @@ def domain_separated_digest(component: str, payload: Mapping[str, Any]) -> str:
         "schema_version": SCHEMA_VERSION,
     }
     return compute_content_sha256(envelope)
+
+
+def compute_trading_decision_core_binding_v1(
+    source_digests: Mapping[str, str],
+) -> dict[str, str]:
+    """Bind canonical trading-decision-core components without mutating trading logic."""
+    if not isinstance(source_digests, Mapping):
+        raise CanonicalExperimentIdentityError(
+            "trading decision core source_digests must be a mapping"
+        )
+    bound: dict[str, str] = {}
+    for component in _TRADING_DECISION_CORE_COMPONENTS:
+        field_name = f"{component}_digest"
+        bound[field_name] = domain_separated_digest(
+            component,
+            {"source_digest": _require_sha256_digest(field_name, source_digests.get(field_name))},
+        )
+    bound["trading_decision_core_digest"] = domain_separated_digest("trading_decision_core", bound)
+    return bound
 
 
 def canonicalize_value(value: Any, *, path: str = "$") -> Any:
@@ -432,6 +481,12 @@ def build_canonical_experiment_identity_v1(
     split_policy_digest = domain_separated_digest(
         "split_policy", {"source_digest": bound_digests["split_policy_digest"]}
     )
+    trading_core = compute_trading_decision_core_binding_v1(
+        {
+            f"{component}_digest": bound_digests[f"{component}_digest"]
+            for component in _TRADING_DECISION_CORE_COMPONENTS
+        }
+    )
     environment_digest = domain_separated_digest("environment", environment)
 
     identity_body = {
@@ -458,6 +513,22 @@ def build_canonical_experiment_identity_v1(
         "strategy_identity": strategy_identity,
         "strategy_identity_digest": strategy_identity_digest,
         "strategy_params_digest": strategy_params_digest,
+        "bull_bear_logic_digest": trading_core["bull_bear_logic_digest"],
+        "canonical_trading_decision_core_bound": CANONICAL_TRADING_DECISION_CORE_BOUND,
+        "double_play_logic_digest": trading_core["double_play_logic_digest"],
+        "entry_position_exit_logic_digest": trading_core["entry_position_exit_logic_digest"],
+        "learning_may_autonomously_replace_core_logic": (
+            LEARNING_MAY_AUTONOMOUSLY_REPLACE_CORE_LOGIC
+        ),
+        "learning_may_research_core_logic_changes": LEARNING_MAY_RESEARCH_CORE_LOGIC_CHANGES,
+        "market_context_contract_digest": trading_core["market_context_contract_digest"],
+        "self_learning_must_learn_from_canonical_trading_decision_path": (
+            SELF_LEARNING_MUST_LEARN_FROM_CANONICAL_TRADING_DECISION_PATH
+        ),
+        "state_switch_logic_digest": trading_core["state_switch_logic_digest"],
+        "suitability_logic_digest": trading_core["suitability_logic_digest"],
+        "survival_logic_digest": trading_core["survival_logic_digest"],
+        "trading_decision_core_digest": trading_core["trading_decision_core_digest"],
         "working_tree_status": WORKING_TREE_CLEAN,
     }
     identity_digest = domain_separated_digest("identity", identity_body)
@@ -512,6 +583,26 @@ def validate_canonical_experiment_identity_v1(record: Mapping[str, Any]) -> None
     else:
         raise CanonicalExperimentIdentityError("parent_lineage.kind is invalid")
 
+    if record.get("canonical_trading_decision_core_bound") is not True:
+        raise CanonicalExperimentIdentityError("canonical_trading_decision_core_bound must be true")
+    if record.get("learning_may_autonomously_replace_core_logic") is not False:
+        raise CanonicalExperimentIdentityError(
+            "learning_may_autonomously_replace_core_logic must be false"
+        )
+    if record.get("self_learning_must_learn_from_canonical_trading_decision_path") is not True:
+        raise CanonicalExperimentIdentityError(
+            "self_learning_must_learn_from_canonical_trading_decision_path must be true"
+        )
+    core_payload = {
+        f"{component}_digest": record.get(f"{component}_digest")
+        for component in _TRADING_DECISION_CORE_COMPONENTS
+    }
+    for field_name, value in core_payload.items():
+        _require_sha256_digest(field_name, value)
+    expected_core_digest = domain_separated_digest("trading_decision_core", core_payload)
+    if record.get("trading_decision_core_digest") != expected_core_digest:
+        raise CanonicalExperimentIdentityError("trading_decision_core_digest mismatch")
+
     identity_body = {
         key: record[key] for key in record if key not in {"identity_digest", "integrity"}
     }
@@ -527,6 +618,7 @@ def validate_canonical_experiment_identity_v1(record: Mapping[str, Any]) -> None
 
 
 __all__ = [
+    "CANONICAL_TRADING_DECISION_CORE_BOUND",
     "COMPLETENESS_COMPLETE",
     "CanonicalCodeProvenanceV1",
     "CanonicalExperimentIdentityError",
@@ -534,15 +626,19 @@ __all__ = [
     "DIGEST_ALGORITHM",
     "EXPERIMENT_IDENTITY_HAS_RUNTIME_AUTHORITY",
     "IDENTITY_DOMAIN",
+    "LEARNING_MAY_AUTONOMOUSLY_REPLACE_CORE_LOGIC",
+    "LEARNING_MAY_RESEARCH_CORE_LOGIC_CHANGES",
     "PARENT_KIND_PARENT_BOUND",
     "PARENT_KIND_ROOT",
     "RUNTIME_AUTHORITY_IMPACT",
     "SCHEMA_VERSION",
+    "SELF_LEARNING_MUST_LEARN_FROM_CANONICAL_TRADING_DECISION_PATH",
     "WORKING_TREE_CLEAN",
     "WORKING_TREE_DIRTY",
     "build_canonical_experiment_identity_v1",
     "canonicalize_mapping",
     "canonicalize_value",
+    "compute_trading_decision_core_binding_v1",
     "digest_domain_name",
     "domain_separated_digest",
     "inspect_code_provenance_v1",

--- a/src/experiments/experiment_identity_manifest_v1.py
+++ b/src/experiments/experiment_identity_manifest_v1.py
@@ -1,4 +1,12 @@
-"""Offline Package N — Experiment Identity Manifest Producer v1."""
+"""Offline Package N — Experiment Identity Manifest Producer v1.
+
+Package N identity is an incomplete historical projection. Phase 1 COMPLETE
+Canonical Experiment Identity lives in
+``src.experiments.canonical_experiment_identity_v1`` and does not reinterpret
+existing Package N ``experiment_identity_id`` hashes.
+
+EXPERIMENT_IDENTITY_HAS_RUNTIME_AUTHORITY=false
+"""
 
 from __future__ import annotations
 
@@ -34,6 +42,7 @@ IDENTITY_DOMAIN = "peak_trade.experiment_identity.v1"
 ARTIFACT_FILENAME = "experiment_identity_manifest_v1.json"
 STAGING_DIRNAME_PREFIX = ".experiment_identity_staging_"
 RUNTIME_AUTHORITY_IMPACT = "NONE"
+PACKAGE_N_IDENTITY_COMPLETENESS = "INCOMPLETE_PACKAGE_N_PROJECTION_NOT_PHASE_1_COMPLETE"
 
 _REQUIRED_IDENTITY_FIELDS = (
     "name",
@@ -566,6 +575,7 @@ __all__ = [
     "ExperimentIdentityManifestError",
     "IDENTITY_DOMAIN",
     "IDENTITY_SCHEMA_VERSION",
+    "PACKAGE_N_IDENTITY_COMPLETENESS",
     "RUNTIME_AUTHORITY_IMPACT",
     "active_input_matrix_classifications",
     "build_identity_config",

--- a/tests/experiments/test_canonical_experiment_identity_v1.py
+++ b/tests/experiments/test_canonical_experiment_identity_v1.py
@@ -13,9 +13,11 @@ from typing import Any, Mapping
 import pytest
 
 from src.experiments.canonical_experiment_identity_v1 import (
+    CANONICAL_TRADING_DECISION_CORE_BOUND,
     COMPLETENESS_COMPLETE,
     EXPERIMENT_IDENTITY_HAS_RUNTIME_AUTHORITY,
     IDENTITY_DOMAIN,
+    LEARNING_MAY_AUTONOMOUSLY_REPLACE_CORE_LOGIC,
     PARENT_KIND_PARENT_BOUND,
     PARENT_KIND_ROOT,
     SCHEMA_VERSION,
@@ -26,6 +28,7 @@ from src.experiments.canonical_experiment_identity_v1 import (
     CanonicalExperimentIdentityRequestV1,
     build_canonical_experiment_identity_v1,
     canonicalize_mapping,
+    compute_trading_decision_core_binding_v1,
     inspect_code_provenance_v1,
     validate_canonical_experiment_identity_v1,
 )
@@ -58,6 +61,13 @@ def _request(**overrides: Any) -> CanonicalExperimentIdentityRequestV1:
         "risk_policy_digest": _digest("risk"),
         "portfolio_digest": _digest("portfolio"),
         "split_policy_digest": _digest("split"),
+        "market_context_contract_digest": _digest("market-context"),
+        "bull_bear_logic_digest": _digest("bull-bear"),
+        "state_switch_logic_digest": _digest("state-switch"),
+        "survival_logic_digest": _digest("survival"),
+        "suitability_logic_digest": _digest("suitability"),
+        "double_play_logic_digest": _digest("double-play"),
+        "entry_position_exit_logic_digest": _digest("entry-position-exit"),
         "seed": 7,
         "environment": {
             "python_version": "3.11.15",
@@ -92,6 +102,13 @@ def test_mutation_sensitivity_each_critical_field_changes_identity() -> None:
         {"risk_policy_digest": _digest("risk-b")},
         {"portfolio_digest": _digest("portfolio-b")},
         {"split_policy_digest": _digest("split-b")},
+        {"market_context_contract_digest": _digest("market-context-b")},
+        {"bull_bear_logic_digest": _digest("bull-bear-b")},
+        {"state_switch_logic_digest": _digest("state-switch-b")},
+        {"survival_logic_digest": _digest("survival-b")},
+        {"suitability_logic_digest": _digest("suitability-b")},
+        {"double_play_logic_digest": _digest("double-play-b")},
+        {"entry_position_exit_logic_digest": _digest("entry-position-exit-b")},
         {"seed": 8},
         {"environment": {"python_version": "3.10.14", "python_implementation": "CPython"}},
         {"parent_lineage_ref": _digest("parent")},
@@ -125,11 +142,75 @@ def test_missing_critical_inputs_fail_closed(monkeypatch: pytest.MonkeyPatch) ->
         {"funding_model_digest": "implicit"},
         {"risk_policy_digest": "default"},
         {"split_policy_digest": "none"},
+        {"bull_bear_logic_digest": "UNKNOWN"},
+        {"survival_logic_digest": "UNAVAILABLE"},
+        {"entry_position_exit_logic_digest": ""},
         {"seed": None},
     ]
     for mutation in missing_cases:
         with pytest.raises(CanonicalExperimentIdentityError, match="fail-closed|explicit int"):
             build_canonical_experiment_identity_v1(_request(**mutation))
+
+
+def test_identical_trading_core_yields_identical_core_digest() -> None:
+    first = build_canonical_experiment_identity_v1(_request())
+    second = build_canonical_experiment_identity_v1(_request())
+    assert first["trading_decision_core_digest"] == second["trading_decision_core_digest"]
+    assert first["canonical_trading_decision_core_bound"] is True
+    assert CANONICAL_TRADING_DECISION_CORE_BOUND is True
+    assert LEARNING_MAY_AUTONOMOUSLY_REPLACE_CORE_LOGIC is False
+
+
+@pytest.mark.parametrize(
+    ("field_name", "label"),
+    [
+        ("bull_bear_logic_digest", "bull-bear-changed"),
+        ("state_switch_logic_digest", "state-switch-changed"),
+        ("survival_logic_digest", "survival-changed"),
+        ("suitability_logic_digest", "suitability-changed"),
+        ("double_play_logic_digest", "double-play-changed"),
+        ("entry_position_exit_logic_digest", "entry-position-exit-changed"),
+        ("market_context_contract_digest", "market-context-changed"),
+    ],
+)
+def test_core_component_change_shifts_core_and_experiment_identity(
+    field_name: str, label: str
+) -> None:
+    baseline = build_canonical_experiment_identity_v1(_request())
+    mutated = build_canonical_experiment_identity_v1(_request(**{field_name: _digest(label)}))
+    assert mutated[field_name] != baseline[field_name]
+    assert mutated["trading_decision_core_digest"] != baseline["trading_decision_core_digest"]
+    assert mutated["identity_digest"] != baseline["identity_digest"]
+    unchanged = [
+        "bull_bear_logic_digest",
+        "state_switch_logic_digest",
+        "survival_logic_digest",
+        "suitability_logic_digest",
+        "double_play_logic_digest",
+        "entry_position_exit_logic_digest",
+        "market_context_contract_digest",
+    ]
+    for name in unchanged:
+        if name != field_name:
+            assert mutated[name] == baseline[name]
+
+
+def test_trading_core_binding_order_stable() -> None:
+    source = {
+        "entry_position_exit_logic_digest": _digest("entry-position-exit"),
+        "double_play_logic_digest": _digest("double-play"),
+        "suitability_logic_digest": _digest("suitability"),
+        "survival_logic_digest": _digest("survival"),
+        "state_switch_logic_digest": _digest("state-switch"),
+        "bull_bear_logic_digest": _digest("bull-bear"),
+        "market_context_contract_digest": _digest("market-context"),
+    }
+    left = compute_trading_decision_core_binding_v1(source)
+    right = compute_trading_decision_core_binding_v1(
+        {key: source[key] for key in reversed(list(source))}
+    )
+    assert left == right
+    assert left["trading_decision_core_digest"] == right["trading_decision_core_digest"]
 
 
 def test_cost_model_decomposition_single_component_changes_identity() -> None:
@@ -245,6 +326,8 @@ def test_authority_boundary_regression_no_write_or_live_paths() -> None:
         "src.execution",
         "scripts.run_learning_apply_cycle",
         "src.live",
+        "src.trading",
+        "src.trading.master_v2",
     }
     assert forbidden_imports.isdisjoint(imported)
     forbidden_tokens = (
@@ -263,6 +346,9 @@ def test_authority_boundary_regression_no_write_or_live_paths() -> None:
     record = build_canonical_experiment_identity_v1(_request())
     assert record["experiment_identity_has_runtime_authority"] is False
     assert record["runtime_authority_impact"] == "NONE"
+    assert record["learning_may_autonomously_replace_core_logic"] is False
+    assert record["canonical_trading_decision_core_bound"] is True
+    assert record["self_learning_must_learn_from_canonical_trading_decision_path"] is True
     assert "write_live_config" not in inspect.getsource(build_canonical_experiment_identity_v1)
 
 

--- a/tests/experiments/test_canonical_experiment_identity_v1.py
+++ b/tests/experiments/test_canonical_experiment_identity_v1.py
@@ -1,0 +1,284 @@
+"""Phase 1 Canonical Experiment Identity v1 contract tests."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import inspect
+import logging
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping
+
+import pytest
+
+from src.experiments.canonical_experiment_identity_v1 import (
+    COMPLETENESS_COMPLETE,
+    EXPERIMENT_IDENTITY_HAS_RUNTIME_AUTHORITY,
+    IDENTITY_DOMAIN,
+    PARENT_KIND_PARENT_BOUND,
+    PARENT_KIND_ROOT,
+    SCHEMA_VERSION,
+    WORKING_TREE_CLEAN,
+    WORKING_TREE_DIRTY,
+    CanonicalCodeProvenanceV1,
+    CanonicalExperimentIdentityError,
+    CanonicalExperimentIdentityRequestV1,
+    build_canonical_experiment_identity_v1,
+    canonicalize_mapping,
+    inspect_code_provenance_v1,
+    validate_canonical_experiment_identity_v1,
+)
+from src.experiments.experiment_identity_manifest_v1 import (
+    PACKAGE_N_IDENTITY_COMPLETENESS,
+    build_manifest,
+)
+from src.experiments.base import ExperimentConfig, ParamSweep
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "src" / "experiments" / "canonical_experiment_identity_v1.py"
+_GIT_SHA = "a7f4502e04e168b2dd12b56fecb745323bd6c783"
+
+
+def _digest(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _request(**overrides: Any) -> CanonicalExperimentIdentityRequestV1:
+    payload: dict[str, Any] = {
+        "git_sha": _GIT_SHA,
+        "working_tree_status": WORKING_TREE_CLEAN,
+        "strategy_identity": "ma_crossover.v1",
+        "strategy_params": {"slow": 50, "fast": 10},
+        "dataset_digest": _digest("dataset"),
+        "feature_pipeline_digest": _digest("features"),
+        "fee_model_digest": _digest("fee"),
+        "slippage_model_digest": _digest("slippage"),
+        "funding_model_digest": _digest("funding"),
+        "risk_policy_digest": _digest("risk"),
+        "portfolio_digest": _digest("portfolio"),
+        "split_policy_digest": _digest("split"),
+        "seed": 7,
+        "environment": {
+            "python_version": "3.11.15",
+            "python_implementation": "CPython",
+        },
+        "parent_lineage_ref": None,
+        "dirty_paths_digest": None,
+    }
+    payload.update(overrides)
+    return CanonicalExperimentIdentityRequestV1(**payload)
+
+
+def test_determinism_same_inputs_same_identity() -> None:
+    first = dict(build_canonical_experiment_identity_v1(_request()))
+    second = dict(build_canonical_experiment_identity_v1(_request()))
+    assert first == second
+    assert first["identity_digest"] == second["identity_digest"]
+    assert first["completeness"] == COMPLETENESS_COMPLETE
+
+
+def test_mutation_sensitivity_each_critical_field_changes_identity() -> None:
+    baseline = build_canonical_experiment_identity_v1(_request())["identity_digest"]
+    mutations: list[dict[str, Any]] = [
+        {"git_sha": "b" * 40},
+        {"strategy_identity": "macd.v1"},
+        {"strategy_params": {"slow": 51, "fast": 10}},
+        {"dataset_digest": _digest("dataset-b")},
+        {"feature_pipeline_digest": _digest("features-b")},
+        {"fee_model_digest": _digest("fee-b")},
+        {"slippage_model_digest": _digest("slippage-b")},
+        {"funding_model_digest": _digest("funding-b")},
+        {"risk_policy_digest": _digest("risk-b")},
+        {"portfolio_digest": _digest("portfolio-b")},
+        {"split_policy_digest": _digest("split-b")},
+        {"seed": 8},
+        {"environment": {"python_version": "3.10.14", "python_implementation": "CPython"}},
+        {"parent_lineage_ref": _digest("parent")},
+    ]
+    changed: set[str] = set()
+    for mutation in mutations:
+        digest = build_canonical_experiment_identity_v1(_request(**mutation))["identity_digest"]
+        assert digest != baseline
+        changed.add(digest)
+    assert len(changed) == len(mutations)
+
+
+def test_ordering_stability_equivalent_maps_and_sets() -> None:
+    left = build_canonical_experiment_identity_v1(
+        _request(strategy_params={"z": 1, "nested": {"b": 2, "a": {3, 1, 2}}, "list": [1, 2]})
+    )
+    right = build_canonical_experiment_identity_v1(
+        _request(strategy_params={"list": [1, 2], "nested": {"a": {2, 3, 1}, "b": 2}, "z": 1})
+    )
+    assert left["strategy_params_digest"] == right["strategy_params_digest"]
+    assert left["identity_digest"] == right["identity_digest"]
+
+
+def test_missing_critical_inputs_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    missing_cases: list[dict[str, Any]] = [
+        {"dataset_digest": None},
+        {"dataset_digest": "UNKNOWN"},
+        {"feature_pipeline_digest": "UNAVAILABLE"},
+        {"fee_model_digest": ""},
+        {"slippage_model_digest": "n/a"},
+        {"funding_model_digest": "implicit"},
+        {"risk_policy_digest": "default"},
+        {"split_policy_digest": "none"},
+        {"seed": None},
+    ]
+    for mutation in missing_cases:
+        with pytest.raises(CanonicalExperimentIdentityError, match="fail-closed|explicit int"):
+            build_canonical_experiment_identity_v1(_request(**mutation))
+
+
+def test_cost_model_decomposition_single_component_changes_identity() -> None:
+    baseline = build_canonical_experiment_identity_v1(_request())
+    fee_changed = build_canonical_experiment_identity_v1(
+        _request(fee_model_digest=_digest("fee-only"))
+    )
+    assert fee_changed["fee_model_digest"] != baseline["fee_model_digest"]
+    assert fee_changed["slippage_model_digest"] == baseline["slippage_model_digest"]
+    assert fee_changed["funding_model_digest"] == baseline["funding_model_digest"]
+    assert fee_changed["cost_model_digest"] != baseline["cost_model_digest"]
+    assert fee_changed["identity_digest"] != baseline["identity_digest"]
+
+
+def test_lineage_root_versus_parent_bound_distinct() -> None:
+    root = build_canonical_experiment_identity_v1(_request(parent_lineage_ref=None))
+    child = build_canonical_experiment_identity_v1(
+        _request(parent_lineage_ref=_digest("parent-experiment"))
+    )
+    assert root["parent_lineage"]["kind"] == PARENT_KIND_ROOT
+    assert root["parent_lineage"]["parent_lineage_ref"] is None
+    assert child["parent_lineage"]["kind"] == PARENT_KIND_PARENT_BOUND
+    assert child["identity_digest"] != root["identity_digest"]
+
+
+def test_secrets_are_neither_serialized_nor_logged(caplog: pytest.LogCaptureFixture) -> None:
+    secret_value = "super-secret-credential-value-9f3a"
+    caplog.set_level(logging.DEBUG)
+    with pytest.raises(CanonicalExperimentIdentityError, match="secret or credential"):
+        build_canonical_experiment_identity_v1(
+            _request(strategy_params={"window": 3, "api_key": secret_value})
+        )
+    joined = "\n".join(record.getMessage() for record in caplog.records)
+    assert secret_value not in joined
+    with pytest.raises(CanonicalExperimentIdentityError) as exc_info:
+        canonicalize_mapping({"confirm_token": secret_value})
+    assert secret_value not in str(exc_info.value)
+
+
+def test_dirty_tree_cannot_equal_clean_git_sha_identity() -> None:
+    clean = build_canonical_experiment_identity_v1(_request())
+    with pytest.raises(CanonicalExperimentIdentityError, match="DIRTY_TREE_PROVENANCE_FAIL_CLOSED"):
+        build_canonical_experiment_identity_v1(
+            _request(
+                working_tree_status=WORKING_TREE_DIRTY,
+                dirty_paths_digest=_digest("dirty-paths"),
+            )
+        )
+    dirty_provenance = CanonicalCodeProvenanceV1(
+        git_sha=_GIT_SHA,
+        working_tree_status=WORKING_TREE_DIRTY,
+        dirty_paths_digest=_digest("dirty-paths"),
+    )
+    assert dirty_provenance.git_sha == clean["git_sha"]
+    assert dirty_provenance.working_tree_status != clean["working_tree_status"]
+
+
+def test_inspect_code_provenance_clean_worktree() -> None:
+    provenance = inspect_code_provenance_v1(REPO_ROOT)
+    assert provenance.git_sha == _GIT_SHA or len(provenance.git_sha) == 40
+    if provenance.working_tree_status == WORKING_TREE_CLEAN:
+        assert provenance.dirty_paths_digest is None
+        record = build_canonical_experiment_identity_v1(_request(git_sha=provenance.git_sha))
+        assert record["working_tree_status"] == WORKING_TREE_CLEAN
+    else:
+        with pytest.raises(CanonicalExperimentIdentityError, match="DIRTY_TREE"):
+            build_canonical_experiment_identity_v1(
+                _request(
+                    git_sha=provenance.git_sha,
+                    working_tree_status=WORKING_TREE_DIRTY,
+                    dirty_paths_digest=provenance.dirty_paths_digest,
+                )
+            )
+
+
+def test_package_n_identity_not_reinterpreted() -> None:
+    config = ExperimentConfig(
+        name="MA Optimization",
+        strategy_name="ma_crossover",
+        param_sweeps=[ParamSweep("fast", [5, 10])],
+        symbols=["BTC/EUR"],
+        timeframe="1h",
+    )
+    package_n = build_manifest(config)
+    canonical = build_canonical_experiment_identity_v1(_request())
+    assert package_n["experiment_identity_id"] != canonical["identity_digest"]
+    assert PACKAGE_N_IDENTITY_COMPLETENESS.startswith("INCOMPLETE_")
+    assert canonical["schema_version"] != package_n["schema_version"]
+    assert canonical["identity_domain"] == IDENTITY_DOMAIN
+    assert canonical["schema_version"] == SCHEMA_VERSION
+
+
+def test_frozen_record_is_immutable() -> None:
+    record = build_canonical_experiment_identity_v1(_request())
+    assert isinstance(record, MappingProxyType)
+    with pytest.raises(TypeError):
+        record["seed"] = 99  # type: ignore[index]
+    validate_canonical_experiment_identity_v1(record)
+
+
+def test_authority_boundary_regression_no_write_or_live_paths() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+    forbidden_imports = {
+        "src.core.peak_config",
+        "src.governance.promotion_loop.engine",
+        "src.execution",
+        "scripts.run_learning_apply_cycle",
+        "src.live",
+    }
+    assert forbidden_imports.isdisjoint(imported)
+    forbidden_tokens = (
+        "config/live_overrides",
+        "load_config_with_live_overrides",
+        "submit_order",
+        "confirm_token",
+        "LIVE_AUTHORIZED",
+        "TESTNET_AUTHORIZED",
+        "apply_proposals_to_live_overrides",
+    )
+    for token in forbidden_tokens:
+        assert token not in source
+    assert "enabled" not in source.split("EXPERIMENT_IDENTITY_HAS_RUNTIME_AUTHORITY")[0]
+    assert EXPERIMENT_IDENTITY_HAS_RUNTIME_AUTHORITY is False
+    record = build_canonical_experiment_identity_v1(_request())
+    assert record["experiment_identity_has_runtime_authority"] is False
+    assert record["runtime_authority_impact"] == "NONE"
+    assert "write_live_config" not in inspect.getsource(build_canonical_experiment_identity_v1)
+
+
+def test_host_identifying_environment_rejected() -> None:
+    with pytest.raises(CanonicalExperimentIdentityError, match="non-reproducibility"):
+        build_canonical_experiment_identity_v1(
+            _request(
+                environment={
+                    "python_version": "3.11.15",
+                    "python_implementation": "CPython",
+                    "hostname": "mac-local",
+                }
+            )
+        )
+
+
+def test_bool_seed_rejected() -> None:
+    with pytest.raises(CanonicalExperimentIdentityError, match="explicit int"):
+        build_canonical_experiment_identity_v1(_request(seed=True))


### PR DESCRIPTION
## Summary
- Adds Phase 1 Canonical Experiment Identity v1 as a deterministic, immutable research-metadata contract.
- Extends Package N identity only as an explicit incomplete historical projection; existing Package N hashes are not reinterpreted.
- Fail-closed for missing fee/slippage/funding/dataset/risk/split/seed bindings, dirty trees, and secret fields. No runtime, live, order, funding, canary, or config-write authority.

## Test plan
- [x] `tests/experiments/test_canonical_experiment_identity_v1.py` (determinism, mutation, ordering, missing inputs, cost decomposition, lineage, secrets, dirty-tree, Package N compatibility, authority boundary)
- [x] Package N identity tests (`tests/experiments/test_experiment_identity_manifest_v1.py`, `tests/scripts/test_run_experiment_identity_manifest_v1.py`)
- [x] Existing experiment/sweep/lineage regression tests
- [x] Ruff format/check on changed Python files
- [x] Pyright on affected identity files
- Merge requires a separate `OWNER_MERGE_GO`.


Made with [Cursor](https://cursor.com)