### PR TITLE
research: add canonical failure memory v1

### DIFF
--- a/docs/ops/specs/CANONICAL_FAILURE_MEMORY_V1.md
+++ b/docs/ops/specs/CANONICAL_FAILURE_MEMORY_V1.md
@@ -1,0 +1,96 @@
+# Canonical Failure Memory v1
+
+Contract for Peak_Trade Phase 3 Failure Memory.
+
+```text
+SCHEMA_VERSION=canonical_failure_memory_v1
+FAILURE_DOMAIN=peak_trade.canonical_failure_memory.v1
+FAILURE_MEMORY_HAS_RUNTIME_AUTHORITY=false
+FAILURE_MEMORY_CAN_MUTATE_LIVE_CONFIG=false
+FAILURE_MEMORY_CAN_PROMOTE=false
+FAILURE_MEMORY_AUTOMATIC_RESEARCH_BAN=false
+DUPLICATE_DETECTED_IS_NOT_AUTOMATIC_RESEARCH_BAN=true
+```
+
+Owners:
+
+- `src&#47;experiments&#47;canonical_failure_memory_v1.py` — schema, fingerprint, duplicate assessment
+- `src&#47;experiments&#47;canonical_failure_memory_store_v1.py` — append-only file persist and read
+
+Reuse, do not replace:
+
+- Phase 1 owner `src&#47;experiments&#47;canonical_experiment_identity_v1.py`
+- Phase 2 owner `src&#47;experiments&#47;canonical_experiment_memory_v1.py` (`REJECTED_*` dispositions and `experiment_id` derivation)
+
+## What is immutable
+
+After a record is successfully persisted, historical failure truth cannot change:
+
+- hypothesis_fingerprint
+- experiment_identity and core-logic digests
+- failure_class / failed_gate / rejection_reason
+- dataset_digest, regime, parameter_region
+- cost_sensitivity / instability_indicators
+- evidence_refs
+- created_at
+
+## What is append-only
+
+```text
+same failure_record_id + identical canonical content => idempotent accept
+same failure_record_id + divergent canonical content => FAIL_CLOSED
+new failure_record_id => append
+```
+
+`failure_record_id` is a content digest of the canonical observation. It is not a timestamp identity. The logical hypothesis key is `hypothesis_fingerprint`.
+
+A later observation of the same logical failure (different canonical content, including a different `created_at`) is a new occurrence record.
+
+## Duplicate detection
+
+`hypothesis_fingerprint` is derived from:
+
+- Phase 1 `identity_digest` (dataset, cost model, trading decision core, risk, portfolio, parent lineage)
+- `hypothesis_id`
+- `parameter_region`
+- `regime`
+- `robustness_policy_digest`
+
+Changing any of those inputs yields a different fingerprint, so a justified retest is representable.
+
+```text
+DUPLICATE_DETECTED != AUTOMATIC_RESEARCH_BAN
+```
+
+Allowed duplicate actions: `WARN`, `ANNOTATE`, `PRIORITIZE`, `DEPRIORITIZE`, `REQUIRE_EXPLICIT_RETEST_REASON`. Persist is never silently blocked solely because a duplicate exists.
+
+## Canonical rejection reasons
+
+Failure class and rejection reason are the Phase 2 `REJECTED_*` tokens. Unknown classes fail closed. No free-text rejection identity.
+
+| failure_class | failed_gate |
+|---|---|
+| `REJECTED_DATA_QUALITY` | `DATA_QUALITY_GATE` |
+| `REJECTED_REPRODUCIBILITY` | `REPRODUCIBILITY_GATE` |
+| `REJECTED_OVERFIT` | `OVERFIT_GATE` |
+| `REJECTED_COST_SENSITIVITY` | `COST_SENSITIVITY_GATE` |
+| `REJECTED_TAIL_RISK` | `TAIL_RISK_GATE` |
+| `REJECTED_REGIME_CONCENTRATION` | `REGIME_CONCENTRATION_GATE` |
+| `REJECTED_COMPARABILITY` | `COMPARABILITY_GATE` |
+| `REJECTED_REALITY_GAP` | `REALITY_GAP_GATE` |
+| `REJECTED_POLICY` | `POLICY_GATE` |
+
+## Experiment identity binding
+
+Every failure record stores the complete Phase 1 Canonical Experiment Identity, including trading-decision-core digests. `dataset_digest` and `experiment_id` are identity-bound. `evidence_refs` must include the bound `EXPERIMENT_RECORD`.
+
+## What this store cannot do
+
+```text
+FAILURE_MEMORY_HAS_RUNTIME_AUTHORITY=false
+FAILURE_MEMORY_CAN_MUTATE_LIVE_CONFIG=false
+FAILURE_MEMORY_CAN_PROMOTE=false
+FAILURE_MEMORY_AUTOMATIC_RESEARCH_BAN=false
+```
+
+Failure Memory is historical research truth. It is not config, not promotion authority, not runtime authority, and not trading authority. It does not implement Phase 4 robustness, Phase 5 comparison, or champion-challenger logic.

--- a/src/experiments/canonical_failure_memory_store_v1.py
+++ b/src/experiments/canonical_failure_memory_store_v1.py
@@ -1,0 +1,220 @@
+"""Append-only file-backed Canonical Failure Memory store v1.
+
+Historical failure records are immutable after successful persist. Identical
+canonical replay is idempotent. Divergent content for the same
+``failure_record_id`` fails closed. Duplicate hypothesis fingerprints are
+queryable; they never authorize an automatic research ban or runtime
+mutation.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.experiments.canonical_failure_memory_v1 import (
+    FailureMemoryValidationError,
+    FailureRecordConflictError,
+    assess_duplicate_hypothesis_v1,
+    canonical_record_payload,
+    freeze_canonical_failure_memory_record_v1,
+    validate_canonical_failure_memory_record_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import (
+    deterministic_json_dumps,
+    is_valid_sha256_hex,
+)
+
+RECORD_FILENAME = "canonical_failure_memory_record_v1.json"
+_TMP_PREFIX = ".canonical_failure_memory_"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CanonicalFailureMemoryStoreV1:
+    """File-backed append-only failure memory."""
+
+    def __init__(self, store_root: Path | str) -> None:
+        root = Path(store_root)
+        if root.exists() and not root.is_dir():
+            raise FailureMemoryValidationError("store_root must be a directory")
+        self._root = root
+
+    @property
+    def store_root(self) -> Path:
+        return self._root
+
+    def append(self, record: Mapping[str, Any]) -> Mapping[str, Any]:
+        validate_canonical_failure_memory_record_v1(record)
+        payload = canonical_record_payload(record)
+        failure_record_id = str(payload["failure_record_id"])
+        dest = self._record_path(failure_record_id)
+        serialized = _serialize_record(payload)
+        if dest.is_file():
+            existing = self.get(failure_record_id)
+            if _serialize_record(canonical_record_payload(existing)) == serialized:
+                _LOGGER.info(
+                    "canonical_failure_memory_v1 idempotent append failure_record_id=%s",
+                    failure_record_id,
+                )
+                return existing
+            raise FailureRecordConflictError(
+                "divergent canonical content for existing failure_record_id is forbidden"
+            )
+        dest_dir = dest.parent
+        if dest_dir.exists():
+            leftovers = [
+                path.name for path in dest_dir.iterdir() if not path.name.startswith(_TMP_PREFIX)
+            ]
+            if leftovers:
+                raise FailureMemoryValidationError(
+                    "failure directory exists without a complete immutable record"
+                )
+        else:
+            dest_dir.mkdir(parents=True, exist_ok=False)
+        _atomic_create_exclusive(dest, serialized)
+        stored = self.get(failure_record_id)
+        _LOGGER.info(
+            "canonical_failure_memory_v1 appended failure_record_id=%s fingerprint=%s",
+            failure_record_id,
+            stored["hypothesis_fingerprint"],
+        )
+        return stored
+
+    def get(self, failure_record_id: str) -> Mapping[str, Any]:
+        path = self._record_path(failure_record_id)
+        if not path.is_file():
+            raise FailureMemoryValidationError(f"failure record not found: {failure_record_id}")
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise FailureMemoryValidationError(
+                f"corrupt failure record JSON: {failure_record_id}"
+            ) from exc
+        if not isinstance(payload, dict):
+            raise FailureMemoryValidationError("corrupt failure record root")
+        validate_canonical_failure_memory_record_v1(payload)
+        stored_id = str(payload.get("failure_record_id") or "")
+        if stored_id != failure_record_id:
+            raise FailureMemoryValidationError(
+                "stored failure_record_id does not match requested id"
+            )
+        return freeze_canonical_failure_memory_record_v1(payload)
+
+    def exists(self, failure_record_id: str) -> bool:
+        path = self._record_path(failure_record_id)
+        if not path.exists():
+            return False
+        self.get(failure_record_id)
+        return True
+
+    def list_records(self) -> list[Mapping[str, Any]]:
+        if not self._root.exists():
+            return []
+        rows: list[Mapping[str, Any]] = []
+        for child in sorted(self._root.iterdir(), key=lambda item: item.name):
+            if not child.is_dir() or child.name.startswith("."):
+                continue
+            if not is_valid_sha256_hex(child.name):
+                raise FailureMemoryValidationError(
+                    f"non-canonical directory under failure memory root: {child.name}"
+                )
+            rows.append(self.get(child.name))
+        return rows
+
+    def list_by_hypothesis_fingerprint(
+        self, hypothesis_fingerprint: str
+    ) -> list[Mapping[str, Any]]:
+        if not isinstance(hypothesis_fingerprint, str) or not is_valid_sha256_hex(
+            hypothesis_fingerprint
+        ):
+            raise FailureMemoryValidationError(
+                "hypothesis_fingerprint must be a lowercase sha256 hex digest"
+            )
+        return [
+            record
+            for record in self.list_records()
+            if record["hypothesis_fingerprint"] == hypothesis_fingerprint
+        ]
+
+    def assess_duplicate(
+        self,
+        *,
+        hypothesis_fingerprint: str,
+        failure_class: str | None = None,
+        parameter_region: Mapping[str, Any] | None = None,
+    ) -> Mapping[str, Any]:
+        return assess_duplicate_hypothesis_v1(
+            self.list_records(),
+            hypothesis_fingerprint=hypothesis_fingerprint,
+            failure_class=failure_class,
+            parameter_region=parameter_region,
+        )
+
+    def _record_path(self, failure_record_id: str) -> Path:
+        if not isinstance(failure_record_id, str) or not is_valid_sha256_hex(failure_record_id):
+            raise FailureMemoryValidationError(
+                "failure_record_id must be a lowercase sha256 hex digest"
+            )
+        if ".." in failure_record_id or "/" in failure_record_id or "\\" in failure_record_id:
+            raise FailureMemoryValidationError("failure_record_id path traversal is forbidden")
+        root = self._root.resolve()
+        dest_dir = (root / failure_record_id).resolve()
+        try:
+            dest_dir.relative_to(root)
+        except ValueError as exc:
+            raise FailureMemoryValidationError("failure record path escaped store root") from exc
+        dest = dest_dir / RECORD_FILENAME
+        dest_resolved = dest.resolve()
+        try:
+            dest_resolved.relative_to(root)
+        except ValueError as exc:
+            raise FailureMemoryValidationError("failure record path escaped store root") from exc
+        return dest
+
+
+def _serialize_record(payload: Mapping[str, Any]) -> str:
+    return deterministic_json_dumps(payload) + "\n"
+
+
+def _atomic_create_exclusive(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=_TMP_PREFIX,
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.link(tmp_name, path)
+        except FileExistsError as exc:
+            existing = Path(path).read_text(encoding="utf-8")
+            if existing != content:
+                raise FailureRecordConflictError(
+                    "divergent canonical content for existing failure_record_id is forbidden"
+                ) from exc
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+    else:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+
+
+__all__ = [
+    "CanonicalFailureMemoryStoreV1",
+    "RECORD_FILENAME",
+]

--- a/src/experiments/canonical_failure_memory_v1.py
+++ b/src/experiments/canonical_failure_memory_v1.py
@@ -1,0 +1,630 @@
+"""Phase 3 Canonical Failure Memory v1 (research evidence only).
+
+Append-only historical memory of rejected research hypotheses. This layer
+reuses Phase 1 Canonical Experiment Identity and Phase 2 rejection
+dispositions. It has no runtime, order, live, funding, canary, promotion,
+or config-write authority.
+
+Duplicate detection is fingerprint-based, not free text. A duplicate is a
+warning / annotation / deprioritization signal. It is never an automatic
+research ban.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Final, Mapping, Sequence
+
+from src.experiments.canonical_experiment_identity_v1 import (
+    CanonicalExperimentIdentityError,
+    canonicalize_mapping,
+    validate_canonical_experiment_identity_v1,
+)
+from src.experiments.canonical_experiment_memory_v1 import (
+    ARTIFACT_KIND_REPO_RELATIVE,
+    ARTIFACT_KIND_STORE_RELATIVE,
+    CANONICAL_DISPOSITIONS,
+    derive_experiment_id_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import (
+    compute_content_sha256,
+    is_valid_sha256_hex,
+)
+
+SCHEMA_VERSION: Final[str] = "canonical_failure_memory_v1"
+FAILURE_DOMAIN: Final[str] = "peak_trade.canonical_failure_memory.v1"
+DIGEST_ALGORITHM: Final[str] = "sha256"
+RECORD_COMPLETENESS_COMPLETE: Final[str] = "COMPLETE"
+EVIDENCE_KIND_EXPERIMENT_RECORD: Final[str] = "EXPERIMENT_RECORD"
+ARTIFACT_KIND_REPO_RELATIVE_REF: Final[str] = ARTIFACT_KIND_REPO_RELATIVE
+ARTIFACT_KIND_STORE_RELATIVE_REF: Final[str] = ARTIFACT_KIND_STORE_RELATIVE
+
+FAILURE_MEMORY_HAS_RUNTIME_AUTHORITY: Final[bool] = False
+FAILURE_MEMORY_CAN_MUTATE_LIVE_CONFIG: Final[bool] = False
+FAILURE_MEMORY_CAN_PROMOTE: Final[bool] = False
+FAILURE_MEMORY_AUTOMATIC_RESEARCH_BAN: Final[bool] = False
+DUPLICATE_DETECTED_IS_NOT_AUTOMATIC_RESEARCH_BAN: Final[bool] = True
+RUNTIME_AUTHORITY_IMPACT: Final[str] = "NONE"
+
+CANONICAL_FAILURE_CLASSES: Final[tuple[str, ...]] = tuple(
+    disposition for disposition in CANONICAL_DISPOSITIONS if disposition.startswith("REJECTED_")
+)
+CANONICAL_REJECTION_REASONS: Final[tuple[str, ...]] = CANONICAL_FAILURE_CLASSES
+FAILURE_CLASS_TO_FAILED_GATE: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "REJECTED_DATA_QUALITY": "DATA_QUALITY_GATE",
+        "REJECTED_REPRODUCIBILITY": "REPRODUCIBILITY_GATE",
+        "REJECTED_OVERFIT": "OVERFIT_GATE",
+        "REJECTED_COST_SENSITIVITY": "COST_SENSITIVITY_GATE",
+        "REJECTED_TAIL_RISK": "TAIL_RISK_GATE",
+        "REJECTED_REGIME_CONCENTRATION": "REGIME_CONCENTRATION_GATE",
+        "REJECTED_COMPARABILITY": "COMPARABILITY_GATE",
+        "REJECTED_REALITY_GAP": "REALITY_GAP_GATE",
+        "REJECTED_POLICY": "POLICY_GATE",
+    }
+)
+CANONICAL_FAILED_GATES: Final[tuple[str, ...]] = tuple(FAILURE_CLASS_TO_FAILED_GATE.values())
+DUPLICATE_ACTIONS: Final[tuple[str, ...]] = (
+    "NONE",
+    "WARN",
+    "ANNOTATE",
+    "PRIORITIZE",
+    "DEPRIORITIZE",
+    "REQUIRE_EXPLICIT_RETEST_REASON",
+)
+
+_CREATED_AT_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$")
+_HYPOTHESIS_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_REGIME_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_UNAVAILABLE_TOKENS = frozenset(
+    {
+        "",
+        "unknown",
+        "unavailable",
+        "n/a",
+        "na",
+        "none",
+        "null",
+        "implicit",
+        "default",
+    }
+)
+_CORE_LOGIC_DIGEST_FIELDS: Final[tuple[str, ...]] = (
+    "trading_decision_core_digest",
+    "market_context_contract_digest",
+    "bull_bear_logic_digest",
+    "state_switch_logic_digest",
+    "survival_logic_digest",
+    "suitability_logic_digest",
+    "double_play_logic_digest",
+    "entry_position_exit_logic_digest",
+)
+_EVIDENCE_KINDS: Final[tuple[str, ...]] = (
+    EVIDENCE_KIND_EXPERIMENT_RECORD,
+    ARTIFACT_KIND_REPO_RELATIVE_REF,
+    ARTIFACT_KIND_STORE_RELATIVE_REF,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class FailureMemoryValidationError(ValueError):
+    """Fail-closed Canonical Failure Memory v1 validation error."""
+
+
+class FailureRecordConflictError(FailureMemoryValidationError):
+    """Same failure_record_id with divergent canonical historical content."""
+
+
+@dataclass(frozen=True)
+class CanonicalFailureMemoryRecordRequestV1:
+    experiment_identity: Mapping[str, Any]
+    hypothesis_id: str
+    failure_class: str
+    failed_gate: str
+    rejection_reason: str
+    regime: str
+    parameter_region: Mapping[str, Any]
+    cost_sensitivity: Mapping[str, Any]
+    instability_indicators: Mapping[str, Any]
+    evidence_refs: Sequence[Mapping[str, Any]]
+    created_at: str
+    robustness_policy_digest: str
+    hypothesis_fingerprint: str | None = None
+    experiment_id: str | None = None
+    retest_reason: str | None = None
+
+
+def derive_hypothesis_fingerprint_v1(
+    *,
+    identity_digest: str,
+    hypothesis_id: str,
+    parameter_region: Mapping[str, Any],
+    regime: str,
+    robustness_policy_digest: str,
+    parent_lineage_ref: str | None,
+) -> str:
+    identity = _require_sha256("identity_digest", identity_digest)
+    robustness = _require_sha256("robustness_policy_digest", robustness_policy_digest)
+    envelope = {
+        "digest_algorithm": DIGEST_ALGORITHM,
+        "digest_domain": f"{FAILURE_DOMAIN}.hypothesis_fingerprint",
+        "payload": {
+            "hypothesis_id": _require_token("hypothesis_id", hypothesis_id, _HYPOTHESIS_ID_RE),
+            "identity_digest": identity,
+            "parameter_region": _canonicalize_numeric_tree("parameter_region", parameter_region),
+            "parent_lineage_ref": parent_lineage_ref,
+            "regime": _require_token("regime", regime, _REGIME_RE),
+            "robustness_policy_digest": robustness,
+        },
+        "schema_version": SCHEMA_VERSION,
+    }
+    return compute_content_sha256(envelope)
+
+
+def derive_failure_record_id_v1(record_without_ids: Mapping[str, Any]) -> str:
+    envelope = {
+        "digest_algorithm": DIGEST_ALGORITHM,
+        "digest_domain": f"{FAILURE_DOMAIN}.failure_record_id",
+        "payload": _plain_mapping(record_without_ids),
+        "schema_version": SCHEMA_VERSION,
+    }
+    return compute_content_sha256(envelope)
+
+
+def build_canonical_failure_memory_record_v1(
+    request: CanonicalFailureMemoryRecordRequestV1,
+) -> Mapping[str, Any]:
+    identity = _require_identity(request.experiment_identity)
+    experiment_id = derive_experiment_id_v1(str(identity["identity_digest"]))
+    if request.experiment_id is not None:
+        provided = _require_sha256("experiment_id", request.experiment_id)
+        if provided != experiment_id:
+            raise FailureMemoryValidationError(
+                "experiment_id is not bound to the Canonical Experiment Identity digest"
+            )
+    parent_lineage_ref = None
+    parent_lineage = identity.get("parent_lineage")
+    if isinstance(parent_lineage, Mapping):
+        parent_lineage_ref = parent_lineage.get("parent_lineage_ref")
+    fingerprint = derive_hypothesis_fingerprint_v1(
+        identity_digest=str(identity["identity_digest"]),
+        hypothesis_id=request.hypothesis_id,
+        parameter_region=request.parameter_region,
+        regime=request.regime,
+        robustness_policy_digest=request.robustness_policy_digest,
+        parent_lineage_ref=parent_lineage_ref if isinstance(parent_lineage_ref, str) else None,
+    )
+    if request.hypothesis_fingerprint is not None:
+        provided_fp = _require_sha256("hypothesis_fingerprint", request.hypothesis_fingerprint)
+        if provided_fp != fingerprint:
+            raise FailureMemoryValidationError(
+                "hypothesis_fingerprint does not match the canonical derived fingerprint"
+            )
+    failure_class = _require_failure_class(request.failure_class)
+    rejection_reason = _require_rejection_reason(request.rejection_reason, failure_class)
+    failed_gate = _require_failed_gate(request.failed_gate, failure_class)
+    created_at = _require_created_at(request.created_at)
+    dataset_digest = _require_sha256("dataset_digest", identity.get("dataset_digest"))
+    evidence_refs = _canonicalize_evidence_refs(request.evidence_refs, experiment_id)
+    parameter_region = _canonicalize_numeric_tree("parameter_region", request.parameter_region)
+    body = {
+        "canonical_trading_decision_core_bound": True,
+        "completeness": RECORD_COMPLETENESS_COMPLETE,
+        "cost_sensitivity": _canonicalize_numeric_tree(
+            "cost_sensitivity", request.cost_sensitivity
+        ),
+        "created_at": created_at,
+        "dataset_digest": dataset_digest,
+        "digest_algorithm": DIGEST_ALGORITHM,
+        "duplicate_detected_is_not_automatic_research_ban": (
+            DUPLICATE_DETECTED_IS_NOT_AUTOMATIC_RESEARCH_BAN
+        ),
+        "evidence_refs": evidence_refs,
+        "experiment_id": experiment_id,
+        "experiment_identity": identity,
+        "failed_gate": failed_gate,
+        "failure_class": failure_class,
+        "failure_domain": FAILURE_DOMAIN,
+        "failure_memory_automatic_research_ban": FAILURE_MEMORY_AUTOMATIC_RESEARCH_BAN,
+        "failure_memory_can_mutate_live_config": FAILURE_MEMORY_CAN_MUTATE_LIVE_CONFIG,
+        "failure_memory_can_promote": FAILURE_MEMORY_CAN_PROMOTE,
+        "failure_memory_has_runtime_authority": FAILURE_MEMORY_HAS_RUNTIME_AUTHORITY,
+        "hypothesis_fingerprint": fingerprint,
+        "hypothesis_id": _require_token("hypothesis_id", request.hypothesis_id, _HYPOTHESIS_ID_RE),
+        "instability_indicators": _canonicalize_numeric_tree(
+            "instability_indicators", request.instability_indicators
+        ),
+        "parameter_region": parameter_region,
+        "record_schema_version": SCHEMA_VERSION,
+        "regime": _require_token("regime", request.regime, _REGIME_RE),
+        "rejection_reason": rejection_reason,
+        "retest_reason": _optional_retest_reason(request.retest_reason),
+        "robustness_policy_digest": _require_sha256(
+            "robustness_policy_digest", request.robustness_policy_digest
+        ),
+        "runtime_authority_impact": RUNTIME_AUTHORITY_IMPACT,
+    }
+    failure_record_id = derive_failure_record_id_v1(body)
+    record = dict(body)
+    record["failure_record_id"] = failure_record_id
+    record["integrity"] = {
+        "content_sha256": compute_content_sha256(
+            {key: value for key, value in record.items() if key != "integrity"}
+        )
+    }
+    validate_canonical_failure_memory_record_v1(record)
+    frozen = _freeze(record)
+    _LOGGER.info(
+        "canonical_failure_memory_v1 built failure_record_id=%s fingerprint=%s "
+        "failure_class=%s runtime_authority=%s automatic_ban=%s",
+        record["failure_record_id"],
+        record["hypothesis_fingerprint"],
+        record["failure_class"],
+        record["failure_memory_has_runtime_authority"],
+        record["failure_memory_automatic_research_ban"],
+    )
+    return frozen
+
+
+def validate_canonical_failure_memory_record_v1(record: Mapping[str, Any]) -> None:
+    if not isinstance(record, Mapping):
+        raise FailureMemoryValidationError("failure record must be a mapping")
+    record = _plain_mapping(record)
+    if record.get("record_schema_version") != SCHEMA_VERSION:
+        raise FailureMemoryValidationError("record_schema_version mismatch")
+    if record.get("failure_domain") != FAILURE_DOMAIN:
+        raise FailureMemoryValidationError("failure_domain mismatch")
+    if record.get("completeness") != RECORD_COMPLETENESS_COMPLETE:
+        raise FailureMemoryValidationError("non-COMPLETE failure records are forbidden")
+    if record.get("digest_algorithm") != DIGEST_ALGORITHM:
+        raise FailureMemoryValidationError("digest_algorithm mismatch")
+    if record.get("failure_memory_has_runtime_authority") is not False:
+        raise FailureMemoryValidationError("failure_memory_has_runtime_authority must be false")
+    if record.get("failure_memory_can_mutate_live_config") is not False:
+        raise FailureMemoryValidationError("failure_memory_can_mutate_live_config must be false")
+    if record.get("failure_memory_can_promote") is not False:
+        raise FailureMemoryValidationError("failure_memory_can_promote must be false")
+    if record.get("failure_memory_automatic_research_ban") is not False:
+        raise FailureMemoryValidationError("failure_memory_automatic_research_ban must be false")
+    if record.get("duplicate_detected_is_not_automatic_research_ban") is not True:
+        raise FailureMemoryValidationError(
+            "duplicate_detected_is_not_automatic_research_ban must be true"
+        )
+    if record.get("runtime_authority_impact") != RUNTIME_AUTHORITY_IMPACT:
+        raise FailureMemoryValidationError("runtime_authority_impact must be NONE")
+    if record.get("canonical_trading_decision_core_bound") is not True:
+        raise FailureMemoryValidationError("canonical_trading_decision_core_bound must be true")
+
+    identity = _require_identity(record.get("experiment_identity"))
+    experiment_id = _require_sha256("experiment_id", record.get("experiment_id"))
+    expected_id = derive_experiment_id_v1(str(identity["identity_digest"]))
+    if experiment_id != expected_id:
+        raise FailureMemoryValidationError(
+            "experiment_id is not bound to the Canonical Experiment Identity digest"
+        )
+    dataset_digest = _require_sha256("dataset_digest", record.get("dataset_digest"))
+    if dataset_digest != identity.get("dataset_digest"):
+        raise FailureMemoryValidationError(
+            "dataset_digest must match experiment_identity.dataset_digest"
+        )
+    failure_class = _require_failure_class(record.get("failure_class"))
+    _require_rejection_reason(record.get("rejection_reason"), failure_class)
+    _require_failed_gate(record.get("failed_gate"), failure_class)
+    _require_created_at(record.get("created_at"))
+    _require_token("hypothesis_id", record.get("hypothesis_id"), _HYPOTHESIS_ID_RE)
+    _require_token("regime", record.get("regime"), _REGIME_RE)
+    _require_sha256("robustness_policy_digest", record.get("robustness_policy_digest"))
+    _optional_retest_reason(record.get("retest_reason"))
+    _canonicalize_numeric_tree("parameter_region", record.get("parameter_region"))
+    _canonicalize_numeric_tree("cost_sensitivity", record.get("cost_sensitivity"))
+    _canonicalize_numeric_tree("instability_indicators", record.get("instability_indicators"))
+    _canonicalize_evidence_refs(record.get("evidence_refs"), experiment_id)
+    for field_name in _CORE_LOGIC_DIGEST_FIELDS:
+        _require_sha256(field_name, identity.get(field_name))
+
+    parent_lineage_ref = None
+    parent_lineage = identity.get("parent_lineage")
+    if isinstance(parent_lineage, Mapping):
+        parent_lineage_ref = parent_lineage.get("parent_lineage_ref")
+    expected_fp = derive_hypothesis_fingerprint_v1(
+        identity_digest=str(identity["identity_digest"]),
+        hypothesis_id=str(record.get("hypothesis_id")),
+        parameter_region=record.get("parameter_region") or {},
+        regime=str(record.get("regime")),
+        robustness_policy_digest=str(record.get("robustness_policy_digest")),
+        parent_lineage_ref=parent_lineage_ref if isinstance(parent_lineage_ref, str) else None,
+    )
+    if record.get("hypothesis_fingerprint") != expected_fp:
+        raise FailureMemoryValidationError("hypothesis_fingerprint is not canonically derived")
+
+    body = {
+        key: value for key, value in record.items() if key not in {"failure_record_id", "integrity"}
+    }
+    expected_record_id = derive_failure_record_id_v1(body)
+    if record.get("failure_record_id") != expected_record_id:
+        raise FailureMemoryValidationError("failure_record_id is not bound to canonical content")
+    expected_integrity = compute_content_sha256(
+        {key: value for key, value in record.items() if key != "integrity"}
+    )
+    integrity = record.get("integrity")
+    if not isinstance(integrity, Mapping) or integrity.get("content_sha256") != expected_integrity:
+        raise FailureMemoryValidationError("integrity.content_sha256 mismatch")
+
+
+def assess_duplicate_hypothesis_v1(
+    existing_records: Sequence[Mapping[str, Any]],
+    *,
+    hypothesis_fingerprint: str,
+    failure_class: str | None = None,
+    parameter_region: Mapping[str, Any] | None = None,
+) -> Mapping[str, Any]:
+    fingerprint = _require_sha256("hypothesis_fingerprint", hypothesis_fingerprint)
+    matches: list[dict[str, Any]] = []
+    for item in existing_records:
+        validate_canonical_failure_memory_record_v1(item)
+        payload = _plain_mapping(item)
+        if payload.get("hypothesis_fingerprint") != fingerprint:
+            continue
+        matches.append(payload)
+    previously_rejected = bool(matches)
+    same_failure_mode = False
+    if failure_class is not None:
+        canonical_class = _require_failure_class(failure_class)
+        same_failure_mode = any(item.get("failure_class") == canonical_class for item in matches)
+    same_parameter_region = False
+    if parameter_region is not None:
+        canonical_region = _canonicalize_numeric_tree("parameter_region", parameter_region)
+        same_parameter_region = (
+            sum(1 for item in matches if item.get("parameter_region") == canonical_region) >= 1
+        )
+    repeatedly_unstable = False
+    if parameter_region is not None:
+        canonical_region = _canonicalize_numeric_tree("parameter_region", parameter_region)
+        region_hits = [
+            item
+            for item in matches
+            if item.get("parameter_region") == canonical_region
+            and _has_instability(item.get("instability_indicators"))
+        ]
+        repeatedly_unstable = len(region_hits) >= 2
+    actions: list[str] = []
+    if previously_rejected:
+        actions.extend(("WARN", "ANNOTATE", "REQUIRE_EXPLICIT_RETEST_REASON"))
+    if same_failure_mode:
+        actions.append("ANNOTATE")
+    if repeatedly_unstable:
+        actions.append("DEPRIORITIZE")
+    ordered_actions = tuple(action for action in DUPLICATE_ACTIONS if action in set(actions))
+    detected = bool(matches)
+    assessment = {
+        "actions": list(ordered_actions) if detected else ["NONE"],
+        "automatic_research_ban": False,
+        "detected": detected,
+        "duplicate_detected_is_not_automatic_research_ban": True,
+        "failure_memory_has_runtime_authority": False,
+        "hypothesis_fingerprint": fingerprint,
+        "matching_failure_record_ids": [item["failure_record_id"] for item in matches],
+        "matching_record_count": len(matches),
+        "previously_rejected": previously_rejected,
+        "same_failure_mode_known": same_failure_mode,
+        "same_parameter_region_repeatedly_unstable": repeatedly_unstable,
+        "same_parameter_region_seen": same_parameter_region,
+    }
+    return _freeze(assessment)
+
+
+def canonical_record_payload(record: Mapping[str, Any]) -> dict[str, Any]:
+    return _plain_mapping(record)
+
+
+def freeze_canonical_failure_memory_record_v1(record: Mapping[str, Any]) -> Mapping[str, Any]:
+    validate_canonical_failure_memory_record_v1(record)
+    return _freeze(canonical_record_payload(record))
+
+
+def _require_identity(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise FailureMemoryValidationError("experiment_identity present and valid is required")
+    identity = _plain_mapping(value)
+    try:
+        validate_canonical_experiment_identity_v1(identity)
+    except CanonicalExperimentIdentityError as exc:
+        raise FailureMemoryValidationError(
+            f"experiment_identity is not a valid Phase 1 Canonical Experiment Identity: {exc}"
+        ) from exc
+    return identity
+
+
+def _require_sha256(field_name: str, value: Any) -> str:
+    if not isinstance(value, str) or not is_valid_sha256_hex(value):
+        raise FailureMemoryValidationError(f"{field_name} must be a lowercase sha256 hex digest")
+    return value
+
+
+def _require_created_at(value: Any) -> str:
+    if not isinstance(value, str) or not _CREATED_AT_RE.fullmatch(value):
+        raise FailureMemoryValidationError(
+            "created_at must be an explicit UTC timestamp ending with Z"
+        )
+    return value
+
+
+def _require_token(field_name: str, value: Any, pattern: re.Pattern[str]) -> str:
+    if not isinstance(value, str) or not pattern.fullmatch(value):
+        raise FailureMemoryValidationError(f"{field_name} is missing or malformed")
+    if value.strip().lower() in _UNAVAILABLE_TOKENS:
+        raise FailureMemoryValidationError(f"{field_name} cannot use implicit unavailable tokens")
+    return value
+
+
+def _require_failure_class(value: Any) -> str:
+    if not isinstance(value, str) or value not in CANONICAL_FAILURE_CLASSES:
+        raise FailureMemoryValidationError("failure_class is unknown or unsupported")
+    return value
+
+
+def _require_rejection_reason(value: Any, failure_class: str) -> str:
+    if not isinstance(value, str) or value not in CANONICAL_REJECTION_REASONS:
+        raise FailureMemoryValidationError("rejection_reason is not a canonical rejection token")
+    if value != failure_class:
+        raise FailureMemoryValidationError(
+            "rejection_reason must equal failure_class for Canonical Failure Memory v1"
+        )
+    return value
+
+
+def _require_failed_gate(value: Any, failure_class: str) -> str:
+    expected = FAILURE_CLASS_TO_FAILED_GATE[failure_class]
+    if not isinstance(value, str) or value not in CANONICAL_FAILED_GATES:
+        raise FailureMemoryValidationError("failed_gate is unknown or unsupported")
+    if value != expected:
+        raise FailureMemoryValidationError(
+            f"failed_gate {value} is inconsistent with failure_class {failure_class}"
+        )
+    return value
+
+
+def _optional_retest_reason(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise FailureMemoryValidationError("retest_reason must be a non-empty string or null")
+    if value.strip().lower() in _UNAVAILABLE_TOKENS:
+        raise FailureMemoryValidationError("retest_reason cannot use implicit unavailable tokens")
+    return value.strip()
+
+
+def _canonicalize_numeric_tree(field_name: str, value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise FailureMemoryValidationError(f"{field_name} must be a mapping")
+    try:
+        return canonicalize_mapping(value, path=f"$.{field_name}")
+    except CanonicalExperimentIdentityError as exc:
+        message = str(exc)
+        if "non-finite float" in message:
+            raise FailureMemoryValidationError(
+                f"non-finite numeric values are forbidden in {field_name}"
+            ) from exc
+        raise FailureMemoryValidationError(
+            f"{field_name} is not canonically serializable: {exc}"
+        ) from exc
+
+
+def _canonicalize_evidence_refs(value: Any, experiment_id: str) -> list[dict[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise FailureMemoryValidationError("evidence_refs must be a sequence")
+    refs: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    experiment_bound = False
+    for index, item in enumerate(value):
+        if not isinstance(item, Mapping):
+            raise FailureMemoryValidationError(f"evidence_refs[{index}] must be a mapping")
+        kind = item.get("kind")
+        if kind not in _EVIDENCE_KINDS:
+            raise FailureMemoryValidationError(f"evidence_refs[{index}].kind is unsupported")
+        digest = _require_sha256(f"evidence_refs[{index}].digest", item.get("digest"))
+        if kind == EVIDENCE_KIND_EXPERIMENT_RECORD:
+            ref = _require_sha256(f"evidence_refs[{index}].ref", item.get("ref"))
+            if ref == experiment_id:
+                experiment_bound = True
+        else:
+            ref = _require_relative_artifact_ref(f"evidence_refs[{index}].ref", item.get("ref"))
+        extra_keys = set(str(key) for key in item.keys()) - {"kind", "ref", "digest"}
+        if extra_keys:
+            raise FailureMemoryValidationError(
+                f"evidence_refs[{index}] has unsupported keys: {sorted(extra_keys)}"
+            )
+        key = (str(kind), ref)
+        if key in seen:
+            raise FailureMemoryValidationError("duplicate evidence_refs are forbidden")
+        seen.add(key)
+        refs.append({"digest": digest, "kind": kind, "ref": ref})
+    if not experiment_bound:
+        raise FailureMemoryValidationError(
+            "evidence_refs must include the bound EXPERIMENT_RECORD experiment_id"
+        )
+    return refs
+
+
+def _require_relative_artifact_ref(field_name: str, value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise FailureMemoryValidationError(f"{field_name} must be a non-empty relative ref")
+    ref = value.strip()
+    if ref.strip().lower() in _UNAVAILABLE_TOKENS:
+        raise FailureMemoryValidationError(f"{field_name} cannot use implicit unavailable tokens")
+    if "\x00" in ref:
+        raise FailureMemoryValidationError(f"{field_name} contains a NUL byte")
+    if ref.startswith("/") or ref.startswith("\\") or ref.startswith("~"):
+        raise FailureMemoryValidationError(f"{field_name} absolute or home paths are forbidden")
+    if ":" in ref.split("/", 1)[0] and len(ref.split("/", 1)[0]) <= 2:
+        raise FailureMemoryValidationError(f"{field_name} drive-qualified paths are forbidden")
+    parts = ref.replace("\\", "/").split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise FailureMemoryValidationError(
+            f"{field_name} path traversal or empty segments are forbidden"
+        )
+    if "\\" in ref:
+        raise FailureMemoryValidationError(
+            f"{field_name} must use store-/repo-relative POSIX paths"
+        )
+    return ref
+
+
+def _has_instability(value: Any) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    payload = _plain_mapping(value)
+    if payload.get("unstable") is True:
+        return True
+    repeated = payload.get("repeated_instability")
+    return repeated is True or repeated == 1
+
+
+def _freeze(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({str(key): _freeze(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return [_freeze(item) for item in value]
+    return value
+
+
+def _plain_mapping(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _plain_mapping(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_plain_mapping(item) for item in value]
+    return value
+
+
+__all__ = [
+    "CANONICAL_FAILED_GATES",
+    "CANONICAL_FAILURE_CLASSES",
+    "CANONICAL_REJECTION_REASONS",
+    "CanonicalFailureMemoryRecordRequestV1",
+    "DIGEST_ALGORITHM",
+    "DUPLICATE_ACTIONS",
+    "DUPLICATE_DETECTED_IS_NOT_AUTOMATIC_RESEARCH_BAN",
+    "EVIDENCE_KIND_EXPERIMENT_RECORD",
+    "FAILURE_CLASS_TO_FAILED_GATE",
+    "FAILURE_DOMAIN",
+    "FAILURE_MEMORY_AUTOMATIC_RESEARCH_BAN",
+    "FAILURE_MEMORY_CAN_MUTATE_LIVE_CONFIG",
+    "FAILURE_MEMORY_CAN_PROMOTE",
+    "FAILURE_MEMORY_HAS_RUNTIME_AUTHORITY",
+    "FailureMemoryValidationError",
+    "FailureRecordConflictError",
+    "RECORD_COMPLETENESS_COMPLETE",
+    "RUNTIME_AUTHORITY_IMPACT",
+    "SCHEMA_VERSION",
+    "assess_duplicate_hypothesis_v1",
+    "build_canonical_failure_memory_record_v1",
+    "canonical_record_payload",
+    "derive_failure_record_id_v1",
+    "derive_hypothesis_fingerprint_v1",
+    "freeze_canonical_failure_memory_record_v1",
+    "validate_canonical_failure_memory_record_v1",
+]

--- a/tests/experiments/test_canonical_failure_memory_v1.py
+++ b/tests/experiments/test_canonical_failure_memory_v1.py
@@ -1,0 +1,401 @@
+"""Phase 3 Canonical Failure Memory v1 contract tests."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import inspect
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping
+
+import pytest
+
+from src.experiments.canonical_experiment_identity_v1 import (
+    CanonicalExperimentIdentityRequestV1,
+    WORKING_TREE_CLEAN,
+    build_canonical_experiment_identity_v1,
+)
+from src.experiments.canonical_experiment_memory_v1 import derive_experiment_id_v1
+from src.experiments.canonical_failure_memory_store_v1 import (
+    RECORD_FILENAME,
+    CanonicalFailureMemoryStoreV1,
+)
+from src.experiments.canonical_failure_memory_v1 import (
+    DUPLICATE_DETECTED_IS_NOT_AUTOMATIC_RESEARCH_BAN,
+    FAILURE_MEMORY_AUTOMATIC_RESEARCH_BAN,
+    FAILURE_MEMORY_CAN_MUTATE_LIVE_CONFIG,
+    FAILURE_MEMORY_CAN_PROMOTE,
+    FAILURE_MEMORY_HAS_RUNTIME_AUTHORITY,
+    CanonicalFailureMemoryRecordRequestV1,
+    FailureMemoryValidationError,
+    assess_duplicate_hypothesis_v1,
+    build_canonical_failure_memory_record_v1,
+    canonical_record_payload,
+    derive_hypothesis_fingerprint_v1,
+    validate_canonical_failure_memory_record_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import deterministic_json_dumps
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MEMORY_MODULE_PATH = REPO_ROOT / "src" / "experiments" / "canonical_failure_memory_v1.py"
+STORE_MODULE_PATH = REPO_ROOT / "src" / "experiments" / "canonical_failure_memory_store_v1.py"
+_GIT_SHA = "e10f32f56fad0576cd250958401d13f044c5920d"
+_CORE_DIGEST_FIELDS = (
+    "trading_decision_core_digest",
+    "market_context_contract_digest",
+    "bull_bear_logic_digest",
+    "state_switch_logic_digest",
+    "survival_logic_digest",
+    "suitability_logic_digest",
+    "double_play_logic_digest",
+    "entry_position_exit_logic_digest",
+)
+
+
+def _digest(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _identity(**overrides: Any) -> Mapping[str, Any]:
+    payload: dict[str, Any] = {
+        "git_sha": _GIT_SHA,
+        "working_tree_status": WORKING_TREE_CLEAN,
+        "strategy_identity": "ma_crossover.v1",
+        "strategy_params": {"slow": 50, "fast": 10},
+        "dataset_digest": _digest("dataset"),
+        "feature_pipeline_digest": _digest("features"),
+        "fee_model_digest": _digest("fee"),
+        "slippage_model_digest": _digest("slippage"),
+        "funding_model_digest": _digest("funding"),
+        "risk_policy_digest": _digest("risk"),
+        "portfolio_digest": _digest("portfolio"),
+        "split_policy_digest": _digest("split"),
+        "market_context_contract_digest": _digest("market-context"),
+        "bull_bear_logic_digest": _digest("bull-bear"),
+        "state_switch_logic_digest": _digest("state-switch"),
+        "survival_logic_digest": _digest("survival"),
+        "suitability_logic_digest": _digest("suitability"),
+        "double_play_logic_digest": _digest("double-play"),
+        "entry_position_exit_logic_digest": _digest("entry-position-exit"),
+        "seed": 7,
+        "environment": {
+            "python_version": "3.11.15",
+            "python_implementation": "CPython",
+        },
+        "parent_lineage_ref": None,
+        "dirty_paths_digest": None,
+    }
+    payload.update(overrides)
+    return build_canonical_experiment_identity_v1(CanonicalExperimentIdentityRequestV1(**payload))
+
+
+def _request(
+    identity: Mapping[str, Any] | None = None, **overrides: Any
+) -> CanonicalFailureMemoryRecordRequestV1:
+    identity = identity or _identity()
+    experiment_id = derive_experiment_id_v1(str(identity["identity_digest"]))
+    payload: dict[str, Any] = {
+        "experiment_identity": identity,
+        "hypothesis_id": "hyp.ma-crossover.v1",
+        "failure_class": "REJECTED_OVERFIT",
+        "failed_gate": "OVERFIT_GATE",
+        "rejection_reason": "REJECTED_OVERFIT",
+        "regime": "high_vol",
+        "parameter_region": {"fast": 10, "slow": 50},
+        "cost_sensitivity": {"fee_stress": 0.25},
+        "instability_indicators": {"unstable": True, "fold_sign_flips": 3},
+        "evidence_refs": [
+            {
+                "kind": "EXPERIMENT_RECORD",
+                "ref": experiment_id,
+                "digest": _digest("experiment-record"),
+            }
+        ],
+        "created_at": "2026-08-17T18:00:00Z",
+        "robustness_policy_digest": _digest("robustness-policy"),
+        "hypothesis_fingerprint": None,
+        "experiment_id": None,
+        "retest_reason": None,
+    }
+    payload.update(overrides)
+    return CanonicalFailureMemoryRecordRequestV1(**payload)
+
+
+def test_valid_record_round_trip_preserves_identity_and_core_digests() -> None:
+    identity = _identity()
+    record = build_canonical_failure_memory_record_v1(_request(identity))
+    assert record["completeness"] == "COMPLETE"
+    assert record["experiment_id"] == derive_experiment_id_v1(str(identity["identity_digest"]))
+    assert record["dataset_digest"] == identity["dataset_digest"]
+    assert canonical_record_payload(record["experiment_identity"]) == canonical_record_payload(
+        identity
+    )
+    for field_name in _CORE_DIGEST_FIELDS:
+        assert record["experiment_identity"][field_name] == identity[field_name]
+    assert record["canonical_trading_decision_core_bound"] is True
+    assert record["failure_memory_has_runtime_authority"] is False
+    assert record["failure_memory_automatic_research_ban"] is False
+    validate_canonical_failure_memory_record_v1(record)
+
+
+def test_deterministic_serialization_and_fingerprint() -> None:
+    first = canonical_record_payload(build_canonical_failure_memory_record_v1(_request()))
+    second = canonical_record_payload(build_canonical_failure_memory_record_v1(_request()))
+    assert deterministic_json_dumps(first) == deterministic_json_dumps(second)
+    identity = _identity()
+    parent_ref = identity["parent_lineage"]["parent_lineage_ref"]
+    expected = derive_hypothesis_fingerprint_v1(
+        identity_digest=str(identity["identity_digest"]),
+        hypothesis_id="hyp.ma-crossover.v1",
+        parameter_region={"fast": 10, "slow": 50},
+        regime="high_vol",
+        robustness_policy_digest=_digest("robustness-policy"),
+        parent_lineage_ref=parent_ref,
+    )
+    assert first["hypothesis_fingerprint"] == expected
+    assert first["failure_record_id"] == second["failure_record_id"]
+
+
+def test_exact_same_hypothesis_is_detected(tmp_path: Path) -> None:
+    store = CanonicalFailureMemoryStoreV1(tmp_path / "failure-memory")
+    record = build_canonical_failure_memory_record_v1(_request())
+    store.append(record)
+    assessment = store.assess_duplicate(
+        hypothesis_fingerprint=str(record["hypothesis_fingerprint"]),
+        failure_class="REJECTED_OVERFIT",
+        parameter_region={"fast": 10, "slow": 50},
+    )
+    assert assessment["detected"] is True
+    assert assessment["previously_rejected"] is True
+    assert assessment["same_failure_mode_known"] is True
+    assert assessment["automatic_research_ban"] is False
+    assert "WARN" in assessment["actions"]
+    assert "REQUIRE_EXPLICIT_RETEST_REASON" in assessment["actions"]
+    assert "AUTOMATIC_RESEARCH_BAN" not in assessment["actions"]
+
+
+def test_identity_relevant_change_is_not_a_false_duplicate() -> None:
+    baseline = build_canonical_failure_memory_record_v1(_request())
+    changed_dataset = build_canonical_failure_memory_record_v1(
+        _request(_identity(dataset_digest=_digest("dataset-v2")))
+    )
+    changed_cost = build_canonical_failure_memory_record_v1(
+        _request(_identity(fee_model_digest=_digest("fee-v2")))
+    )
+    changed_core = build_canonical_failure_memory_record_v1(
+        _request(_identity(bull_bear_logic_digest=_digest("bull-bear-v2")))
+    )
+    changed_region = build_canonical_failure_memory_record_v1(
+        _request(parameter_region={"fast": 12, "slow": 50})
+    )
+    changed_regime = build_canonical_failure_memory_record_v1(_request(regime="low_vol"))
+    changed_robustness = build_canonical_failure_memory_record_v1(
+        _request(robustness_policy_digest=_digest("robustness-v2"))
+    )
+    fingerprints = {
+        baseline["hypothesis_fingerprint"],
+        changed_dataset["hypothesis_fingerprint"],
+        changed_cost["hypothesis_fingerprint"],
+        changed_core["hypothesis_fingerprint"],
+        changed_region["hypothesis_fingerprint"],
+        changed_regime["hypothesis_fingerprint"],
+        changed_robustness["hypothesis_fingerprint"],
+    }
+    assert len(fingerprints) == 7
+    assessment = assess_duplicate_hypothesis_v1(
+        [baseline],
+        hypothesis_fingerprint=str(changed_dataset["hypothesis_fingerprint"]),
+    )
+    assert assessment["detected"] is False
+    assert assessment["actions"] == ["NONE"]
+
+
+def test_canonical_rejection_reason_and_unknown_class_fail_closed() -> None:
+    with pytest.raises(FailureMemoryValidationError, match="canonical rejection"):
+        build_canonical_failure_memory_record_v1(
+            _request(rejection_reason="looks overfit in the notebook")
+        )
+    with pytest.raises(FailureMemoryValidationError, match="unknown or unsupported"):
+        build_canonical_failure_memory_record_v1(_request(failure_class="REJECTED_VIBES"))
+    with pytest.raises(FailureMemoryValidationError, match="inconsistent"):
+        build_canonical_failure_memory_record_v1(
+            _request(failure_class="REJECTED_OVERFIT", failed_gate="TAIL_RISK_GATE")
+        )
+    record = build_canonical_failure_memory_record_v1(
+        _request(
+            failure_class="REJECTED_TAIL_RISK",
+            failed_gate="TAIL_RISK_GATE",
+            rejection_reason="REJECTED_TAIL_RISK",
+        )
+    )
+    assert record["rejection_reason"] == "REJECTED_TAIL_RISK"
+    assert record["failed_gate"] == "TAIL_RISK_GATE"
+
+
+def test_append_only_identical_replay_and_divergent_conflict(tmp_path: Path) -> None:
+    store = CanonicalFailureMemoryStoreV1(tmp_path / "failure-memory")
+    record = build_canonical_failure_memory_record_v1(_request())
+    first = store.append(record)
+    second = store.append(record)
+    assert canonical_record_payload(first) == canonical_record_payload(second)
+    dest = tmp_path / "failure-memory" / str(record["failure_record_id"]) / RECORD_FILENAME
+    original = dest.read_text(encoding="utf-8")
+    mutated = canonical_record_payload(record)
+    mutated["cost_sensitivity"] = {"fee_stress": 0.99}
+    dest.write_text(deterministic_json_dumps(mutated) + "\n", encoding="utf-8")
+    with pytest.raises(FailureMemoryValidationError):
+        store.get(str(record["failure_record_id"]))
+    dest.write_text(original, encoding="utf-8")
+    later = build_canonical_failure_memory_record_v1(_request(created_at="2026-08-17T19:00:00Z"))
+    stored_later = store.append(later)
+    assert stored_later["failure_record_id"] != record["failure_record_id"]
+    assert stored_later["hypothesis_fingerprint"] == record["hypothesis_fingerprint"]
+    assert len(store.list_by_hypothesis_fingerprint(str(record["hypothesis_fingerprint"]))) == 2
+
+
+def test_historical_record_not_overwritten_on_conflict(tmp_path: Path) -> None:
+    store = CanonicalFailureMemoryStoreV1(tmp_path / "failure-memory")
+    record = build_canonical_failure_memory_record_v1(_request())
+    store.append(record)
+    dest = tmp_path / "failure-memory" / str(record["failure_record_id"]) / RECORD_FILENAME
+    original = dest.read_text(encoding="utf-8")
+    store.append(record)
+    assert dest.read_text(encoding="utf-8") == original
+    later = store.append(
+        build_canonical_failure_memory_record_v1(_request(created_at="2026-08-17T21:00:00Z"))
+    )
+    assert later["failure_record_id"] != record["failure_record_id"]
+    assert dest.read_text(encoding="utf-8") == original
+    loaded = store.get(str(record["failure_record_id"]))
+    assert canonical_record_payload(loaded) == canonical_record_payload(record)
+
+
+def test_evidence_and_experiment_refs_remain_complete(tmp_path: Path) -> None:
+    identity = _identity()
+    record = build_canonical_failure_memory_record_v1(_request(identity))
+    store = CanonicalFailureMemoryStoreV1(tmp_path / "failure-memory")
+    loaded = store.append(record)
+    assert loaded["evidence_refs"][0]["kind"] == "EXPERIMENT_RECORD"
+    assert loaded["evidence_refs"][0]["ref"] == loaded["experiment_id"]
+    assert loaded["experiment_id"] == derive_experiment_id_v1(str(identity["identity_digest"]))
+    with pytest.raises(FailureMemoryValidationError, match="EXPERIMENT_RECORD"):
+        build_canonical_failure_memory_record_v1(
+            _request(
+                identity,
+                evidence_refs=[
+                    {
+                        "kind": "REPO_RELATIVE",
+                        "ref": "docs/ops/specs/CANONICAL_FAILURE_MEMORY_V1.md",
+                        "digest": _digest("doc"),
+                    }
+                ],
+            )
+        )
+
+
+def test_path_traversal_and_non_finite_values_fail_closed() -> None:
+    identity = _identity()
+    experiment_id = derive_experiment_id_v1(str(identity["identity_digest"]))
+    with pytest.raises(FailureMemoryValidationError, match="path traversal"):
+        build_canonical_failure_memory_record_v1(
+            _request(
+                identity,
+                evidence_refs=[
+                    {
+                        "kind": "EXPERIMENT_RECORD",
+                        "ref": experiment_id,
+                        "digest": _digest("experiment-record"),
+                    },
+                    {
+                        "kind": "REPO_RELATIVE",
+                        "ref": "../secrets.env",
+                        "digest": _digest("escape"),
+                    },
+                ],
+            )
+        )
+    with pytest.raises(FailureMemoryValidationError, match="non-finite"):
+        build_canonical_failure_memory_record_v1(
+            _request(cost_sensitivity={"fee_stress": float("nan")})
+        )
+    with pytest.raises(FailureMemoryValidationError, match="not bound"):
+        build_canonical_failure_memory_record_v1(_request(experiment_id=_digest("unrelated")))
+    with pytest.raises(FailureMemoryValidationError, match="does not match"):
+        build_canonical_failure_memory_record_v1(
+            _request(hypothesis_fingerprint=_digest("wrong-fingerprint"))
+        )
+
+
+def test_authority_boundary_no_runtime_or_promotion_paths() -> None:
+    for module_path in (MEMORY_MODULE_PATH, STORE_MODULE_PATH):
+        source = module_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module)
+        forbidden_imports = {
+            "src.core.peak_config",
+            "src.governance.promotion_loop.engine",
+            "src.execution",
+            "scripts.run_learning_apply_cycle",
+            "src.live",
+            "src.trading",
+            "src.trading.master_v2",
+            "src.risk",
+        }
+        assert forbidden_imports.isdisjoint(imported)
+        for token in (
+            "config/live_overrides",
+            "load_config_with_live_overrides",
+            "submit_order",
+            "confirm_token",
+            "LIVE_AUTHORIZED",
+            "TESTNET_AUTHORIZED",
+            "apply_proposals_to_live_overrides",
+            "write_live_config",
+            "armed",
+            "FUNDING_AUTHORIZED",
+        ):
+            assert token not in source
+    assert FAILURE_MEMORY_HAS_RUNTIME_AUTHORITY is False
+    assert FAILURE_MEMORY_CAN_MUTATE_LIVE_CONFIG is False
+    assert FAILURE_MEMORY_CAN_PROMOTE is False
+    assert FAILURE_MEMORY_AUTOMATIC_RESEARCH_BAN is False
+    assert DUPLICATE_DETECTED_IS_NOT_AUTOMATIC_RESEARCH_BAN is True
+    record = build_canonical_failure_memory_record_v1(_request())
+    assert record["failure_memory_has_runtime_authority"] is False
+    assert record["failure_memory_can_mutate_live_config"] is False
+    assert record["failure_memory_can_promote"] is False
+    assert record["failure_memory_automatic_research_ban"] is False
+    assert "write_live_config" not in inspect.getsource(build_canonical_failure_memory_record_v1)
+    assert "apply_proposals_to_live_overrides" not in inspect.getsource(
+        CanonicalFailureMemoryStoreV1.append
+    )
+
+
+def test_frozen_record_is_immutable() -> None:
+    record = build_canonical_failure_memory_record_v1(_request())
+    assert isinstance(record, MappingProxyType)
+    with pytest.raises(TypeError):
+        record["failure_class"] = "REJECTED_POLICY"  # type: ignore[index]
+
+
+def test_repeated_parameter_region_instability_deprioritizes_without_ban(tmp_path: Path) -> None:
+    store = CanonicalFailureMemoryStoreV1(tmp_path / "failure-memory")
+    first = store.append(build_canonical_failure_memory_record_v1(_request()))
+    second = store.append(
+        build_canonical_failure_memory_record_v1(_request(created_at="2026-08-17T20:00:00Z"))
+    )
+    assessment = store.assess_duplicate(
+        hypothesis_fingerprint=str(first["hypothesis_fingerprint"]),
+        failure_class="REJECTED_OVERFIT",
+        parameter_region={"slow": 50, "fast": 10},
+    )
+    assert assessment["same_parameter_region_repeatedly_unstable"] is True
+    assert "DEPRIORITIZE" in assessment["actions"]
+    assert assessment["automatic_research_ban"] is False
+    assert second["failure_record_id"] != first["failure_record_id"]


### PR DESCRIPTION
## Summary
- Add Phase 3 Canonical Failure Memory: append-only rejected-hypothesis records bound to Phase 1 experiment identity and Phase 2 `REJECTED_*` tokens.
- Duplicate detection uses a derived `hypothesis_fingerprint` (identity, hypothesis, parameter region, regime, robustness policy). Duplicates warn/annotate/deprioritize; they never automatic-ban research.
- No runtime, live-config, promotion, order, funding, risk, leverage, or trading authority.

## Test plan
- [x] `pytest tests/experiments/test_canonical_failure_memory_v1.py tests/experiments/test_canonical_experiment_memory_v1.py tests/experiments/test_canonical_experiment_identity_v1.py tests/experiments/test_experiment_identity_manifest_v1.py`
- [x] `ruff check` / `ruff format --check` on the new Python files
- [x] docs token policy preflight vs `origin/main`
- [ ] GitHub required checks on this PR

MERGE=false. Requires separate OWNER_MERGE_GO.


Made with [Cursor](https://cursor.com)