### PR TITLE
research: add immutable experiment memory v1

### DIFF
--- a/docs/ops/specs/CANONICAL_EXPERIMENT_MEMORY_V1.md
+++ b/docs/ops/specs/CANONICAL_EXPERIMENT_MEMORY_V1.md
@@ -1,0 +1,89 @@
+# Canonical Experiment Memory v1
+
+Contract for Peak_Trade Phase 2 Immutable Experiment Memory.
+
+```text
+SCHEMA_VERSION=canonical_experiment_memory_v1
+MEMORY_DOMAIN=peak_trade.canonical_experiment_memory.v1
+EXPERIMENT_MEMORY_HAS_RUNTIME_AUTHORITY=false
+EXPERIMENT_MEMORY_CAN_MUTATE_LIVE_CONFIG=false
+EXPERIMENT_MEMORY_CAN_PROMOTE=false
+```
+
+Owners:
+
+- `src&#47;experiments&#47;canonical_experiment_memory_v1.py` — schema, validation, identity binding
+- `src&#47;experiments&#47;canonical_experiment_memory_store_v1.py` — append-only file persist and read
+
+Phase 1 owner `src&#47;experiments&#47;canonical_experiment_identity_v1.py` remains the Canonical Experiment Identity. This layer stores that identity in full; it does not invent a second identity.
+
+Existing `src&#47;experiments&#47;tracking&#47;run_summary.py` and `src&#47;experiments&#47;live_session_registry.py` remain incomplete historical tracking surfaces. They are not COMPLETE experiment memory and are not imported or migrated by this contract.
+
+## What is immutable
+
+After a record is successfully persisted, historical truth cannot change:
+
+- metrics
+- disposition / rejection_reason
+- lineage / parent_experiment
+- experiment_identity and core-logic digests
+- artifact refs
+- created_at
+
+## What is append-only
+
+```text
+same experiment_id + identical canonical content => idempotent accept
+same experiment_id + divergent canonical content => FAIL_CLOSED
+new experiment_id => append
+```
+
+Silent overwrite, upsert-with-changed-truth, and in-place mutation are forbidden. Later corrections must be a new record. `supersedes_experiment_id` is an optional typed reference only; this phase does not apply amendments.
+
+## Conflict
+
+A conflict is any persist attempt where `experiment_id` already exists and the canonical JSON payload differs. The store raises `ExperimentRecordConflictError` and leaves the original file unchanged.
+
+## Experiment identity binding
+
+`experiment_id` is derived deterministically from Phase 1 `identity_digest`. The persisted `experiment_identity` object is the complete Canonical Experiment Identity v1 record, including:
+
+- `trading_decision_core_digest`
+- `market_context_contract_digest`
+- `bull_bear_logic_digest`
+- `state_switch_logic_digest`
+- `survival_logic_digest`
+- `suitability_logic_digest`
+- `double_play_logic_digest`
+- `entry_position_exit_logic_digest`
+
+`dataset_ref`, `cost_model_ref`, `risk_policy_ref`, and `portfolio_ref` must be `IDENTITY_DIGEST_BOUND` to the corresponding identity digests. Missing fee, slippage, funding, or risk bindings remain fail-closed in Phase 1 identity; this memory layer never defaults them to zero.
+
+## Lineage
+
+- Root: `parent_experiment=null`, `lineage.kind=ROOT`, empty ancestors
+- Child: explicit `parent_experiment`, `lineage.kind=PARENT_BOUND`, ancestors starting with the parent
+- Self-parent and direct cyclic ancestors are rejected
+- Parent overwrite of an existing record is a conflict, not a mutation
+
+## Artifact refs
+
+Artifacts are reproducible pointers, not local developer paths:
+
+- `REPO_RELATIVE` or `STORE_RELATIVE`
+- POSIX relative path without `..`, empty segments, or absolute/home/drive prefixes
+- sha256 digest of the artifact bytes as claimed by the caller
+
+## Read surface
+
+The store can `append`, `get`, `exists`, and `list_metadata`. It does not rank, compare, promote, or run failure-memory / champion-challenger logic.
+
+## What this store cannot do
+
+```text
+EXPERIMENT_MEMORY_HAS_RUNTIME_AUTHORITY=false
+EXPERIMENT_MEMORY_CAN_MUTATE_LIVE_CONFIG=false
+EXPERIMENT_MEMORY_CAN_PROMOTE=false
+```
+
+Experiment Memory is historical research truth. It is not config, not promotion authority, not runtime authority, and not trading authority. Disposition values such as `SHADOW_ELIGIBLE`, `TESTNET_ELIGIBLE`, and `PROMOTION_EVIDENCE_READY` are memory labels only and do not authorize live, canary, orders, funding, risk, or leverage.

--- a/src/experiments/canonical_experiment_memory_store_v1.py
+++ b/src/experiments/canonical_experiment_memory_store_v1.py
@@ -1,0 +1,203 @@
+"""Append-only file-backed Canonical Experiment Memory store v1.
+
+Historical records are immutable after successful persist. Identical
+canonical replay is idempotent. Divergent content for the same
+``experiment_id`` fails closed. This store cannot mutate runtime config,
+live overrides, orders, funding, risk, leverage, or promotion authority.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.experiments.canonical_experiment_memory_v1 import (
+    ExperimentMemoryValidationError,
+    ExperimentRecordConflictError,
+    canonical_record_payload,
+    freeze_canonical_experiment_memory_record_v1,
+    validate_canonical_experiment_memory_record_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import (
+    deterministic_json_dumps,
+    is_valid_sha256_hex,
+)
+
+RECORD_FILENAME = "canonical_experiment_memory_record_v1.json"
+_TMP_PREFIX = ".canonical_experiment_memory_"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CanonicalExperimentMemoryStoreV1:
+    """File-backed append-only experiment memory."""
+
+    def __init__(self, store_root: Path | str) -> None:
+        root = Path(store_root)
+        if root.exists() and not root.is_dir():
+            raise ExperimentMemoryValidationError("store_root must be a directory")
+        self._root = root
+
+    @property
+    def store_root(self) -> Path:
+        return self._root
+
+    def append(self, record: Mapping[str, Any]) -> Mapping[str, Any]:
+        validate_canonical_experiment_memory_record_v1(record)
+        payload = canonical_record_payload(record)
+        experiment_id = str(payload["experiment_id"])
+        dest = self._record_path(experiment_id)
+        serialized = _serialize_record(payload)
+        if dest.is_file():
+            existing = self.get(experiment_id)
+            if _serialize_record(canonical_record_payload(existing)) == serialized:
+                _LOGGER.info(
+                    "canonical_experiment_memory_v1 idempotent append experiment_id=%s",
+                    experiment_id,
+                )
+                return existing
+            raise ExperimentRecordConflictError(
+                "divergent canonical content for existing experiment_id is forbidden"
+            )
+        dest_dir = dest.parent
+        if dest_dir.exists():
+            leftovers = [
+                path.name for path in dest_dir.iterdir() if not path.name.startswith(_TMP_PREFIX)
+            ]
+            if leftovers:
+                raise ExperimentMemoryValidationError(
+                    "experiment directory exists without a complete immutable record"
+                )
+        else:
+            dest_dir.mkdir(parents=True, exist_ok=False)
+        _atomic_create_exclusive(dest, serialized)
+        stored = self.get(experiment_id)
+        _LOGGER.info(
+            "canonical_experiment_memory_v1 appended experiment_id=%s",
+            experiment_id,
+        )
+        return stored
+
+    def get(self, experiment_id: str) -> Mapping[str, Any]:
+        path = self._record_path(experiment_id)
+        if not path.is_file():
+            raise ExperimentMemoryValidationError(f"experiment record not found: {experiment_id}")
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise ExperimentMemoryValidationError(
+                f"corrupt experiment record JSON: {experiment_id}"
+            ) from exc
+        if not isinstance(payload, dict):
+            raise ExperimentMemoryValidationError("corrupt experiment record root")
+        validate_canonical_experiment_memory_record_v1(payload)
+        stored_id = str(payload.get("experiment_id") or "")
+        if stored_id != experiment_id:
+            raise ExperimentMemoryValidationError(
+                "stored experiment_id does not match requested id"
+            )
+        return freeze_canonical_experiment_memory_record_v1(payload)
+
+    def exists(self, experiment_id: str) -> bool:
+        path = self._record_path(experiment_id)
+        if not path.exists():
+            return False
+        self.get(experiment_id)
+        return True
+
+    def list_metadata(self) -> list[dict[str, Any]]:
+        if not self._root.exists():
+            return []
+        rows: list[dict[str, Any]] = []
+        for child in sorted(self._root.iterdir(), key=lambda item: item.name):
+            if not child.is_dir() or child.name.startswith("."):
+                continue
+            if not is_valid_sha256_hex(child.name):
+                raise ExperimentMemoryValidationError(
+                    f"non-canonical directory under experiment memory root: {child.name}"
+                )
+            record = self.get(child.name)
+            rows.append(
+                {
+                    "candidate_role": record["candidate_role"],
+                    "created_at": record["created_at"],
+                    "disposition": record["disposition"],
+                    "experiment_id": record["experiment_id"],
+                    "hypothesis_id": record["hypothesis_id"],
+                    "identity_digest": record["experiment_identity"]["identity_digest"],
+                    "parent_experiment": record["parent_experiment"],
+                }
+            )
+        return rows
+
+    def _record_path(self, experiment_id: str) -> Path:
+        if not isinstance(experiment_id, str) or not is_valid_sha256_hex(experiment_id):
+            raise ExperimentMemoryValidationError(
+                "experiment_id must be a lowercase sha256 hex digest"
+            )
+        if ".." in experiment_id or "/" in experiment_id or "\\" in experiment_id:
+            raise ExperimentMemoryValidationError("experiment_id path traversal is forbidden")
+        root = self._root.resolve()
+        dest_dir = (root / experiment_id).resolve()
+        try:
+            dest_dir.relative_to(root)
+        except ValueError as exc:
+            raise ExperimentMemoryValidationError(
+                "experiment record path escaped store root"
+            ) from exc
+        dest = dest_dir / RECORD_FILENAME
+        dest_resolved = dest.resolve()
+        try:
+            dest_resolved.relative_to(root)
+        except ValueError as exc:
+            raise ExperimentMemoryValidationError(
+                "experiment record path escaped store root"
+            ) from exc
+        return dest
+
+
+def _serialize_record(payload: Mapping[str, Any]) -> str:
+    return deterministic_json_dumps(payload) + "\n"
+
+
+def _atomic_create_exclusive(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=_TMP_PREFIX,
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.link(tmp_name, path)
+        except FileExistsError as exc:
+            existing = Path(path).read_text(encoding="utf-8")
+            if existing != content:
+                raise ExperimentRecordConflictError(
+                    "divergent canonical content for existing experiment_id is forbidden"
+                ) from exc
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+    else:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+
+
+__all__ = [
+    "CanonicalExperimentMemoryStoreV1",
+    "RECORD_FILENAME",
+]

--- a/src/experiments/canonical_experiment_memory_v1.py
+++ b/src/experiments/canonical_experiment_memory_v1.py
@@ -1,0 +1,611 @@
+"""Phase 2 Immutable Experiment Memory v1 (research evidence only).
+
+Append-only historical research truth for COMPLETE Canonical Experiment
+Identity v1 records. This layer has no runtime, order, live, funding,
+canary, promotion, or config-write authority.
+
+Existing tracking surfaces (``tracking/run_summary.py``,
+``live_session_registry.py``, Package N identity) remain incomplete
+historical projections and are not reinterpreted as COMPLETE memory.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Final, Mapping, Sequence
+
+from src.experiments.canonical_experiment_identity_v1 import (
+    CanonicalExperimentIdentityError,
+    canonicalize_mapping,
+    validate_canonical_experiment_identity_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import (
+    compute_content_sha256,
+    is_valid_sha256_hex,
+)
+
+SCHEMA_VERSION: Final[str] = "canonical_experiment_memory_v1"
+MEMORY_DOMAIN: Final[str] = "peak_trade.canonical_experiment_memory.v1"
+DIGEST_ALGORITHM: Final[str] = "sha256"
+RECORD_COMPLETENESS_COMPLETE: Final[str] = "COMPLETE"
+LINEAGE_KIND_ROOT: Final[str] = "ROOT"
+LINEAGE_KIND_PARENT_BOUND: Final[str] = "PARENT_BOUND"
+ARTIFACT_KIND_REPO_RELATIVE: Final[str] = "REPO_RELATIVE"
+ARTIFACT_KIND_STORE_RELATIVE: Final[str] = "STORE_RELATIVE"
+REF_KIND_IDENTITY_DIGEST_BOUND: Final[str] = "IDENTITY_DIGEST_BOUND"
+
+EXPERIMENT_MEMORY_HAS_RUNTIME_AUTHORITY: Final[bool] = False
+EXPERIMENT_MEMORY_CAN_MUTATE_LIVE_CONFIG: Final[bool] = False
+EXPERIMENT_MEMORY_CAN_PROMOTE: Final[bool] = False
+RUNTIME_AUTHORITY_IMPACT: Final[str] = "NONE"
+
+CANONICAL_DISPOSITIONS: Final[tuple[str, ...]] = (
+    "REJECTED_DATA_QUALITY",
+    "REJECTED_REPRODUCIBILITY",
+    "REJECTED_OVERFIT",
+    "REJECTED_COST_SENSITIVITY",
+    "REJECTED_TAIL_RISK",
+    "REJECTED_REGIME_CONCENTRATION",
+    "REJECTED_COMPARABILITY",
+    "REJECTED_REALITY_GAP",
+    "REJECTED_POLICY",
+    "RETEST_WITH_NEW_COST_MODEL",
+    "RESEARCH_ONLY",
+    "CHALLENGER_ELIGIBLE",
+    "SHADOW_ELIGIBLE",
+    "TESTNET_ELIGIBLE",
+    "PROMOTION_EVIDENCE_READY",
+)
+_REJECTION_DISPOSITIONS: Final[frozenset[str]] = frozenset(
+    disposition for disposition in CANONICAL_DISPOSITIONS if disposition.startswith("REJECTED_")
+)
+_REJECTION_DISPOSITIONS_REQUIRING_REASON: Final[frozenset[str]] = (
+    _REJECTION_DISPOSITIONS | frozenset({"RETEST_WITH_NEW_COST_MODEL"})
+)
+
+CANDIDATE_ROLES: Final[tuple[str, ...]] = (
+    "UNSCOPED",
+    "RESEARCH",
+    "CHALLENGER",
+    "SHADOW",
+    "TESTNET",
+)
+COMPARISON_STATUSES: Final[tuple[str, ...]] = (
+    "NOT_COMPARED",
+    "INCOMPARABLE",
+    "DEFERRED",
+)
+ARTIFACT_KINDS: Final[tuple[str, ...]] = (
+    ARTIFACT_KIND_REPO_RELATIVE,
+    ARTIFACT_KIND_STORE_RELATIVE,
+)
+
+_CREATED_AT_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$")
+_HYPOTHESIS_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_STRATEGY_FAMILY_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_UNAVAILABLE_TOKENS = frozenset(
+    {
+        "",
+        "unknown",
+        "unavailable",
+        "n/a",
+        "na",
+        "none",
+        "null",
+        "implicit",
+        "default",
+    }
+)
+_CORE_LOGIC_DIGEST_FIELDS: Final[tuple[str, ...]] = (
+    "trading_decision_core_digest",
+    "market_context_contract_digest",
+    "bull_bear_logic_digest",
+    "state_switch_logic_digest",
+    "survival_logic_digest",
+    "suitability_logic_digest",
+    "double_play_logic_digest",
+    "entry_position_exit_logic_digest",
+)
+_IDENTITY_REF_BINDINGS: Final[tuple[tuple[str, str], ...]] = (
+    ("dataset_ref", "dataset_digest"),
+    ("cost_model_ref", "cost_model_digest"),
+    ("risk_policy_ref", "risk_policy_digest"),
+    ("portfolio_ref", "portfolio_digest"),
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ExperimentMemoryValidationError(ValueError):
+    """Fail-closed Canonical Experiment Memory v1 validation error."""
+
+
+class ExperimentRecordConflictError(ExperimentMemoryValidationError):
+    """Same experiment_id with divergent canonical historical content."""
+
+
+@dataclass(frozen=True)
+class ArtifactReferenceV1:
+    kind: str
+    ref: str
+    digest: str
+    media_type: str | None = None
+
+
+@dataclass(frozen=True)
+class LineageReferenceV1:
+    kind: str
+    parent_experiment: str | None
+    ancestors: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class CanonicalExperimentMemoryRecordRequestV1:
+    experiment_identity: Mapping[str, Any]
+    hypothesis_id: str
+    hypothesis_fingerprint: str
+    parent_experiment: str | None
+    strategy_family: str
+    candidate_role: str
+    dataset_ref: Mapping[str, Any]
+    cost_model_ref: Mapping[str, Any]
+    risk_policy_ref: Mapping[str, Any]
+    portfolio_ref: Mapping[str, Any]
+    metrics: Mapping[str, Any]
+    robustness_results: Mapping[str, Any]
+    regime_results: Mapping[str, Any]
+    comparison_status: str
+    disposition: str
+    rejection_reason: str | None
+    created_at: str
+    artifacts: Sequence[Mapping[str, Any]]
+    experiment_id: str | None = None
+    lineage_ancestors: Sequence[str] | tuple[str, ...] | None = None
+    supersedes_experiment_id: str | None = None
+
+
+def derive_experiment_id_v1(identity_digest: str) -> str:
+    digest = _require_sha256("identity_digest", identity_digest)
+    envelope = {
+        "digest_algorithm": DIGEST_ALGORITHM,
+        "digest_domain": f"{MEMORY_DOMAIN}.experiment_id",
+        "payload": {"identity_digest": digest},
+        "schema_version": SCHEMA_VERSION,
+    }
+    return compute_content_sha256(envelope)
+
+
+def build_canonical_experiment_memory_record_v1(
+    request: CanonicalExperimentMemoryRecordRequestV1,
+) -> Mapping[str, Any]:
+    identity = _require_identity(request.experiment_identity)
+    experiment_id = derive_experiment_id_v1(str(identity["identity_digest"]))
+    if request.experiment_id is not None:
+        provided = _require_sha256("experiment_id", request.experiment_id)
+        if provided != experiment_id:
+            raise ExperimentMemoryValidationError(
+                "experiment_id is not bound to the Canonical Experiment Identity digest"
+            )
+    created_at = _require_created_at(request.created_at)
+    lineage = _lineage_block(
+        experiment_id=experiment_id,
+        parent_experiment=request.parent_experiment,
+        ancestors=request.lineage_ancestors,
+    )
+    artifacts = _canonicalize_artifacts(request.artifacts)
+    record = {
+        "artifacts": artifacts,
+        "candidate_role": _require_enum("candidate_role", request.candidate_role, CANDIDATE_ROLES),
+        "canonical_trading_decision_core_bound": True,
+        "comparison_status": _require_enum(
+            "comparison_status", request.comparison_status, COMPARISON_STATUSES
+        ),
+        "completeness": RECORD_COMPLETENESS_COMPLETE,
+        "cost_model_ref": _bound_ref("cost_model_ref", request.cost_model_ref, identity),
+        "created_at": created_at,
+        "dataset_ref": _bound_ref("dataset_ref", request.dataset_ref, identity),
+        "digest_algorithm": DIGEST_ALGORITHM,
+        "disposition": _require_disposition(request.disposition),
+        "experiment_id": experiment_id,
+        "experiment_identity": identity,
+        "experiment_memory_can_mutate_live_config": EXPERIMENT_MEMORY_CAN_MUTATE_LIVE_CONFIG,
+        "experiment_memory_can_promote": EXPERIMENT_MEMORY_CAN_PROMOTE,
+        "experiment_memory_has_runtime_authority": EXPERIMENT_MEMORY_HAS_RUNTIME_AUTHORITY,
+        "hypothesis_fingerprint": _require_sha256(
+            "hypothesis_fingerprint", request.hypothesis_fingerprint
+        ),
+        "hypothesis_id": _require_token("hypothesis_id", request.hypothesis_id, _HYPOTHESIS_ID_RE),
+        "lineage": lineage,
+        "memory_domain": MEMORY_DOMAIN,
+        "metrics": _canonicalize_numeric_tree("metrics", request.metrics),
+        "parent_experiment": lineage["parent_experiment"],
+        "portfolio_ref": _bound_ref("portfolio_ref", request.portfolio_ref, identity),
+        "record_schema_version": SCHEMA_VERSION,
+        "regime_results": _canonicalize_numeric_tree("regime_results", request.regime_results),
+        "rejection_reason": _require_rejection_reason(
+            request.disposition, request.rejection_reason
+        ),
+        "risk_policy_ref": _bound_ref("risk_policy_ref", request.risk_policy_ref, identity),
+        "robustness_results": _canonicalize_numeric_tree(
+            "robustness_results", request.robustness_results
+        ),
+        "runtime_authority_impact": RUNTIME_AUTHORITY_IMPACT,
+        "strategy_family": _require_token(
+            "strategy_family", request.strategy_family, _STRATEGY_FAMILY_RE
+        ),
+        "supersedes_experiment_id": _optional_experiment_id(
+            "supersedes_experiment_id",
+            request.supersedes_experiment_id,
+            experiment_id,
+        ),
+    }
+    record["integrity"] = {
+        "content_sha256": compute_content_sha256(
+            {key: value for key, value in record.items() if key != "integrity"}
+        )
+    }
+    validate_canonical_experiment_memory_record_v1(record)
+    frozen = _freeze(record)
+    _LOGGER.info(
+        "canonical_experiment_memory_v1 built experiment_id=%s identity_digest=%s disposition=%s runtime_authority=%s",
+        record["experiment_id"],
+        identity["identity_digest"],
+        record["disposition"],
+        record["experiment_memory_has_runtime_authority"],
+    )
+    return frozen
+
+
+def validate_canonical_experiment_memory_record_v1(record: Mapping[str, Any]) -> None:
+    if not isinstance(record, Mapping):
+        raise ExperimentMemoryValidationError("memory record must be a mapping")
+    record = _plain_mapping(record)
+    if record.get("record_schema_version") != SCHEMA_VERSION:
+        raise ExperimentMemoryValidationError("record_schema_version mismatch")
+    if record.get("memory_domain") != MEMORY_DOMAIN:
+        raise ExperimentMemoryValidationError("memory_domain mismatch")
+    if record.get("completeness") != RECORD_COMPLETENESS_COMPLETE:
+        raise ExperimentMemoryValidationError("non-COMPLETE memory records are forbidden")
+    if record.get("digest_algorithm") != DIGEST_ALGORITHM:
+        raise ExperimentMemoryValidationError("digest_algorithm mismatch")
+    if record.get("experiment_memory_has_runtime_authority") is not False:
+        raise ExperimentMemoryValidationError(
+            "experiment_memory_has_runtime_authority must be false"
+        )
+    if record.get("experiment_memory_can_mutate_live_config") is not False:
+        raise ExperimentMemoryValidationError(
+            "experiment_memory_can_mutate_live_config must be false"
+        )
+    if record.get("experiment_memory_can_promote") is not False:
+        raise ExperimentMemoryValidationError("experiment_memory_can_promote must be false")
+    if record.get("runtime_authority_impact") != RUNTIME_AUTHORITY_IMPACT:
+        raise ExperimentMemoryValidationError("runtime_authority_impact must be NONE")
+    if record.get("canonical_trading_decision_core_bound") is not True:
+        raise ExperimentMemoryValidationError("canonical_trading_decision_core_bound must be true")
+
+    identity = _require_identity(record.get("experiment_identity"))
+    experiment_id = _require_sha256("experiment_id", record.get("experiment_id"))
+    expected_id = derive_experiment_id_v1(str(identity["identity_digest"]))
+    if experiment_id != expected_id:
+        raise ExperimentMemoryValidationError(
+            "experiment_id is not bound to the Canonical Experiment Identity digest"
+        )
+    _require_created_at(record.get("created_at"))
+    _require_enum("candidate_role", record.get("candidate_role"), CANDIDATE_ROLES)
+    _require_enum("comparison_status", record.get("comparison_status"), COMPARISON_STATUSES)
+    disposition = _require_disposition(record.get("disposition"))
+    _require_rejection_reason(disposition, record.get("rejection_reason"))
+    _require_token("hypothesis_id", record.get("hypothesis_id"), _HYPOTHESIS_ID_RE)
+    _require_sha256("hypothesis_fingerprint", record.get("hypothesis_fingerprint"))
+    _require_token("strategy_family", record.get("strategy_family"), _STRATEGY_FAMILY_RE)
+    _optional_experiment_id(
+        "supersedes_experiment_id",
+        record.get("supersedes_experiment_id"),
+        experiment_id,
+    )
+
+    lineage = record.get("lineage")
+    if not isinstance(lineage, Mapping):
+        raise ExperimentMemoryValidationError("lineage must be a mapping")
+    expected_lineage = _lineage_block(
+        experiment_id=experiment_id,
+        parent_experiment=lineage.get("parent_experiment"),
+        ancestors=lineage.get("ancestors"),
+    )
+    if _plain_mapping(lineage) != expected_lineage:
+        raise ExperimentMemoryValidationError("lineage is inconsistent")
+    if record.get("parent_experiment") != expected_lineage["parent_experiment"]:
+        raise ExperimentMemoryValidationError("parent_experiment does not match lineage")
+
+    for ref_field, digest_field in _IDENTITY_REF_BINDINGS:
+        expected_ref = _bound_ref(ref_field, record.get(ref_field), identity)
+        if _plain_mapping(record.get(ref_field)) != expected_ref:
+            raise ExperimentMemoryValidationError(f"{ref_field} is not identity-digest-bound")
+
+    _canonicalize_numeric_tree("metrics", record.get("metrics"))
+    _canonicalize_numeric_tree("robustness_results", record.get("robustness_results"))
+    _canonicalize_numeric_tree("regime_results", record.get("regime_results"))
+    _canonicalize_artifacts(record.get("artifacts"))
+
+    for field_name in _CORE_LOGIC_DIGEST_FIELDS:
+        _require_sha256(field_name, identity.get(field_name))
+
+    expected_integrity = compute_content_sha256(
+        {key: value for key, value in record.items() if key != "integrity"}
+    )
+    integrity = record.get("integrity")
+    if not isinstance(integrity, Mapping) or integrity.get("content_sha256") != expected_integrity:
+        raise ExperimentMemoryValidationError("integrity.content_sha256 mismatch")
+
+
+def canonical_record_payload(record: Mapping[str, Any]) -> dict[str, Any]:
+    return _plain_mapping(record)
+
+
+def freeze_canonical_experiment_memory_record_v1(record: Mapping[str, Any]) -> Mapping[str, Any]:
+    validate_canonical_experiment_memory_record_v1(record)
+    return _freeze(canonical_record_payload(record))
+
+
+def _require_identity(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ExperimentMemoryValidationError("experiment_identity present and valid is required")
+    identity = _plain_mapping(value)
+    try:
+        validate_canonical_experiment_identity_v1(identity)
+    except CanonicalExperimentIdentityError as exc:
+        raise ExperimentMemoryValidationError(
+            f"experiment_identity is not a valid Phase 1 Canonical Experiment Identity: {exc}"
+        ) from exc
+    return identity
+
+
+def _require_sha256(field_name: str, value: Any) -> str:
+    if not isinstance(value, str) or not is_valid_sha256_hex(value):
+        raise ExperimentMemoryValidationError(f"{field_name} must be a lowercase sha256 hex digest")
+    return value
+
+
+def _require_created_at(value: Any) -> str:
+    if not isinstance(value, str) or not _CREATED_AT_RE.fullmatch(value):
+        raise ExperimentMemoryValidationError(
+            "created_at must be an explicit UTC timestamp ending with Z"
+        )
+    return value
+
+
+def _require_enum(field_name: str, value: Any, allowed: Sequence[str]) -> str:
+    if not isinstance(value, str) or value not in allowed:
+        raise ExperimentMemoryValidationError(f"{field_name} is not a canonical value")
+    return value
+
+
+def _require_disposition(value: Any) -> str:
+    disposition = _require_enum("disposition", value, CANONICAL_DISPOSITIONS)
+    lowered = disposition.lower()
+    if "live" in lowered or "authoriz" in lowered:
+        raise ExperimentMemoryValidationError("disposition cannot authorize live")
+    return disposition
+
+
+def _require_token(field_name: str, value: Any, pattern: re.Pattern[str]) -> str:
+    if not isinstance(value, str) or not pattern.fullmatch(value):
+        raise ExperimentMemoryValidationError(f"{field_name} is missing or malformed")
+    if value.strip().lower() in _UNAVAILABLE_TOKENS:
+        raise ExperimentMemoryValidationError(
+            f"{field_name} cannot use implicit unavailable tokens"
+        )
+    return value
+
+
+def _require_rejection_reason(disposition: Any, reason: Any) -> str | None:
+    disposition_text = str(disposition or "")
+    if disposition_text in _REJECTION_DISPOSITIONS_REQUIRING_REASON:
+        if not isinstance(reason, str) or not reason.strip():
+            raise ExperimentMemoryValidationError(
+                "rejection_reason is required for rejected or retest dispositions"
+            )
+        if reason.strip().lower() in _UNAVAILABLE_TOKENS:
+            raise ExperimentMemoryValidationError(
+                "rejection_reason cannot use implicit unavailable tokens"
+            )
+        return reason.strip()
+    if reason is None:
+        return None
+    if not isinstance(reason, str) or not reason.strip():
+        raise ExperimentMemoryValidationError("rejection_reason must be a non-empty string or null")
+    return reason.strip()
+
+
+def _optional_experiment_id(field_name: str, value: Any, experiment_id: str) -> str | None:
+    if value is None:
+        return None
+    digest = _require_sha256(field_name, value)
+    if digest == experiment_id:
+        raise ExperimentMemoryValidationError(f"{field_name} cannot equal experiment_id")
+    return digest
+
+
+def _lineage_block(
+    *,
+    experiment_id: str,
+    parent_experiment: Any,
+    ancestors: Any,
+) -> dict[str, Any]:
+    if parent_experiment is None:
+        if ancestors not in (None, (), []):
+            raise ExperimentMemoryValidationError("ROOT lineage cannot declare ancestors")
+        return {
+            "ancestors": [],
+            "kind": LINEAGE_KIND_ROOT,
+            "parent_experiment": None,
+        }
+    parent_id = _require_sha256("parent_experiment", parent_experiment)
+    if parent_id == experiment_id:
+        raise ExperimentMemoryValidationError("self-parent lineage is forbidden")
+    ancestor_ids: list[str]
+    if ancestors is None:
+        ancestor_ids = [parent_id]
+    else:
+        if not isinstance(ancestors, Sequence) or isinstance(ancestors, (str, bytes)):
+            raise ExperimentMemoryValidationError("lineage.ancestors must be a sequence")
+        ancestor_ids = [_require_sha256("lineage.ancestors[]", item) for item in ancestors]
+        if not ancestor_ids or ancestor_ids[0] != parent_id:
+            raise ExperimentMemoryValidationError(
+                "lineage.ancestors must start with parent_experiment"
+            )
+    if experiment_id in ancestor_ids:
+        raise ExperimentMemoryValidationError("direct cyclic lineage is forbidden")
+    if len(set(ancestor_ids)) != len(ancestor_ids):
+        raise ExperimentMemoryValidationError("lineage.ancestors must be unique")
+    return {
+        "ancestors": ancestor_ids,
+        "kind": LINEAGE_KIND_PARENT_BOUND,
+        "parent_experiment": parent_id,
+    }
+
+
+def _bound_ref(field_name: str, value: Any, identity: Mapping[str, Any]) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ExperimentMemoryValidationError(f"{field_name} must be a mapping")
+    kind = value.get("kind")
+    if kind != REF_KIND_IDENTITY_DIGEST_BOUND:
+        raise ExperimentMemoryValidationError(f"{field_name}.kind must be IDENTITY_DIGEST_BOUND")
+    digest_field = dict(_IDENTITY_REF_BINDINGS)[field_name]
+    expected_digest = _require_sha256(digest_field, identity.get(digest_field))
+    provided = _require_sha256(f"{field_name}.digest", value.get("digest"))
+    if provided != expected_digest:
+        raise ExperimentMemoryValidationError(
+            f"{field_name}.digest must match experiment_identity.{digest_field}"
+        )
+    extra_keys = set(str(key) for key in value.keys()) - {"kind", "digest"}
+    if extra_keys:
+        raise ExperimentMemoryValidationError(
+            f"{field_name} has unsupported keys: {sorted(extra_keys)}"
+        )
+    return {"digest": expected_digest, "kind": REF_KIND_IDENTITY_DIGEST_BOUND}
+
+
+def _canonicalize_numeric_tree(field_name: str, value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ExperimentMemoryValidationError(f"{field_name} must be a mapping")
+    try:
+        return canonicalize_mapping(value, path=f"$.{field_name}")
+    except CanonicalExperimentIdentityError as exc:
+        message = str(exc)
+        if "non-finite float" in message:
+            raise ExperimentMemoryValidationError(
+                f"non-finite numeric values are forbidden in {field_name}"
+            ) from exc
+        raise ExperimentMemoryValidationError(
+            f"{field_name} is not canonically serializable: {exc}"
+        ) from exc
+
+
+def _canonicalize_artifacts(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise ExperimentMemoryValidationError("artifacts must be a sequence")
+    artifacts: list[dict[str, Any]] = []
+    seen_refs: set[tuple[str, str]] = set()
+    for index, item in enumerate(value):
+        if not isinstance(item, Mapping):
+            raise ExperimentMemoryValidationError(f"artifacts[{index}] must be a mapping")
+        kind = _require_enum(f"artifacts[{index}].kind", item.get("kind"), ARTIFACT_KINDS)
+        ref = _require_relative_artifact_ref(f"artifacts[{index}].ref", item.get("ref"))
+        digest = _require_sha256(f"artifacts[{index}].digest", item.get("digest"))
+        media_type = item.get("media_type")
+        if media_type is not None:
+            if not isinstance(media_type, str) or not media_type.strip() or "/" not in media_type:
+                raise ExperimentMemoryValidationError(
+                    f"artifacts[{index}].media_type must be a MIME type or null"
+                )
+            media_type = media_type.strip()
+        extra_keys = set(str(key) for key in item.keys()) - {"kind", "ref", "digest", "media_type"}
+        if extra_keys:
+            raise ExperimentMemoryValidationError(
+                f"artifacts[{index}] has unsupported keys: {sorted(extra_keys)}"
+            )
+        key = (kind, ref)
+        if key in seen_refs:
+            raise ExperimentMemoryValidationError("duplicate artifact refs are forbidden")
+        seen_refs.add(key)
+        artifact = {"digest": digest, "kind": kind, "ref": ref}
+        if media_type is not None:
+            artifact["media_type"] = media_type
+        artifacts.append(artifact)
+    return artifacts
+
+
+def _require_relative_artifact_ref(field_name: str, value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ExperimentMemoryValidationError(f"{field_name} must be a non-empty relative ref")
+    ref = value.strip()
+    if ref.strip().lower() in _UNAVAILABLE_TOKENS:
+        raise ExperimentMemoryValidationError(
+            f"{field_name} cannot use implicit unavailable tokens"
+        )
+    if "\x00" in ref:
+        raise ExperimentMemoryValidationError(f"{field_name} contains a NUL byte")
+    if ref.startswith("/") or ref.startswith("\\") or ref.startswith("~"):
+        raise ExperimentMemoryValidationError(f"{field_name} absolute or home paths are forbidden")
+    if ":" in ref.split("/", 1)[0] and len(ref.split("/", 1)[0]) <= 2:
+        raise ExperimentMemoryValidationError(f"{field_name} drive-qualified paths are forbidden")
+    parts = ref.replace("\\", "/").split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ExperimentMemoryValidationError(
+            f"{field_name} path traversal or empty segments are forbidden"
+        )
+    if "\\" in ref:
+        raise ExperimentMemoryValidationError(
+            f"{field_name} must use store-/repo-relative POSIX paths"
+        )
+    return ref
+
+
+def _freeze(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({str(key): _freeze(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return [_freeze(item) for item in value]
+    return value
+
+
+def _plain_mapping(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _plain_mapping(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_plain_mapping(item) for item in value]
+    return value
+
+
+__all__ = [
+    "ARTIFACT_KIND_REPO_RELATIVE",
+    "ARTIFACT_KIND_STORE_RELATIVE",
+    "ArtifactReferenceV1",
+    "CANONICAL_DISPOSITIONS",
+    "CANDIDATE_ROLES",
+    "COMPARISON_STATUSES",
+    "CanonicalExperimentMemoryRecordRequestV1",
+    "DIGEST_ALGORITHM",
+    "EXPERIMENT_MEMORY_CAN_MUTATE_LIVE_CONFIG",
+    "EXPERIMENT_MEMORY_CAN_PROMOTE",
+    "EXPERIMENT_MEMORY_HAS_RUNTIME_AUTHORITY",
+    "ExperimentMemoryValidationError",
+    "ExperimentRecordConflictError",
+    "LINEAGE_KIND_PARENT_BOUND",
+    "LINEAGE_KIND_ROOT",
+    "LineageReferenceV1",
+    "MEMORY_DOMAIN",
+    "RECORD_COMPLETENESS_COMPLETE",
+    "REF_KIND_IDENTITY_DIGEST_BOUND",
+    "RUNTIME_AUTHORITY_IMPACT",
+    "SCHEMA_VERSION",
+    "build_canonical_experiment_memory_record_v1",
+    "canonical_record_payload",
+    "derive_experiment_id_v1",
+    "freeze_canonical_experiment_memory_record_v1",
+    "validate_canonical_experiment_memory_record_v1",
+]

--- a/tests/experiments/test_canonical_experiment_memory_v1.py
+++ b/tests/experiments/test_canonical_experiment_memory_v1.py
@@ -1,0 +1,450 @@
+"""Phase 2 Immutable Experiment Memory v1 contract tests."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import inspect
+import os
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping
+
+import pytest
+
+from src.experiments.canonical_experiment_identity_v1 import (
+    CanonicalExperimentIdentityRequestV1,
+    WORKING_TREE_CLEAN,
+    build_canonical_experiment_identity_v1,
+)
+from src.experiments.canonical_experiment_memory_store_v1 import (
+    RECORD_FILENAME,
+    CanonicalExperimentMemoryStoreV1,
+)
+from src.experiments.canonical_experiment_memory_v1 import (
+    EXPERIMENT_MEMORY_CAN_MUTATE_LIVE_CONFIG,
+    EXPERIMENT_MEMORY_CAN_PROMOTE,
+    EXPERIMENT_MEMORY_HAS_RUNTIME_AUTHORITY,
+    CanonicalExperimentMemoryRecordRequestV1,
+    ExperimentMemoryValidationError,
+    ExperimentRecordConflictError,
+    build_canonical_experiment_memory_record_v1,
+    canonical_record_payload,
+    derive_experiment_id_v1,
+    validate_canonical_experiment_memory_record_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import deterministic_json_dumps
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MEMORY_MODULE_PATH = REPO_ROOT / "src" / "experiments" / "canonical_experiment_memory_v1.py"
+STORE_MODULE_PATH = REPO_ROOT / "src" / "experiments" / "canonical_experiment_memory_store_v1.py"
+_GIT_SHA = "ecbe5b7b4f8a71d3a81443a65949fcce6a5de350"
+_CORE_DIGEST_FIELDS = (
+    "trading_decision_core_digest",
+    "market_context_contract_digest",
+    "bull_bear_logic_digest",
+    "state_switch_logic_digest",
+    "survival_logic_digest",
+    "suitability_logic_digest",
+    "double_play_logic_digest",
+    "entry_position_exit_logic_digest",
+)
+
+
+def _digest(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _identity(**overrides: Any) -> Mapping[str, Any]:
+    payload: dict[str, Any] = {
+        "git_sha": _GIT_SHA,
+        "working_tree_status": WORKING_TREE_CLEAN,
+        "strategy_identity": "ma_crossover.v1",
+        "strategy_params": {"slow": 50, "fast": 10},
+        "dataset_digest": _digest("dataset"),
+        "feature_pipeline_digest": _digest("features"),
+        "fee_model_digest": _digest("fee"),
+        "slippage_model_digest": _digest("slippage"),
+        "funding_model_digest": _digest("funding"),
+        "risk_policy_digest": _digest("risk"),
+        "portfolio_digest": _digest("portfolio"),
+        "split_policy_digest": _digest("split"),
+        "market_context_contract_digest": _digest("market-context"),
+        "bull_bear_logic_digest": _digest("bull-bear"),
+        "state_switch_logic_digest": _digest("state-switch"),
+        "survival_logic_digest": _digest("survival"),
+        "suitability_logic_digest": _digest("suitability"),
+        "double_play_logic_digest": _digest("double-play"),
+        "entry_position_exit_logic_digest": _digest("entry-position-exit"),
+        "seed": 7,
+        "environment": {
+            "python_version": "3.11.15",
+            "python_implementation": "CPython",
+        },
+        "parent_lineage_ref": None,
+        "dirty_paths_digest": None,
+    }
+    payload.update(overrides)
+    return build_canonical_experiment_identity_v1(CanonicalExperimentIdentityRequestV1(**payload))
+
+
+def _bound_ref(digest: str) -> dict[str, str]:
+    return {"digest": digest, "kind": "IDENTITY_DIGEST_BOUND"}
+
+
+def _request(
+    identity: Mapping[str, Any] | None = None, **overrides: Any
+) -> CanonicalExperimentMemoryRecordRequestV1:
+    identity = identity or _identity()
+    payload: dict[str, Any] = {
+        "experiment_identity": identity,
+        "hypothesis_id": "hyp.ma-crossover.v1",
+        "hypothesis_fingerprint": _digest("hypothesis"),
+        "parent_experiment": None,
+        "strategy_family": "ma_crossover",
+        "candidate_role": "RESEARCH",
+        "dataset_ref": _bound_ref(str(identity["dataset_digest"])),
+        "cost_model_ref": _bound_ref(str(identity["cost_model_digest"])),
+        "risk_policy_ref": _bound_ref(str(identity["risk_policy_digest"])),
+        "portfolio_ref": _bound_ref(str(identity["portfolio_digest"])),
+        "metrics": {"sharpe": 1.25, "max_drawdown": -0.12},
+        "robustness_results": {"walk_forward": {"passed": True, "folds": 4}},
+        "regime_results": {"high_vol": {"sharpe": 0.4}},
+        "comparison_status": "NOT_COMPARED",
+        "disposition": "RESEARCH_ONLY",
+        "rejection_reason": None,
+        "created_at": "2026-08-17T17:00:00Z",
+        "artifacts": [
+            {
+                "kind": "REPO_RELATIVE",
+                "ref": "docs/ops/specs/CANONICAL_EXPERIMENT_IDENTITY_V1.md",
+                "digest": _digest("artifact"),
+                "media_type": "text/markdown",
+            }
+        ],
+        "experiment_id": None,
+        "lineage_ancestors": None,
+        "supersedes_experiment_id": None,
+    }
+    payload.update(overrides)
+    return CanonicalExperimentMemoryRecordRequestV1(**payload)
+
+
+def test_valid_record_accepted_and_identity_round_trips() -> None:
+    identity = _identity()
+    record = build_canonical_experiment_memory_record_v1(_request(identity))
+    assert record["completeness"] == "COMPLETE"
+    assert record["experiment_id"] == derive_experiment_id_v1(str(identity["identity_digest"]))
+    assert canonical_record_payload(record["experiment_identity"]) == canonical_record_payload(
+        identity
+    )
+    for field_name in _CORE_DIGEST_FIELDS:
+        assert record["experiment_identity"][field_name] == identity[field_name]
+        assert isinstance(record["experiment_identity"][field_name], str)
+        assert len(record["experiment_identity"][field_name]) == 64
+    assert record["canonical_trading_decision_core_bound"] is True
+    assert record["experiment_memory_has_runtime_authority"] is False
+    validate_canonical_experiment_memory_record_v1(record)
+
+
+def test_required_field_missing_rejected() -> None:
+    identity = _identity()
+    with pytest.raises(ExperimentMemoryValidationError):
+        build_canonical_experiment_memory_record_v1(_request(identity, created_at=None))
+    with pytest.raises(ExperimentMemoryValidationError):
+        build_canonical_experiment_memory_record_v1(_request(identity, hypothesis_id=""))
+    with pytest.raises(ExperimentMemoryValidationError):
+        build_canonical_experiment_memory_record_v1(
+            _request(
+                identity, dataset_ref={"kind": "IDENTITY_DIGEST_BOUND", "digest": _digest("other")}
+            )
+        )
+
+
+def test_phase_1_identity_and_core_digests_survive_persistence(tmp_path: Path) -> None:
+    identity = _identity()
+    record = build_canonical_experiment_memory_record_v1(_request(identity))
+    store = CanonicalExperimentMemoryStoreV1(tmp_path / "memory")
+    stored = store.append(record)
+    loaded = store.get(str(record["experiment_id"]))
+    assert canonical_record_payload(loaded["experiment_identity"]) == canonical_record_payload(
+        identity
+    )
+    for field_name in _CORE_DIGEST_FIELDS:
+        assert loaded["experiment_identity"][field_name] == identity[field_name]
+    assert canonical_record_payload(stored) == canonical_record_payload(record)
+
+
+def test_first_append_success_identical_replay_idempotent(tmp_path: Path) -> None:
+    record = build_canonical_experiment_memory_record_v1(_request())
+    store = CanonicalExperimentMemoryStoreV1(tmp_path / "memory")
+    first = store.append(record)
+    dest = tmp_path / "memory" / str(record["experiment_id"]) / RECORD_FILENAME
+    original = dest.read_bytes()
+    second = store.append(record)
+    assert dest.read_bytes() == original
+    assert canonical_record_payload(first) == canonical_record_payload(second)
+    assert store.exists(str(record["experiment_id"])) is True
+
+
+def test_same_id_changed_metrics_disposition_lineage_rejected(tmp_path: Path) -> None:
+    identity = _identity()
+    record = build_canonical_experiment_memory_record_v1(_request(identity))
+    store = CanonicalExperimentMemoryStoreV1(tmp_path / "memory")
+    store.append(record)
+
+    metrics_changed = build_canonical_experiment_memory_record_v1(
+        _request(identity, metrics={"sharpe": 9.99})
+    )
+    with pytest.raises(ExperimentRecordConflictError, match="divergent"):
+        store.append(metrics_changed)
+
+    disposition_changed = build_canonical_experiment_memory_record_v1(
+        _request(
+            identity,
+            disposition="REJECTED_OVERFIT",
+            rejection_reason="holdout collapse",
+        )
+    )
+    with pytest.raises(ExperimentRecordConflictError, match="divergent"):
+        store.append(disposition_changed)
+
+    parent_identity = _identity(strategy_identity="parent.v1")
+    parent_record = build_canonical_experiment_memory_record_v1(
+        _request(parent_identity, hypothesis_id="hyp.parent")
+    )
+    lineage_changed = build_canonical_experiment_memory_record_v1(
+        _request(identity, parent_experiment=str(parent_record["experiment_id"]))
+    )
+    with pytest.raises(ExperimentRecordConflictError, match="divergent"):
+        store.append(lineage_changed)
+
+
+def test_parent_lineage_round_trip_and_self_parent_rejected(tmp_path: Path) -> None:
+    parent_identity = _identity(strategy_identity="parent.v1")
+    parent = build_canonical_experiment_memory_record_v1(
+        _request(parent_identity, hypothesis_id="hyp.parent")
+    )
+    child_identity = _identity(
+        strategy_identity="child.v1", parent_lineage_ref=str(parent["experiment_id"])
+    )
+    child = build_canonical_experiment_memory_record_v1(
+        _request(
+            child_identity,
+            hypothesis_id="hyp.child",
+            parent_experiment=str(parent["experiment_id"]),
+        )
+    )
+    assert child["parent_experiment"] == parent["experiment_id"]
+    assert child["lineage"]["kind"] == "PARENT_BOUND"
+    assert child["lineage"]["ancestors"] == [parent["experiment_id"]]
+
+    store = CanonicalExperimentMemoryStoreV1(tmp_path / "memory")
+    store.append(parent)
+    stored_child = store.append(child)
+    loaded = store.get(str(child["experiment_id"]))
+    assert loaded["parent_experiment"] == parent["experiment_id"]
+    assert loaded["lineage"] == stored_child["lineage"]
+
+    with pytest.raises(ExperimentMemoryValidationError, match="self-parent"):
+        build_canonical_experiment_memory_record_v1(
+            _request(
+                child_identity,
+                experiment_id=str(child["experiment_id"]),
+                parent_experiment=str(child["experiment_id"]),
+            )
+        )
+
+
+def test_deterministic_serialization_and_artifact_refs(tmp_path: Path) -> None:
+    record = build_canonical_experiment_memory_record_v1(_request())
+    first = deterministic_json_dumps(canonical_record_payload(record))
+    second = deterministic_json_dumps(
+        canonical_record_payload(build_canonical_experiment_memory_record_v1(_request()))
+    )
+    assert first == second
+    store = CanonicalExperimentMemoryStoreV1(tmp_path / "memory")
+    store.append(record)
+    loaded = store.get(str(record["experiment_id"]))
+    assert loaded["artifacts"][0]["ref"] == "docs/ops/specs/CANONICAL_EXPERIMENT_IDENTITY_V1.md"
+    assert loaded["artifacts"][0]["kind"] == "REPO_RELATIVE"
+    assert "media_type" in loaded["artifacts"][0]
+
+
+def test_atomic_write_failure_leaves_no_partial_record(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    record = build_canonical_experiment_memory_record_v1(_request())
+    store = CanonicalExperimentMemoryStoreV1(tmp_path / "memory")
+
+    def _boom(src: str, dst: str) -> None:
+        raise OSError("simulated link failure")
+
+    monkeypatch.setattr(os, "link", _boom)
+    with pytest.raises(OSError, match="simulated link failure"):
+        store.append(record)
+    dest_dir = tmp_path / "memory" / str(record["experiment_id"])
+    leftover_records = list(dest_dir.glob(RECORD_FILENAME)) if dest_dir.exists() else []
+    assert leftover_records == []
+    assert store.exists(str(record["experiment_id"])) is False
+
+
+def test_corrupt_record_fails_closed(tmp_path: Path) -> None:
+    record = build_canonical_experiment_memory_record_v1(_request())
+    store = CanonicalExperimentMemoryStoreV1(tmp_path / "memory")
+    store.append(record)
+    dest = tmp_path / "memory" / str(record["experiment_id"]) / RECORD_FILENAME
+    dest.write_text("{not-json", encoding="utf-8")
+    with pytest.raises(ExperimentMemoryValidationError, match="corrupt"):
+        store.get(str(record["experiment_id"]))
+    with pytest.raises(ExperimentMemoryValidationError, match="corrupt"):
+        store.exists(str(record["experiment_id"]))
+
+
+@pytest.mark.parametrize("bad_value", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_metrics_rejected(bad_value: float) -> None:
+    with pytest.raises(ExperimentMemoryValidationError, match="non-finite"):
+        build_canonical_experiment_memory_record_v1(_request(metrics={"sharpe": bad_value}))
+    with pytest.raises(ExperimentMemoryValidationError, match="non-finite"):
+        build_canonical_experiment_memory_record_v1(
+            _request(robustness_results={"score": bad_value})
+        )
+
+
+def test_filesystem_traversal_and_malformed_ids_rejected(tmp_path: Path) -> None:
+    store = CanonicalExperimentMemoryStoreV1(tmp_path / "memory")
+    for bad_id in ("../etc/passwd", "/tmp/abs", "abcd", ".." * 32, r"..\\secret"):
+        with pytest.raises(ExperimentMemoryValidationError):
+            store.get(bad_id)
+        with pytest.raises(ExperimentMemoryValidationError):
+            store.exists(bad_id)
+    with pytest.raises(ExperimentMemoryValidationError, match="path traversal|relative ref"):
+        build_canonical_experiment_memory_record_v1(
+            _request(
+                artifacts=[
+                    {
+                        "kind": "REPO_RELATIVE",
+                        "ref": "../secrets/id_rsa",
+                        "digest": _digest("oops"),
+                    }
+                ]
+            )
+        )
+    with pytest.raises(ExperimentMemoryValidationError, match="absolute"):
+        build_canonical_experiment_memory_record_v1(
+            _request(
+                artifacts=[
+                    {
+                        "kind": "STORE_RELATIVE",
+                        "ref": "/etc/passwd",
+                        "digest": _digest("oops"),
+                    }
+                ]
+            )
+        )
+
+
+def test_list_metadata_is_unsorted_ranking_free(tmp_path: Path) -> None:
+    store = CanonicalExperimentMemoryStoreV1(tmp_path / "memory")
+    first = build_canonical_experiment_memory_record_v1(
+        _request(_identity(seed=1), hypothesis_id="hyp.a")
+    )
+    second = build_canonical_experiment_memory_record_v1(
+        _request(_identity(seed=2), hypothesis_id="hyp.b")
+    )
+    store.append(second)
+    store.append(first)
+    rows = store.list_metadata()
+    assert [row["experiment_id"] for row in rows] == sorted(row["experiment_id"] for row in rows)
+    assert {row["hypothesis_id"] for row in rows} == {"hyp.a", "hyp.b"}
+    assert "sharpe" not in rows[0]
+    assert "rank" not in rows[0]
+
+
+def test_frozen_record_is_immutable() -> None:
+    record = build_canonical_experiment_memory_record_v1(_request())
+    assert isinstance(record, MappingProxyType)
+    with pytest.raises(TypeError):
+        record["disposition"] = "REJECTED_OVERFIT"  # type: ignore[index]
+
+
+def test_authority_boundary_no_runtime_or_promotion_paths() -> None:
+    for module_path in (MEMORY_MODULE_PATH, STORE_MODULE_PATH):
+        source = module_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module)
+        forbidden_imports = {
+            "src.core.peak_config",
+            "src.governance.promotion_loop.engine",
+            "src.execution",
+            "scripts.run_learning_apply_cycle",
+            "src.live",
+            "src.trading",
+            "src.trading.master_v2",
+            "src.risk",
+        }
+        assert forbidden_imports.isdisjoint(imported)
+        for token in (
+            "config/live_overrides",
+            "load_config_with_live_overrides",
+            "submit_order",
+            "confirm_token",
+            "LIVE_AUTHORIZED",
+            "TESTNET_AUTHORIZED",
+            "apply_proposals_to_live_overrides",
+            "write_live_config",
+        ):
+            assert token not in source
+    assert EXPERIMENT_MEMORY_HAS_RUNTIME_AUTHORITY is False
+    assert EXPERIMENT_MEMORY_CAN_MUTATE_LIVE_CONFIG is False
+    assert EXPERIMENT_MEMORY_CAN_PROMOTE is False
+    record = build_canonical_experiment_memory_record_v1(_request())
+    assert record["experiment_memory_has_runtime_authority"] is False
+    assert record["experiment_memory_can_mutate_live_config"] is False
+    assert record["experiment_memory_can_promote"] is False
+    assert "write_live_config" not in inspect.getsource(build_canonical_experiment_memory_record_v1)
+    assert "apply_proposals_to_live_overrides" not in inspect.getsource(
+        CanonicalExperimentMemoryStoreV1.append
+    )
+
+
+def test_rejected_disposition_requires_reason_and_does_not_authorize_live() -> None:
+    with pytest.raises(ExperimentMemoryValidationError, match="rejection_reason"):
+        build_canonical_experiment_memory_record_v1(
+            _request(disposition="REJECTED_TAIL_RISK", rejection_reason=None)
+        )
+    record = build_canonical_experiment_memory_record_v1(
+        _request(disposition="PROMOTION_EVIDENCE_READY", rejection_reason=None)
+    )
+    assert record["disposition"] == "PROMOTION_EVIDENCE_READY"
+    assert record["experiment_memory_has_runtime_authority"] is False
+    with pytest.raises(ExperimentMemoryValidationError):
+        build_canonical_experiment_memory_record_v1(_request(disposition="LIVE_AUTHORIZED"))
+
+
+def test_new_experiment_id_appends(tmp_path: Path) -> None:
+    store = CanonicalExperimentMemoryStoreV1(tmp_path / "memory")
+    first = store.append(build_canonical_experiment_memory_record_v1(_request(_identity(seed=1))))
+    second = store.append(build_canonical_experiment_memory_record_v1(_request(_identity(seed=2))))
+    assert first["experiment_id"] != second["experiment_id"]
+    assert len(store.list_metadata()) == 2
+
+
+def test_provided_experiment_id_must_match_identity_binding() -> None:
+    identity = _identity()
+    with pytest.raises(ExperimentMemoryValidationError, match="not bound"):
+        build_canonical_experiment_memory_record_v1(
+            _request(identity, experiment_id=_digest("unrelated"))
+        )
+
+
+def test_no_silent_cost_or_risk_defaults() -> None:
+    identity = dict(_identity())
+    identity["fee_model_digest"] = "0"
+    with pytest.raises(ExperimentMemoryValidationError, match="Canonical Experiment Identity"):
+        build_canonical_experiment_memory_record_v1(_request(identity))


### PR DESCRIPTION
## Summary
- Adds Phase 2 Immutable Experiment Memory v1 as an append-only, digest-verifiable research-evidence store.
- Reuses the Phase 1 Canonical Experiment Identity in full, including trading-decision-core digests; identical replay is idempotent and divergent duplicates fail closed.
- No runtime, live-config, promotion, order, funding, risk, or leverage authority. Disposition labels do not authorize live.

## Test plan
- [x] `tests/experiments/test_canonical_experiment_memory_v1.py` (record correctness, identity/core-digest round-trip, immutability, lineage, atomic write, NaN/Inf, path traversal, authority boundary)
- [x] Phase 1 identity + Package N identity + learning-loop bridge/emitter regression
- [x] PR_BOUNDED_FULL selector targets (`tests/ci/*` contracts + smoke)
- [x] `ruff format --check`, `ruff check`
- [x] Docs token policy + docs-reference-targets (pre-existing unrelated missing target on origin/main unchanged)


Made with [Cursor](https://cursor.com)