### PR TITLE
research: add canonical champion-challenger v1

### DIFF
--- a/docs/ops/specs/CANONICAL_CHAMPION_CHALLENGER_V1.md
+++ b/docs/ops/specs/CANONICAL_CHAMPION_CHALLENGER_V1.md
@@ -1,0 +1,129 @@
+# Canonical Champion-Challenger v1
+
+Contract for Peak_Trade Phase 6 Champion-Challenger research evaluation.
+
+```text
+SCHEMA_VERSION=canonical_champion_challenger_v1
+CHAMPION_CHALLENGER_DOMAIN=peak_trade.canonical_champion_challenger.v1
+CHAMPION_CHALLENGER_PRESENT=true
+AUTONOMOUS_CHAMPION_SWAP=false
+CHAMPION_CHALLENGER_HAS_RUNTIME_AUTHORITY=false
+CHAMPION_CHALLENGER_CAN_MUTATE_LIVE_CONFIG=false
+CHAMPION_CHALLENGER_CAN_PROMOTE=false
+PROMOTION_AUTHORITY=NONE
+SELF_LEARNING_SELF_AUTHORIZING_SEPARATION=true
+```
+
+Owner:
+
+- `src&#47;experiments&#47;canonical_champion_challenger_v1.py` — evaluate, classify, recommend, evidence
+
+Reuse, do not replace:
+
+```text
+Phase 1  src.experiments.canonical_experiment_identity_v1     REUSE
+Phase 2  src.experiments.canonical_experiment_memory_v1       REUSE experiment_id
+Phase 3  REJECTED_COMPARABILITY                               REUSE
+Phase 4  robustness_suite_version / metric_definitions        REUSE tokens
+Phase 5  src.experiments.canonical_comparison_ssot_v1         REUSE comparability and ranking
+```
+
+```text
+src.governance.promotion_loop.engine                         NOT_APPLICABLE
+src.meta.learning_loop.comparison_ssot_v1                    NOT_APPLICABLE
+src.meta.learning_loop.canary_micro_live_readiness_v1        NOT_APPLICABLE
+src.meta.learning_loop.autonomous_non_live_orchestration_plan_v1  NOT_APPLICABLE
+```
+
+Phase 5 remains the only comparability SSOT. This layer does not re-implement dataset, split, fee, slippage, funding, risk, portfolio, robustness version, metric, time-horizon, or market-universe checks.
+
+## Shape
+
+```text
+Champion
+  ├── Challenger A
+  ├── Challenger B
+  └── Challenger N
+```
+
+Champion and Challenger are Phase-1/2 experiment identities. Complete experiments are not copied.
+
+## Comparability
+
+Every Champion-Challenger pair is evaluated by Phase 5 `build_canonical_comparison_result_v1`. Ranking of the comparable subset uses Phase 5 `rank_comparable_candidates_v1`.
+
+```text
+COMPARABLE => eligible for ranking / classification / research recommendation
+COMPARISON_REJECTED => REJECTED_COMPARABILITY, excluded from ranked_experiment_ids
+```
+
+Incomparable candidates are never silently ranked. `BEST_SHARPE => WINNER` is forbidden.
+
+## Evaluation dispositions
+
+Per comparable Challenger:
+
+```text
+CHALLENGER_RESEARCH_PREFERRED
+CHALLENGER_INFERIOR
+TIE_OR_INCONCLUSIVE
+```
+
+Per incomparable Challenger:
+
+```text
+REJECTED_COMPARABILITY
+```
+
+Overall research recommendation:
+
+```text
+CHALLENGER_RESEARCH_PREFERRED
+CHALLENGER_INFERIOR
+TIE_OR_INCONCLUSIVE
+NO_CLEAR_WINNER
+REJECTED_COMPARABILITY
+```
+
+A Challenger may be `CHALLENGER_RESEARCH_PREFERRED` without replacing the Champion. Output `champion_experiment_id` equals the input Champion id. `autonomous_champion_swap=false`.
+
+## Canonical evidence fields
+
+```text
+champion_experiment_id
+challenger_experiment_ids
+comparison_contract_version
+comparison_ssot_version
+robustness_suite_version
+metric_definitions
+evaluation_policy_version
+pair_results
+challenger_results
+ranked_experiment_ids
+research_recommendation
+champion_state
+evidence_refs
+created_at
+```
+
+Scores are explicit research inputs bound to `metric_definitions`. This phase does not invent a new statistical optimizer.
+
+## What this layer cannot do
+
+```text
+AUTONOMOUS_CHAMPION_SWAP=false
+LEARNING_CAN_WRITE_LIVE_CONFIG=false
+LEARNING_CAN_INCREASE_RISK=false
+LEARNING_CAN_INCREASE_LEVERAGE=false
+LEARNING_CAN_FUND=false
+LEARNING_CAN_SUBMIT_ORDER=false
+LEARNING_CAN_ARM=false
+LEARNING_CAN_ENABLE=false
+LEARNING_CAN_CREATE_CONFIRM_TOKEN=false
+LEARNING_CAN_USE_CONFIRM_TOKEN=false
+LEARNING_CAN_AUTHORIZE_CANARY=false
+LEARNING_CAN_PROMOTE_TO_LIVE=false
+LEARNING_MAY_AUTONOMOUSLY_REPLACE_CORE_LOGIC=false
+```
+
+Phase 6 does not start Phase 7 Reality Gap Store, live, canary, funding, or order submit.

--- a/src/experiments/canonical_champion_challenger_v1.py
+++ b/src/experiments/canonical_champion_challenger_v1.py
@@ -1,0 +1,616 @@
+"""Phase 6 Canonical Champion-Challenger v1 (research evaluation only).
+
+Deterministic Champion versus Challenger evaluation. Comparability is
+delegated entirely to Phase 5 Comparison SSOT. This layer classifies and
+recommends; it does not swap the Champion, mutate runtime, write config,
+promote, fund, or submit orders.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Final, Mapping, Sequence
+
+from src.experiments.canonical_comparison_ssot_v1 import (
+    COMPARISON_CONTRACT_VERSION,
+    CanonicalComparisonRankingRequestV1,
+    CanonicalComparisonRequestV1,
+    ComparisonCandidateV1,
+    ComparisonCompatibilityContractV1,
+    OVERALL_COMPARABLE,
+    RANKING_STATUS_RANKED,
+    SCHEMA_VERSION as COMPARISON_SSOT_VERSION,
+    build_canonical_comparison_result_v1,
+    canonical_record_payload,
+    rank_comparable_candidates_v1,
+)
+from src.experiments.canonical_experiment_identity_v1 import (
+    CanonicalExperimentIdentityError,
+    validate_canonical_experiment_identity_v1,
+)
+from src.experiments.canonical_experiment_memory_v1 import derive_experiment_id_v1
+from src.meta.learning_loop.contract_safety_v1 import (
+    compute_content_sha256,
+    is_valid_sha256_hex,
+)
+
+SCHEMA_VERSION: Final[str] = "canonical_champion_challenger_v1"
+CHAMPION_CHALLENGER_DOMAIN: Final[str] = "peak_trade.canonical_champion_challenger.v1"
+DIGEST_ALGORITHM: Final[str] = "sha256"
+RECORD_COMPLETENESS_COMPLETE: Final[str] = "COMPLETE"
+EVALUATION_POLICY_VERSION: Final[str] = "canonical_champion_challenger_policy_v1"
+SCORE_METRIC: Final[str] = "explicit_research_score"
+
+CHAMPION_CHALLENGER_PRESENT: Final[bool] = True
+AUTONOMOUS_CHAMPION_SWAP: Final[bool] = False
+CHAMPION_CHALLENGER_HAS_RUNTIME_AUTHORITY: Final[bool] = False
+CHAMPION_CHALLENGER_CAN_MUTATE_LIVE_CONFIG: Final[bool] = False
+CHAMPION_CHALLENGER_CAN_WRITE_LIVE_CONFIG: Final[bool] = False
+CHAMPION_CHALLENGER_CAN_PROMOTE: Final[bool] = False
+CHAMPION_CHALLENGER_CAN_PROMOTE_TO_LIVE: Final[bool] = False
+CHAMPION_CHALLENGER_CAN_INCREASE_RISK: Final[bool] = False
+CHAMPION_CHALLENGER_CAN_INCREASE_LEVERAGE: Final[bool] = False
+CHAMPION_CHALLENGER_CAN_FUND: Final[bool] = False
+CHAMPION_CHALLENGER_CAN_SUBMIT_ORDER: Final[bool] = False
+CHAMPION_CHALLENGER_CAN_ARM: Final[bool] = False
+CHAMPION_CHALLENGER_CAN_ENABLE: Final[bool] = False
+CHAMPION_CHALLENGER_CAN_CREATE_CONFIRM_TOKEN: Final[bool] = False
+CHAMPION_CHALLENGER_CAN_USE_CONFIRM_TOKEN: Final[bool] = False
+CHAMPION_CHALLENGER_CAN_AUTHORIZE_CANARY: Final[bool] = False
+LEARNING_MAY_AUTONOMOUSLY_REPLACE_CORE_LOGIC: Final[bool] = False
+SELF_LEARNING_SELF_AUTHORIZING_SEPARATION: Final[bool] = True
+PROMOTION_AUTHORITY: Final[str] = "NONE"
+RUNTIME_AUTHORITY_IMPACT: Final[str] = "NONE"
+
+ROLE_CHALLENGER: Final[str] = "CHALLENGER"
+DISPOSITION_RESEARCH_PREFERRED: Final[str] = "CHALLENGER_RESEARCH_PREFERRED"
+DISPOSITION_INFERIOR: Final[str] = "CHALLENGER_INFERIOR"
+DISPOSITION_TIE: Final[str] = "TIE_OR_INCONCLUSIVE"
+DISPOSITION_NO_CLEAR_WINNER: Final[str] = "NO_CLEAR_WINNER"
+DISPOSITION_REJECTED_COMPARABILITY: Final[str] = "REJECTED_COMPARABILITY"
+EVALUATION_COMPLETE: Final[str] = "EVALUATION_COMPLETE"
+EVALUATION_REJECTED: Final[str] = "EVALUATION_REJECTED"
+
+_CREATED_AT_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$")
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_UNAVAILABLE_TOKENS = frozenset(
+    {
+        "",
+        "unknown",
+        "unavailable",
+        "n/a",
+        "na",
+        "none",
+        "null",
+        "implicit",
+        "default",
+        "compatible",
+    }
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class ChampionChallengerValidationError(ValueError):
+    """Fail-closed Canonical Champion-Challenger v1 validation error."""
+
+
+@dataclass(frozen=True)
+class CanonicalChampionChallengerRequestV1:
+    champion: ComparisonCandidateV1
+    challengers: Sequence[ComparisonCandidateV1]
+    scores: Mapping[str, float]
+    created_at: str
+    evaluation_policy_version: str = EVALUATION_POLICY_VERSION
+    compatibility_contract: ComparisonCompatibilityContractV1 | None = None
+    score_metric: str = SCORE_METRIC
+
+
+def evaluate_canonical_champion_challenger_v1(
+    request: CanonicalChampionChallengerRequestV1,
+) -> Mapping[str, Any]:
+    if request.evaluation_policy_version != EVALUATION_POLICY_VERSION:
+        raise ChampionChallengerValidationError("evaluation_policy_version mismatch")
+    if request.score_metric != SCORE_METRIC:
+        raise ChampionChallengerValidationError("score_metric mismatch")
+    if not request.challengers:
+        raise ChampionChallengerValidationError("at least one challenger is required")
+    created_at = _require_created_at(request.created_at)
+    champion_id = _experiment_id(request.champion)
+    challenger_ids = [_experiment_id(item) for item in request.challengers]
+    if champion_id in challenger_ids:
+        raise ChampionChallengerValidationError("champion cannot also appear as a challenger")
+    if len(set(challenger_ids)) != len(challenger_ids):
+        raise ChampionChallengerValidationError("challenger experiment_id values must be unique")
+    all_ids = [champion_id, *challenger_ids]
+    scores = _canonicalize_scores(request.scores, all_ids)
+    pair_results, comparable_challengers, rejected_challengers = _compare_challengers(
+        champion=request.champion,
+        champion_id=champion_id,
+        challengers=request.challengers,
+        challenger_ids=challenger_ids,
+        created_at=created_at,
+        compatibility_contract=request.compatibility_contract,
+    )
+    ranking_payload, ranked_ids = _rank_comparable_subset(
+        champion=request.champion,
+        champion_id=champion_id,
+        comparable_challengers=comparable_challengers,
+        scores=scores,
+        created_at=created_at,
+        compatibility_contract=request.compatibility_contract,
+    )
+    challenger_results = _classify_challengers(
+        champion_id=champion_id,
+        scores=scores,
+        comparable_challengers=comparable_challengers,
+        rejected_challengers=rejected_challengers,
+    )
+    research_recommendation = _overall_recommendation(challenger_results)
+    overall_status = (
+        EVALUATION_REJECTED
+        if research_recommendation == DISPOSITION_REJECTED_COMPARABILITY
+        else EVALUATION_COMPLETE
+    )
+    champion_state = {
+        "champion_experiment_id": champion_id,
+        "mutated": False,
+        "swapped": False,
+    }
+    evidence_refs = _evidence_refs(champion_id, pair_results)
+    evaluation_identity = derive_champion_challenger_identity_v1(
+        champion_experiment_id=champion_id,
+        challenger_experiment_ids=challenger_ids,
+        pair_results=pair_results,
+        challenger_results=challenger_results,
+        ranked_experiment_ids=ranked_ids,
+        research_recommendation=research_recommendation,
+    )
+    record = {
+        "autonomous_champion_swap": AUTONOMOUS_CHAMPION_SWAP,
+        "challenger_experiment_ids": list(challenger_ids),
+        "challenger_results": challenger_results,
+        "champion_challenger_can_arm": CHAMPION_CHALLENGER_CAN_ARM,
+        "champion_challenger_can_authorize_canary": CHAMPION_CHALLENGER_CAN_AUTHORIZE_CANARY,
+        "champion_challenger_can_create_confirm_token": (
+            CHAMPION_CHALLENGER_CAN_CREATE_CONFIRM_TOKEN
+        ),
+        "champion_challenger_can_enable": CHAMPION_CHALLENGER_CAN_ENABLE,
+        "champion_challenger_can_fund": CHAMPION_CHALLENGER_CAN_FUND,
+        "champion_challenger_can_increase_leverage": CHAMPION_CHALLENGER_CAN_INCREASE_LEVERAGE,
+        "champion_challenger_can_increase_risk": CHAMPION_CHALLENGER_CAN_INCREASE_RISK,
+        "champion_challenger_can_mutate_live_config": CHAMPION_CHALLENGER_CAN_MUTATE_LIVE_CONFIG,
+        "champion_challenger_can_promote": CHAMPION_CHALLENGER_CAN_PROMOTE,
+        "champion_challenger_can_promote_to_live": CHAMPION_CHALLENGER_CAN_PROMOTE_TO_LIVE,
+        "champion_challenger_can_submit_order": CHAMPION_CHALLENGER_CAN_SUBMIT_ORDER,
+        "champion_challenger_can_use_confirm_token": CHAMPION_CHALLENGER_CAN_USE_CONFIRM_TOKEN,
+        "champion_challenger_can_write_live_config": CHAMPION_CHALLENGER_CAN_WRITE_LIVE_CONFIG,
+        "champion_challenger_domain": CHAMPION_CHALLENGER_DOMAIN,
+        "champion_challenger_has_runtime_authority": CHAMPION_CHALLENGER_HAS_RUNTIME_AUTHORITY,
+        "champion_challenger_present": CHAMPION_CHALLENGER_PRESENT,
+        "champion_experiment_id": champion_id,
+        "champion_state": champion_state,
+        "comparable_challenger_experiment_ids": [
+            item["experiment_id"] for item in comparable_challengers
+        ],
+        "comparison_contract_version": COMPARISON_CONTRACT_VERSION,
+        "comparison_ssot_version": COMPARISON_SSOT_VERSION,
+        "completeness": RECORD_COMPLETENESS_COMPLETE,
+        "created_at": created_at,
+        "digest_algorithm": DIGEST_ALGORITHM,
+        "evaluation_identity": evaluation_identity,
+        "evaluation_policy_version": EVALUATION_POLICY_VERSION,
+        "evidence_refs": evidence_refs,
+        "learning_may_autonomously_replace_core_logic": (
+            LEARNING_MAY_AUTONOMOUSLY_REPLACE_CORE_LOGIC
+        ),
+        "metric_definitions": _optional_token(
+            "metric_definitions", request.champion.metric_definitions
+        ),
+        "overall_status": overall_status,
+        "pair_results": pair_results,
+        "promotion_authority": PROMOTION_AUTHORITY,
+        "ranked_experiment_ids": ranked_ids,
+        "ranking": ranking_payload,
+        "research_recommendation": research_recommendation,
+        "robustness_suite_version": _optional_token(
+            "robustness_suite_version", request.champion.robustness_suite_version
+        ),
+        "runtime_authority_impact": RUNTIME_AUTHORITY_IMPACT,
+        "schema_version": SCHEMA_VERSION,
+        "score_metric": SCORE_METRIC,
+        "scores": scores,
+        "self_learning_self_authorizing_separation": SELF_LEARNING_SELF_AUTHORIZING_SEPARATION,
+    }
+    record["integrity"] = {
+        "content_sha256": compute_content_sha256(
+            {key: value for key, value in record.items() if key != "integrity"}
+        )
+    }
+    validate_canonical_champion_challenger_result_v1(record)
+    frozen = _freeze(record)
+    _LOGGER.info(
+        "canonical_champion_challenger_v1 built identity=%s recommendation=%s",
+        evaluation_identity,
+        research_recommendation,
+    )
+    return frozen
+
+
+def derive_champion_challenger_identity_v1(
+    *,
+    champion_experiment_id: str,
+    challenger_experiment_ids: Sequence[str],
+    pair_results: Sequence[Mapping[str, Any]],
+    challenger_results: Sequence[Mapping[str, Any]],
+    ranked_experiment_ids: Sequence[str],
+    research_recommendation: str,
+) -> str:
+    envelope = {
+        "digest_algorithm": DIGEST_ALGORITHM,
+        "digest_domain": f"{CHAMPION_CHALLENGER_DOMAIN}.evaluation_identity",
+        "payload": {
+            "challenger_experiment_ids": list(challenger_experiment_ids),
+            "challenger_results": list(challenger_results),
+            "champion_experiment_id": champion_experiment_id,
+            "comparison_ssot_version": COMPARISON_SSOT_VERSION,
+            "evaluation_policy_version": EVALUATION_POLICY_VERSION,
+            "pair_results": list(pair_results),
+            "ranked_experiment_ids": list(ranked_experiment_ids),
+            "research_recommendation": research_recommendation,
+        },
+        "schema_version": SCHEMA_VERSION,
+    }
+    return compute_content_sha256(envelope)
+
+
+def validate_canonical_champion_challenger_result_v1(record: Mapping[str, Any]) -> None:
+    if not isinstance(record, Mapping):
+        raise ChampionChallengerValidationError("evaluation result must be a mapping")
+    payload = _plain_mapping(record)
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise ChampionChallengerValidationError("schema_version mismatch")
+    if payload.get("champion_challenger_domain") != CHAMPION_CHALLENGER_DOMAIN:
+        raise ChampionChallengerValidationError("champion_challenger_domain mismatch")
+    if payload.get("comparison_ssot_version") != COMPARISON_SSOT_VERSION:
+        raise ChampionChallengerValidationError("comparison_ssot_version mismatch")
+    if payload.get("comparison_contract_version") != COMPARISON_CONTRACT_VERSION:
+        raise ChampionChallengerValidationError("comparison_contract_version mismatch")
+    if payload.get("evaluation_policy_version") != EVALUATION_POLICY_VERSION:
+        raise ChampionChallengerValidationError("evaluation_policy_version mismatch")
+    if payload.get("completeness") != RECORD_COMPLETENESS_COMPLETE:
+        raise ChampionChallengerValidationError("non-COMPLETE evaluation results are forbidden")
+    if payload.get("champion_challenger_present") is not True:
+        raise ChampionChallengerValidationError("champion_challenger_present must be true")
+    if payload.get("autonomous_champion_swap") is not False:
+        raise ChampionChallengerValidationError("autonomous_champion_swap must be false")
+    if payload.get("champion_challenger_has_runtime_authority") is not False:
+        raise ChampionChallengerValidationError(
+            "champion_challenger_has_runtime_authority must be false"
+        )
+    if payload.get("champion_challenger_can_mutate_live_config") is not False:
+        raise ChampionChallengerValidationError(
+            "champion_challenger_can_mutate_live_config must be false"
+        )
+    if payload.get("champion_challenger_can_promote") is not False:
+        raise ChampionChallengerValidationError("champion_challenger_can_promote must be false")
+    if payload.get("promotion_authority") != PROMOTION_AUTHORITY:
+        raise ChampionChallengerValidationError("promotion_authority must be NONE")
+    champion_id = _require_sha256("champion_experiment_id", payload.get("champion_experiment_id"))
+    champion_state = payload.get("champion_state")
+    if not isinstance(champion_state, Mapping):
+        raise ChampionChallengerValidationError("champion_state must be a mapping")
+    if champion_state.get("champion_experiment_id") != champion_id:
+        raise ChampionChallengerValidationError(
+            "champion_state does not preserve champion identity"
+        )
+    if champion_state.get("mutated") is not False or champion_state.get("swapped") is not False:
+        raise ChampionChallengerValidationError("champion_state mutation or swap is forbidden")
+    ranked_ids = payload.get("ranked_experiment_ids")
+    rejected_ids = {
+        item["challenger_experiment_id"]
+        for item in payload.get("challenger_results", [])
+        if isinstance(item, Mapping)
+        and item.get("disposition") == DISPOSITION_REJECTED_COMPARABILITY
+    }
+    if not isinstance(ranked_ids, list):
+        raise ChampionChallengerValidationError("ranked_experiment_ids must be a list")
+    if rejected_ids.intersection(ranked_ids):
+        raise ChampionChallengerValidationError(
+            "incomparable challengers cannot appear in ranked_experiment_ids"
+        )
+    expected_integrity = compute_content_sha256(
+        {key: value for key, value in payload.items() if key != "integrity"}
+    )
+    integrity = payload.get("integrity")
+    if not isinstance(integrity, Mapping) or integrity.get("content_sha256") != expected_integrity:
+        raise ChampionChallengerValidationError("integrity.content_sha256 mismatch")
+
+
+def canonical_record_payload_v1(record: Mapping[str, Any]) -> dict[str, Any]:
+    return _plain_mapping(record)
+
+
+def _compare_challengers(
+    *,
+    champion: ComparisonCandidateV1,
+    champion_id: str,
+    challengers: Sequence[ComparisonCandidateV1],
+    challenger_ids: Sequence[str],
+    created_at: str,
+    compatibility_contract: ComparisonCompatibilityContractV1 | None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    pair_results: list[dict[str, Any]] = []
+    comparable: list[dict[str, Any]] = []
+    rejected: list[dict[str, Any]] = []
+    for challenger, challenger_id in zip(challengers, challenger_ids, strict=True):
+        pair = canonical_record_payload(
+            build_canonical_comparison_result_v1(
+                CanonicalComparisonRequestV1(
+                    left=champion,
+                    right=challenger,
+                    created_at=created_at,
+                    compatibility_contract=compatibility_contract,
+                )
+            )
+        )
+        summary = {
+            "challenger_experiment_id": challenger_id,
+            "champion_experiment_id": champion_id,
+            "comparison_identity": pair["comparison_identity"],
+            "overall_comparability": pair["overall_comparability"],
+            "rejection_reasons": list(pair["rejection_reasons"]),
+        }
+        pair_results.append(summary)
+        if pair["overall_comparability"] == OVERALL_COMPARABLE:
+            comparable.append({"candidate": challenger, "experiment_id": challenger_id})
+        else:
+            rejected.append(
+                {
+                    "experiment_id": challenger_id,
+                    "rejection_reasons": list(pair["rejection_reasons"]),
+                }
+            )
+    return pair_results, comparable, rejected
+
+
+def _rank_comparable_subset(
+    *,
+    champion: ComparisonCandidateV1,
+    champion_id: str,
+    comparable_challengers: Sequence[Mapping[str, Any]],
+    scores: Mapping[str, float],
+    created_at: str,
+    compatibility_contract: ComparisonCompatibilityContractV1 | None,
+) -> tuple[Mapping[str, Any] | None, list[str]]:
+    if not comparable_challengers:
+        return None, []
+    candidates = [champion, *[item["candidate"] for item in comparable_challengers]]
+    subset_ids = [champion_id, *[item["experiment_id"] for item in comparable_challengers]]
+    ranking = canonical_record_payload(
+        rank_comparable_candidates_v1(
+            CanonicalComparisonRankingRequestV1(
+                candidates=candidates,
+                scores={experiment_id: scores[experiment_id] for experiment_id in subset_ids},
+                created_at=created_at,
+                compatibility_contract=compatibility_contract,
+                score_metric="explicit_score",
+            )
+        )
+    )
+    summary = {
+        "ranking_identity": ranking["ranking_identity"],
+        "ranking_status": ranking["ranking_status"],
+        "ranked_experiment_ids": list(ranking["ranked_experiment_ids"]),
+        "rejection_reasons": list(ranking["rejection_reasons"]),
+    }
+    if ranking["ranking_status"] != RANKING_STATUS_RANKED:
+        return summary, []
+    return summary, list(ranking["ranked_experiment_ids"])
+
+
+def _classify_challengers(
+    *,
+    champion_id: str,
+    scores: Mapping[str, float],
+    comparable_challengers: Sequence[Mapping[str, Any]],
+    rejected_challengers: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    champion_score = scores[champion_id]
+    results: list[dict[str, Any]] = []
+    for item in comparable_challengers:
+        experiment_id = str(item["experiment_id"])
+        score = scores[experiment_id]
+        if score > champion_score:
+            disposition = DISPOSITION_RESEARCH_PREFERRED
+        elif score < champion_score:
+            disposition = DISPOSITION_INFERIOR
+        else:
+            disposition = DISPOSITION_TIE
+        results.append(
+            {
+                "challenger_experiment_id": experiment_id,
+                "disposition": disposition,
+                "role": ROLE_CHALLENGER,
+                "score": score,
+            }
+        )
+    for item in rejected_challengers:
+        results.append(
+            {
+                "challenger_experiment_id": str(item["experiment_id"]),
+                "disposition": DISPOSITION_REJECTED_COMPARABILITY,
+                "rejection_reasons": list(item["rejection_reasons"]),
+                "role": ROLE_CHALLENGER,
+                "score": scores[str(item["experiment_id"])],
+            }
+        )
+    results.sort(key=lambda item: item["challenger_experiment_id"])
+    return results
+
+
+def _overall_recommendation(challenger_results: Sequence[Mapping[str, Any]]) -> str:
+    comparable = [
+        item
+        for item in challenger_results
+        if item["disposition"] != DISPOSITION_REJECTED_COMPARABILITY
+    ]
+    if not comparable:
+        return DISPOSITION_REJECTED_COMPARABILITY
+    preferred = [
+        item for item in comparable if item["disposition"] == DISPOSITION_RESEARCH_PREFERRED
+    ]
+    if preferred:
+        best_score = max(float(item["score"]) for item in preferred)
+        leaders = [item for item in preferred if float(item["score"]) == best_score]
+        if len(leaders) == 1:
+            return DISPOSITION_RESEARCH_PREFERRED
+        return DISPOSITION_NO_CLEAR_WINNER
+    if all(item["disposition"] == DISPOSITION_INFERIOR for item in comparable):
+        return DISPOSITION_INFERIOR
+    if all(item["disposition"] == DISPOSITION_TIE for item in comparable):
+        return DISPOSITION_TIE
+    return DISPOSITION_NO_CLEAR_WINNER
+
+
+def _evidence_refs(
+    champion_id: str,
+    pair_results: Sequence[Mapping[str, Any]],
+) -> list[dict[str, str]]:
+    refs = [
+        {
+            "digest": champion_id,
+            "kind": "EXPERIMENT_RECORD",
+            "ref": champion_id,
+        }
+    ]
+    for item in pair_results:
+        refs.append(
+            {
+                "digest": str(item["comparison_identity"]),
+                "kind": "COMPARISON_RESULT",
+                "ref": str(item["challenger_experiment_id"]),
+            }
+        )
+    unique: dict[tuple[str, str, str], dict[str, str]] = {}
+    for item in refs:
+        unique[(item["kind"], item["ref"], item["digest"])] = item
+    return [unique[key] for key in sorted(unique)]
+
+
+def _experiment_id(candidate: ComparisonCandidateV1) -> str:
+    identity = candidate.experiment_identity
+    if not isinstance(identity, Mapping):
+        raise ChampionChallengerValidationError("experiment_identity present and valid is required")
+    payload = _plain_mapping(identity)
+    try:
+        validate_canonical_experiment_identity_v1(payload)
+    except CanonicalExperimentIdentityError as exc:
+        raise ChampionChallengerValidationError(
+            f"experiment_identity is not a valid Phase 1 Canonical Experiment Identity: {exc}"
+        ) from exc
+    experiment_id = derive_experiment_id_v1(str(payload["identity_digest"]))
+    if candidate.experiment_id is not None:
+        provided = _require_sha256("experiment_id", candidate.experiment_id)
+        if provided != experiment_id:
+            raise ChampionChallengerValidationError(
+                "experiment_id is not bound to the Canonical Experiment Identity digest"
+            )
+    return experiment_id
+
+
+def _canonicalize_scores(
+    scores: Mapping[str, float],
+    experiment_ids: Sequence[str],
+) -> dict[str, float]:
+    if not isinstance(scores, Mapping):
+        raise ChampionChallengerValidationError("scores must be a mapping")
+    canonical: dict[str, float] = {}
+    for experiment_id in experiment_ids:
+        if experiment_id not in scores:
+            raise ChampionChallengerValidationError(f"scores missing experiment_id {experiment_id}")
+        value = scores[experiment_id]
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ChampionChallengerValidationError(
+                f"scores[{experiment_id}] must be a finite number"
+            )
+        number = float(value)
+        if not math.isfinite(number):
+            raise ChampionChallengerValidationError(f"scores[{experiment_id}] must be finite")
+        canonical[experiment_id] = number
+    extra = set(str(key) for key in scores.keys()) - set(experiment_ids)
+    if extra:
+        raise ChampionChallengerValidationError(
+            f"scores contain unknown experiment_id values: {sorted(extra)}"
+        )
+    return canonical
+
+
+def _optional_token(field_name: str, value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        return None
+    if value.strip().lower() in _UNAVAILABLE_TOKENS:
+        return None
+    if not _TOKEN_RE.fullmatch(value):
+        raise ChampionChallengerValidationError(f"{field_name} is missing or malformed")
+    return value
+
+
+def _require_sha256(field_name: str, value: Any) -> str:
+    if not isinstance(value, str) or not is_valid_sha256_hex(value):
+        raise ChampionChallengerValidationError(
+            f"{field_name} must be a lowercase sha256 hex digest"
+        )
+    return value
+
+
+def _require_created_at(value: Any) -> str:
+    if not isinstance(value, str) or not _CREATED_AT_RE.fullmatch(value):
+        raise ChampionChallengerValidationError(
+            "created_at must be an explicit UTC timestamp ending with Z"
+        )
+    return value
+
+
+def _freeze(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({str(key): _freeze(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return [_freeze(item) for item in value]
+    return value
+
+
+def _plain_mapping(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _plain_mapping(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_plain_mapping(item) for item in value]
+    return value
+
+
+__all__ = [
+    "AUTONOMOUS_CHAMPION_SWAP",
+    "CHAMPION_CHALLENGER_CAN_PROMOTE",
+    "CHAMPION_CHALLENGER_HAS_RUNTIME_AUTHORITY",
+    "CHAMPION_CHALLENGER_PRESENT",
+    "CanonicalChampionChallengerRequestV1",
+    "ChampionChallengerValidationError",
+    "DISPOSITION_INFERIOR",
+    "DISPOSITION_NO_CLEAR_WINNER",
+    "DISPOSITION_REJECTED_COMPARABILITY",
+    "DISPOSITION_RESEARCH_PREFERRED",
+    "DISPOSITION_TIE",
+    "EVALUATION_POLICY_VERSION",
+    "PROMOTION_AUTHORITY",
+    "SCHEMA_VERSION",
+    "canonical_record_payload_v1",
+    "derive_champion_challenger_identity_v1",
+    "evaluate_canonical_champion_challenger_v1",
+    "validate_canonical_champion_challenger_result_v1",
+]

--- a/tests/experiments/test_canonical_champion_challenger_v1.py
+++ b/tests/experiments/test_canonical_champion_challenger_v1.py
@@ -1,0 +1,322 @@
+"""Phase 6 Canonical Champion-Challenger v1 contract tests."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import inspect
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping
+
+import pytest
+
+from src.experiments.canonical_champion_challenger_v1 import (
+    AUTONOMOUS_CHAMPION_SWAP,
+    CHAMPION_CHALLENGER_CAN_PROMOTE,
+    CHAMPION_CHALLENGER_HAS_RUNTIME_AUTHORITY,
+    CHAMPION_CHALLENGER_PRESENT,
+    CanonicalChampionChallengerRequestV1,
+    DISPOSITION_INFERIOR,
+    DISPOSITION_REJECTED_COMPARABILITY,
+    DISPOSITION_RESEARCH_PREFERRED,
+    DISPOSITION_TIE,
+    PROMOTION_AUTHORITY,
+    canonical_record_payload_v1,
+    evaluate_canonical_champion_challenger_v1,
+)
+from src.experiments.canonical_comparison_ssot_v1 import ComparisonCandidateV1
+from src.experiments.canonical_experiment_identity_v1 import (
+    CanonicalExperimentIdentityRequestV1,
+    WORKING_TREE_CLEAN,
+    build_canonical_experiment_identity_v1,
+)
+from src.experiments.canonical_experiment_memory_v1 import derive_experiment_id_v1
+from src.meta.learning_loop.contract_safety_v1 import deterministic_json_dumps
+
+ROBUSTNESS_SUITE_VERSION = "canonical_robustness_suite_v1"
+METRIC_DEFINITION_VERSION = "canonical_robustness_metrics_v1"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "src" / "experiments" / "canonical_champion_challenger_v1.py"
+_GIT_SHA = "e763bf1bf133afab1c3850a6bbaafde6f83e39d2"
+_CREATED_AT = "2026-08-17T22:00:00Z"
+_TIME_HORIZON = {"end": "2024-12-31T00:00:00Z", "start": "2020-01-01T00:00:00Z"}
+_MARKET_UNIVERSE = ("BTC-USDT-SWAP", "ETH-USDT-SWAP")
+
+
+def _digest(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _identity(**overrides: Any) -> Mapping[str, Any]:
+    payload: dict[str, Any] = {
+        "git_sha": _GIT_SHA,
+        "working_tree_status": WORKING_TREE_CLEAN,
+        "strategy_identity": "ma_crossover.v1",
+        "strategy_params": {"slow": 50, "fast": 10},
+        "dataset_digest": _digest("dataset"),
+        "feature_pipeline_digest": _digest("features"),
+        "fee_model_digest": _digest("fee"),
+        "slippage_model_digest": _digest("slippage"),
+        "funding_model_digest": _digest("funding"),
+        "risk_policy_digest": _digest("risk"),
+        "portfolio_digest": _digest("portfolio"),
+        "split_policy_digest": _digest("split"),
+        "market_context_contract_digest": _digest("market-context"),
+        "bull_bear_logic_digest": _digest("bull-bear"),
+        "state_switch_logic_digest": _digest("state-switch"),
+        "survival_logic_digest": _digest("survival"),
+        "suitability_logic_digest": _digest("suitability"),
+        "double_play_logic_digest": _digest("double-play"),
+        "entry_position_exit_logic_digest": _digest("entry-position-exit"),
+        "seed": 7,
+        "environment": {
+            "python_version": "3.11.15",
+            "python_implementation": "CPython",
+        },
+        "parent_lineage_ref": None,
+        "dirty_paths_digest": None,
+    }
+    payload.update(overrides)
+    return build_canonical_experiment_identity_v1(CanonicalExperimentIdentityRequestV1(**payload))
+
+
+def _candidate(
+    identity: Mapping[str, Any] | None = None, **overrides: Any
+) -> ComparisonCandidateV1:
+    payload: dict[str, Any] = {
+        "experiment_identity": identity or _identity(),
+        "robustness_suite_version": ROBUSTNESS_SUITE_VERSION,
+        "metric_definitions": METRIC_DEFINITION_VERSION,
+        "time_horizon": dict(_TIME_HORIZON),
+        "market_universe": list(_MARKET_UNIVERSE),
+        "experiment_id": None,
+        "evidence_refs": (),
+    }
+    payload.update(overrides)
+    return ComparisonCandidateV1(**payload)
+
+
+def _experiment_id(identity: Mapping[str, Any] | None = None, **overrides: Any) -> str:
+    record = identity or _identity(**overrides)
+    return derive_experiment_id_v1(str(record["identity_digest"]))
+
+
+def _evaluate(
+    champion: ComparisonCandidateV1 | None = None,
+    challengers: tuple[ComparisonCandidateV1, ...] | None = None,
+    scores: Mapping[str, float] | None = None,
+) -> Mapping[str, Any]:
+    champion = champion or _candidate()
+    if challengers is None:
+        challengers = (_candidate(_identity(seed=11)),)
+    if scores is None:
+        scores = {
+            _experiment_id(): 1.0,
+            _experiment_id(_identity(seed=11)): 1.2,
+        }
+    return evaluate_canonical_champion_challenger_v1(
+        CanonicalChampionChallengerRequestV1(
+            champion=champion,
+            challengers=challengers,
+            scores=scores,
+            created_at=_CREATED_AT,
+        )
+    )
+
+
+def _disposition_by_id(result: Mapping[str, Any]) -> dict[str, str]:
+    return {
+        item["challenger_experiment_id"]: item["disposition"]
+        for item in result["challenger_results"]
+    }
+
+
+def test_champion_and_comparable_challenger_can_be_evaluated() -> None:
+    result = _evaluate()
+    champion_id = _experiment_id()
+    challenger_id = _experiment_id(_identity(seed=11))
+    assert result["overall_status"] == "EVALUATION_COMPLETE"
+    assert result["champion_experiment_id"] == champion_id
+    assert result["challenger_experiment_ids"] == [challenger_id]
+    assert champion_id in result["ranked_experiment_ids"]
+    assert challenger_id in result["ranked_experiment_ids"]
+    assert result["comparison_ssot_version"] == "canonical_comparison_ssot_v1"
+
+
+def test_multiple_comparable_challengers_are_deterministic() -> None:
+    challengers = (
+        _candidate(_identity(seed=11)),
+        _candidate(_identity(seed=13)),
+    )
+    scores = {
+        _experiment_id(): 1.0,
+        _experiment_id(_identity(seed=11)): 0.4,
+        _experiment_id(_identity(seed=13)): 0.7,
+    }
+    first = canonical_record_payload_v1(_evaluate(challengers=challengers, scores=scores))
+    second = canonical_record_payload_v1(_evaluate(challengers=challengers, scores=scores))
+    assert first == second
+    assert first["research_recommendation"] == DISPOSITION_INFERIOR
+    assert set(first["ranked_experiment_ids"]) == {
+        _experiment_id(),
+        _experiment_id(_identity(seed=11)),
+        _experiment_id(_identity(seed=13)),
+    }
+
+
+def test_identical_inputs_yield_deterministic_output() -> None:
+    first = canonical_record_payload_v1(_evaluate())
+    second = canonical_record_payload_v1(_evaluate())
+    assert deterministic_json_dumps(first) == deterministic_json_dumps(second)
+
+
+def test_incomparable_challenger_is_fail_closed_and_not_ranked() -> None:
+    mismatched = _candidate(_identity(seed=11, dataset_digest=_digest("dataset-b")))
+    result = _evaluate(
+        challengers=(mismatched,),
+        scores={
+            _experiment_id(): 1.0,
+            _experiment_id(_identity(seed=11, dataset_digest=_digest("dataset-b"))): 9.9,
+        },
+    )
+    challenger_id = _experiment_id(_identity(seed=11, dataset_digest=_digest("dataset-b")))
+    assert result["research_recommendation"] == DISPOSITION_REJECTED_COMPARABILITY
+    assert result["ranked_experiment_ids"] == []
+    assert _disposition_by_id(result)[challenger_id] == DISPOSITION_REJECTED_COMPARABILITY
+    assert result["overall_status"] == "EVALUATION_REJECTED"
+
+
+def test_mixed_set_does_not_silently_rank_incomparable_challenger() -> None:
+    comparable = _candidate(_identity(seed=11))
+    incomparable = _candidate(_identity(seed=13, dataset_digest=_digest("dataset-b")))
+    comparable_id = _experiment_id(_identity(seed=11))
+    incomparable_id = _experiment_id(_identity(seed=13, dataset_digest=_digest("dataset-b")))
+    champion_id = _experiment_id()
+    result = _evaluate(
+        challengers=(comparable, incomparable),
+        scores={champion_id: 1.0, comparable_id: 1.4, incomparable_id: 9.9},
+    )
+    assert incomparable_id not in result["ranked_experiment_ids"]
+    assert comparable_id in result["ranked_experiment_ids"]
+    assert champion_id in result["ranked_experiment_ids"]
+    assert _disposition_by_id(result)[incomparable_id] == DISPOSITION_REJECTED_COMPARABILITY
+    assert _disposition_by_id(result)[comparable_id] == DISPOSITION_RESEARCH_PREFERRED
+    assert result["research_recommendation"] == DISPOSITION_RESEARCH_PREFERRED
+
+
+def test_robustness_and_metric_mismatch_is_rejected_by_comparison_ssot() -> None:
+    robustness_mismatch = _candidate(
+        _identity(seed=11), robustness_suite_version="canonical_robustness_suite_v0"
+    )
+    metric_mismatch = _candidate(_identity(seed=13), metric_definitions="other_metrics_v1")
+    robustness_id = _experiment_id(_identity(seed=11))
+    metric_id = _experiment_id(_identity(seed=13))
+    robustness_result = _evaluate(
+        challengers=(robustness_mismatch,),
+        scores={_experiment_id(): 1.0, robustness_id: 2.0},
+    )
+    metric_result = _evaluate(
+        challengers=(metric_mismatch,),
+        scores={_experiment_id(): 1.0, metric_id: 2.0},
+    )
+    assert _disposition_by_id(robustness_result)[robustness_id] == (
+        DISPOSITION_REJECTED_COMPARABILITY
+    )
+    assert (
+        "robustness_suite_version:MISMATCH"
+        in robustness_result["pair_results"][0]["rejection_reasons"]
+    )
+    assert _disposition_by_id(metric_result)[metric_id] == DISPOSITION_REJECTED_COMPARABILITY
+    assert "metric_definitions:MISMATCH" in metric_result["pair_results"][0]["rejection_reasons"]
+    assert robustness_result["ranked_experiment_ids"] == []
+    assert metric_result["ranked_experiment_ids"] == []
+
+
+def test_challenger_can_receive_research_recommendation() -> None:
+    result = _evaluate()
+    challenger_id = _experiment_id(_identity(seed=11))
+    assert _disposition_by_id(result)[challenger_id] == DISPOSITION_RESEARCH_PREFERRED
+    assert result["research_recommendation"] == DISPOSITION_RESEARCH_PREFERRED
+
+
+def test_research_recommendation_does_not_mutate_champion_state() -> None:
+    champion_id = _experiment_id()
+    result = _evaluate()
+    assert result["champion_experiment_id"] == champion_id
+    assert result["champion_state"]["champion_experiment_id"] == champion_id
+    assert result["champion_state"]["mutated"] is False
+    assert result["champion_state"]["swapped"] is False
+    assert result["autonomous_champion_swap"] is False
+    assert AUTONOMOUS_CHAMPION_SWAP is False
+
+
+def test_tie_is_inconclusive_not_a_winner() -> None:
+    challenger_id = _experiment_id(_identity(seed=11))
+    result = _evaluate(scores={_experiment_id(): 1.1, challenger_id: 1.1})
+    assert _disposition_by_id(result)[challenger_id] == DISPOSITION_TIE
+    assert result["research_recommendation"] == DISPOSITION_TIE
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    assert "BEST_SHARPE" not in source
+    assert "BEST_SHARPE => WINNER" not in source
+
+
+def test_no_runtime_live_config_promotion_or_authority_paths() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+    forbidden_imports = {
+        "src.core.peak_config",
+        "src.governance.promotion_loop",
+        "src.governance.promotion_loop.engine",
+        "src.execution",
+        "scripts.run_learning_apply_cycle",
+        "src.live",
+        "src.trading",
+        "src.trading.master_v2",
+        "src.risk",
+        "src.experiments.canonical_robustness_suite_v1",
+        "src.meta.learning_loop.comparison_ssot_v1",
+        "src.meta.learning_loop.bridge",
+        "src.meta.learning_loop.emitter",
+        "src.meta.learning_loop.canary_micro_live_readiness_v1",
+    }
+    assert forbidden_imports.isdisjoint(imported)
+    for token in (
+        "config/live_overrides",
+        "config/auto/",
+        "load_config_with_live_overrides",
+        "submit_order(",
+        "apply_proposals_to_live_overrides",
+        "write_live_config(",
+        "LIVE_AUTHORIZED",
+        "TESTNET_AUTHORIZED",
+        "FUNDING_AUTHORIZED",
+        "promote_to_live(",
+        "create_confirm_token(",
+        "use_confirm_token(",
+    ):
+        assert token not in source
+    result = _evaluate()
+    assert isinstance(result, MappingProxyType)
+    with pytest.raises(TypeError):
+        result["research_recommendation"] = DISPOSITION_RESEARCH_PREFERRED  # type: ignore[index]
+    assert CHAMPION_CHALLENGER_PRESENT is True
+    assert CHAMPION_CHALLENGER_HAS_RUNTIME_AUTHORITY is False
+    assert CHAMPION_CHALLENGER_CAN_PROMOTE is False
+    assert PROMOTION_AUTHORITY == "NONE"
+    assert result["champion_challenger_can_mutate_live_config"] is False
+    assert result["champion_challenger_can_submit_order"] is False
+    assert result["champion_challenger_can_fund"] is False
+    assert result["champion_challenger_can_increase_risk"] is False
+    assert result["champion_challenger_can_increase_leverage"] is False
+    assert result["champion_challenger_can_authorize_canary"] is False
+    assert result["champion_challenger_can_promote_to_live"] is False
+    assert "apply_proposals_to_live_overrides" not in inspect.getsource(
+        evaluate_canonical_champion_challenger_v1
+    )


### PR DESCRIPTION
## Summary
- Adds the Phase 6 Canonical Champion-Challenger research contract. Champion and Challengers are Phase-1/2 experiment identities; comparability and subset ranking are delegated to the Phase 5 Comparison SSOT.
- Incomparable Challengers receive `REJECTED_COMPARABILITY` and are excluded from ranking. A Challenger may be `CHALLENGER_RESEARCH_PREFERRED` without swapping the Champion. No live-config, promotion-apply, risk, leverage, funding, order, canary, or authority-surface change.
- Does not implement Phase 7 Reality Gap Store.

## Test plan
- [x] `uv run python -m pytest tests/experiments/test_canonical_champion_challenger_v1.py -q`
- [x] Phase 1–5 regression: identity, memory, failure memory, robustness, comparison SSOT
- [x] Selector `PR_BOUNDED_FULL` path-equivalent targets (729 passed)
- [x] `ruff format --check` / `ruff check` on touched Python
- [x] Docs token policy + docs reference targets on the new spec
- [ ] GitHub required checks on this PR
- [ ] Do not merge without separate `OWNER_MERGE_GO`


Made with [Cursor](https://cursor.com)