### PR TITLE
research: add canonical reality-gap store v1

### DIFF
--- a/docs/ops/specs/CANONICAL_REALITY_GAP_STORE_V1.md
+++ b/docs/ops/specs/CANONICAL_REALITY_GAP_STORE_V1.md
@@ -1,0 +1,131 @@
+# Canonical Reality Gap Store v1
+
+Contract for Peak_Trade Phase 7 Reality Gap Store.
+
+```text
+SCHEMA_VERSION=canonical_reality_gap_store_v1
+REALITY_GAP_DOMAIN=peak_trade.canonical_reality_gap_store.v1
+REALITY_GAP_STORE_PRESENT=true
+REALITY_GAP_STORE_HAS_RUNTIME_AUTHORITY=false
+REALITY_GAP_CAN_MUTATE_LIVE_CONFIG=false
+REALITY_GAP_CAN_PROMOTE=false
+PROMOTION_AUTHORITY=NONE
+OBSERVED_SURFACE_IS_NOT_AUTHORIZATION=true
+SELF_LEARNING_SELF_AUTHORIZING_SEPARATION=true
+```
+
+Owners:
+
+- `src&#47;experiments&#47;canonical_reality_gap_store_v1.py` — schema, gap evaluation, evidence
+- `src&#47;experiments&#47;canonical_reality_gap_store_persist_v1.py` — append-only file persist and read
+
+Reuse, do not replace:
+
+```text
+Phase 1  src.experiments.canonical_experiment_identity_v1     REUSE
+Phase 2  src.experiments.canonical_experiment_memory_v1       REUSE experiment_id and REJECTED_REALITY_GAP
+Phase 3  src.experiments.canonical_failure_memory_v1          REUSE REALITY_GAP_GATE mapping
+Phase 4  metric_definitions                                   REUSE token
+Phase 5  comparison SSOT                                      NOT_APPLICABLE
+Phase 6  champion-challenger                                  NOT_APPLICABLE
+```
+
+```text
+src.meta.learning_loop.runtime_observation_feedback_v1        NOT_APPLICABLE
+src.governance.promotion_loop.engine                          NOT_APPLICABLE
+src.experiments.live_session_registry                         NOT_APPLICABLE
+```
+
+Phase 3 remains the only Failure Memory SSOT. This layer may classify a gap as `REJECTED_REALITY_GAP`; it does not append failure-memory records and does not invent a second identity, comparability, robustness, or comparison truth.
+
+## Shape
+
+A Reality Gap record binds one COMPLETE Phase-1 experiment identity to explicit expected-versus-observed research measurements. Observations are caller-supplied numbers. This store does not query venues, start sessions, or submit orders.
+
+```text
+expected_surface = RESEARCH
+observed_surface in {SHADOW, PAPER_EXCHANGE, TESTNET, LIVE}
+observed_surface_is_not_authorization = true
+```
+
+`SHADOW`, `PAPER_EXCHANGE`, `TESTNET`, and `LIVE` are observation-source labels only. They do not authorize those execution planes.
+
+## Canonical gap dimensions
+
+Every supplied dimension must include explicit finite `expected`, `observed`, and non-negative `threshold` values. Missing values fail closed. Zero is never inferred for missing fee, slippage, funding, fill, latency, spread, or pnl.
+
+| dimension | identity binding |
+|---|---|
+| `fee` | `fee_model_digest` |
+| `slippage` | `slippage_model_digest` |
+| `funding` | `funding_model_digest` |
+| `fill` | none; explicit measurement only |
+| `latency` | none; explicit measurement only |
+| `spread` | none; explicit measurement only |
+| `pnl` | none; explicit measurement only |
+
+Cost dimensions must match the bound Phase-1 digest. At least one dimension is required.
+
+```text
+abs(observed - expected) <= threshold  => WITHIN_THRESHOLD
+abs(observed - expected) >  threshold  => EXCEEDS_THRESHOLD
+```
+
+## Overall disposition
+
+```text
+any EXCEEDS_THRESHOLD => REJECTED_REALITY_GAP / REALITY_GAP_GATE
+all WITHIN_THRESHOLD  => WITHIN_THRESHOLD / NOT_TRIGGERED
+```
+
+`REJECTED_REALITY_GAP` and `REALITY_GAP_GATE` are the Phase-2/3 tokens. Classification here is research evidence only.
+
+## Canonical evidence fields
+
+```text
+experiment_id
+experiment_identity
+expected_surface
+observed_surface
+metric_definitions
+threshold_policy_digest
+gap_dimensions
+dimension_results
+overall_disposition
+failed_gate
+evidence_refs
+created_at
+```
+
+## What is append-only
+
+```text
+same reality_gap_record_id + identical canonical content => idempotent accept
+same reality_gap_record_id + divergent canonical content => FAIL_CLOSED
+new reality_gap_record_id => append
+```
+
+`reality_gap_record_id` is a content digest of the canonical observation. It is not a timestamp identity.
+
+## What this store cannot do
+
+```text
+REALITY_GAP_STORE_HAS_RUNTIME_AUTHORITY=false
+REALITY_GAP_CAN_MUTATE_LIVE_CONFIG=false
+REALITY_GAP_CAN_PROMOTE=false
+LEARNING_CAN_WRITE_LIVE_CONFIG=false
+LEARNING_CAN_INCREASE_RISK=false
+LEARNING_CAN_INCREASE_LEVERAGE=false
+LEARNING_CAN_FUND=false
+LEARNING_CAN_SUBMIT_ORDER=false
+LEARNING_CAN_ARM=false
+LEARNING_CAN_ENABLE=false
+LEARNING_CAN_CREATE_CONFIRM_TOKEN=false
+LEARNING_CAN_USE_CONFIRM_TOKEN=false
+LEARNING_CAN_AUTHORIZE_CANARY=false
+LEARNING_CAN_PROMOTE_TO_LIVE=false
+LEARNING_MAY_AUTONOMOUSLY_REPLACE_CORE_LOGIC=false
+OBSERVED_SURFACE_IS_NOT_AUTHORIZATION=true
+```
+
+Phase 7 does not start Phase 8 Regime-Aware Evaluation, live, canary, funding, or order submit.

--- a/src/experiments/canonical_reality_gap_store_persist_v1.py
+++ b/src/experiments/canonical_reality_gap_store_persist_v1.py
@@ -1,0 +1,205 @@
+"""Append-only file-backed Canonical Reality Gap Store persist v1.
+
+Historical reality-gap records are immutable after successful persist.
+Identical canonical replay is idempotent. Divergent content for the same
+``reality_gap_record_id`` fails closed. This persist layer cannot mutate
+runtime config, live overrides, orders, funding, risk, leverage, or
+promotion authority.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Mapping
+
+from src.experiments.canonical_reality_gap_store_v1 import (
+    RealityGapRecordConflictError,
+    RealityGapValidationError,
+    canonical_record_payload,
+    freeze_canonical_reality_gap_record_v1,
+    validate_canonical_reality_gap_record_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import (
+    deterministic_json_dumps,
+    is_valid_sha256_hex,
+)
+
+RECORD_FILENAME = "canonical_reality_gap_record_v1.json"
+_TMP_PREFIX = ".canonical_reality_gap_"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CanonicalRealityGapStoreV1:
+    """File-backed append-only reality gap store."""
+
+    def __init__(self, store_root: Path | str) -> None:
+        root = Path(store_root)
+        if root.exists() and not root.is_dir():
+            raise RealityGapValidationError("store_root must be a directory")
+        self._root = root
+
+    @property
+    def store_root(self) -> Path:
+        return self._root
+
+    def append(self, record: Mapping[str, Any]) -> Mapping[str, Any]:
+        validate_canonical_reality_gap_record_v1(record)
+        payload = canonical_record_payload(record)
+        reality_gap_record_id = str(payload["reality_gap_record_id"])
+        dest = self._record_path(reality_gap_record_id)
+        serialized = _serialize_record(payload)
+        if dest.is_file():
+            existing = self.get(reality_gap_record_id)
+            if _serialize_record(canonical_record_payload(existing)) == serialized:
+                _LOGGER.info(
+                    "canonical_reality_gap_store_v1 idempotent append reality_gap_record_id=%s",
+                    reality_gap_record_id,
+                )
+                return existing
+            raise RealityGapRecordConflictError(
+                "divergent canonical content for existing reality_gap_record_id is forbidden"
+            )
+        dest_dir = dest.parent
+        if dest_dir.exists():
+            leftovers = [
+                path.name for path in dest_dir.iterdir() if not path.name.startswith(_TMP_PREFIX)
+            ]
+            if leftovers:
+                raise RealityGapValidationError(
+                    "reality gap directory exists without a complete immutable record"
+                )
+        else:
+            dest_dir.mkdir(parents=True, exist_ok=False)
+        _atomic_create_exclusive(dest, serialized)
+        stored = self.get(reality_gap_record_id)
+        _LOGGER.info(
+            "canonical_reality_gap_store_v1 appended reality_gap_record_id=%s disposition=%s",
+            reality_gap_record_id,
+            stored["overall_disposition"],
+        )
+        return stored
+
+    def get(self, reality_gap_record_id: str) -> Mapping[str, Any]:
+        path = self._record_path(reality_gap_record_id)
+        if not path.is_file():
+            raise RealityGapValidationError(
+                f"reality gap record not found: {reality_gap_record_id}"
+            )
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise RealityGapValidationError(
+                f"corrupt reality gap record JSON: {reality_gap_record_id}"
+            ) from exc
+        if not isinstance(payload, dict):
+            raise RealityGapValidationError("corrupt reality gap record root")
+        validate_canonical_reality_gap_record_v1(payload)
+        stored_id = str(payload.get("reality_gap_record_id") or "")
+        if stored_id != reality_gap_record_id:
+            raise RealityGapValidationError(
+                "stored reality_gap_record_id does not match requested id"
+            )
+        return freeze_canonical_reality_gap_record_v1(payload)
+
+    def exists(self, reality_gap_record_id: str) -> bool:
+        path = self._record_path(reality_gap_record_id)
+        if not path.exists():
+            return False
+        self.get(reality_gap_record_id)
+        return True
+
+    def list_records(self) -> list[Mapping[str, Any]]:
+        if not self._root.exists():
+            return []
+        rows: list[Mapping[str, Any]] = []
+        for child in sorted(self._root.iterdir(), key=lambda item: item.name):
+            if not child.is_dir() or child.name.startswith("."):
+                continue
+            if not is_valid_sha256_hex(child.name):
+                raise RealityGapValidationError(
+                    f"non-canonical directory under reality gap store root: {child.name}"
+                )
+            rows.append(self.get(child.name))
+        return rows
+
+    def list_by_experiment_id(self, experiment_id: str) -> list[Mapping[str, Any]]:
+        if not isinstance(experiment_id, str) or not is_valid_sha256_hex(experiment_id):
+            raise RealityGapValidationError("experiment_id must be a lowercase sha256 hex digest")
+        return [
+            record for record in self.list_records() if record["experiment_id"] == experiment_id
+        ]
+
+    def _record_path(self, reality_gap_record_id: str) -> Path:
+        if not isinstance(reality_gap_record_id, str) or not is_valid_sha256_hex(
+            reality_gap_record_id
+        ):
+            raise RealityGapValidationError(
+                "reality_gap_record_id must be a lowercase sha256 hex digest"
+            )
+        if (
+            ".." in reality_gap_record_id
+            or "/" in reality_gap_record_id
+            or "\\" in reality_gap_record_id
+        ):
+            raise RealityGapValidationError("reality_gap_record_id path traversal is forbidden")
+        root = self._root.resolve()
+        dest_dir = (root / reality_gap_record_id).resolve()
+        try:
+            dest_dir.relative_to(root)
+        except ValueError as exc:
+            raise RealityGapValidationError("reality gap record path escaped store root") from exc
+        dest = dest_dir / RECORD_FILENAME
+        dest_resolved = dest.resolve()
+        try:
+            dest_resolved.relative_to(root)
+        except ValueError as exc:
+            raise RealityGapValidationError("reality gap record path escaped store root") from exc
+        return dest
+
+
+def _serialize_record(payload: Mapping[str, Any]) -> str:
+    return deterministic_json_dumps(payload) + "\n"
+
+
+def _atomic_create_exclusive(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=_TMP_PREFIX,
+        suffix=".tmp",
+        dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.link(tmp_name, path)
+        except FileExistsError as exc:
+            existing = Path(path).read_text(encoding="utf-8")
+            if existing != content:
+                raise RealityGapRecordConflictError(
+                    "divergent canonical content for existing reality_gap_record_id is forbidden"
+                ) from exc
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+    else:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+
+
+__all__ = [
+    "CanonicalRealityGapStoreV1",
+    "RECORD_FILENAME",
+]

--- a/src/experiments/canonical_reality_gap_store_v1.py
+++ b/src/experiments/canonical_reality_gap_store_v1.py
@@ -1,0 +1,638 @@
+"""Phase 7 Canonical Reality Gap Store v1 (research evidence only).
+
+Append-only historical memory of expected-versus-observed research gaps.
+This layer reuses Phase 1 Canonical Experiment Identity, Phase 2
+``experiment_id`` / ``REJECTED_REALITY_GAP``, and the Phase 3
+``REALITY_GAP_GATE`` mapping. It has no runtime, order, live, funding,
+canary, promotion, or config-write authority.
+
+Observed-surface labels are not execution authorization. Missing fee,
+slippage, funding, or other gap values are never defaulted to zero.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Final, Mapping, Sequence
+
+from src.experiments.canonical_experiment_identity_v1 import (
+    CanonicalExperimentIdentityError,
+    validate_canonical_experiment_identity_v1,
+)
+from src.experiments.canonical_experiment_memory_v1 import (
+    ARTIFACT_KIND_REPO_RELATIVE,
+    ARTIFACT_KIND_STORE_RELATIVE,
+    CANONICAL_DISPOSITIONS,
+    derive_experiment_id_v1,
+)
+from src.experiments.canonical_failure_memory_v1 import FAILURE_CLASS_TO_FAILED_GATE
+from src.meta.learning_loop.contract_safety_v1 import (
+    compute_content_sha256,
+    is_valid_sha256_hex,
+)
+
+SCHEMA_VERSION: Final[str] = "canonical_reality_gap_store_v1"
+REALITY_GAP_DOMAIN: Final[str] = "peak_trade.canonical_reality_gap_store.v1"
+DIGEST_ALGORITHM: Final[str] = "sha256"
+RECORD_COMPLETENESS_COMPLETE: Final[str] = "COMPLETE"
+EVIDENCE_KIND_EXPERIMENT_RECORD: Final[str] = "EXPERIMENT_RECORD"
+ARTIFACT_KIND_REPO_RELATIVE_REF: Final[str] = ARTIFACT_KIND_REPO_RELATIVE
+ARTIFACT_KIND_STORE_RELATIVE_REF: Final[str] = ARTIFACT_KIND_STORE_RELATIVE
+
+REALITY_GAP_STORE_PRESENT: Final[bool] = True
+REALITY_GAP_STORE_HAS_RUNTIME_AUTHORITY: Final[bool] = False
+REALITY_GAP_CAN_MUTATE_LIVE_CONFIG: Final[bool] = False
+REALITY_GAP_CAN_WRITE_LIVE_CONFIG: Final[bool] = False
+REALITY_GAP_CAN_PROMOTE: Final[bool] = False
+REALITY_GAP_CAN_PROMOTE_TO_LIVE: Final[bool] = False
+REALITY_GAP_CAN_INCREASE_RISK: Final[bool] = False
+REALITY_GAP_CAN_INCREASE_LEVERAGE: Final[bool] = False
+REALITY_GAP_CAN_FUND: Final[bool] = False
+REALITY_GAP_CAN_SUBMIT_ORDER: Final[bool] = False
+REALITY_GAP_CAN_ARM: Final[bool] = False
+REALITY_GAP_CAN_ENABLE: Final[bool] = False
+REALITY_GAP_CAN_CREATE_CONFIRM_TOKEN: Final[bool] = False
+REALITY_GAP_CAN_USE_CONFIRM_TOKEN: Final[bool] = False
+REALITY_GAP_CAN_AUTHORIZE_CANARY: Final[bool] = False
+LEARNING_MAY_AUTONOMOUSLY_REPLACE_CORE_LOGIC: Final[bool] = False
+OBSERVED_SURFACE_IS_NOT_AUTHORIZATION: Final[bool] = True
+SELF_LEARNING_SELF_AUTHORIZING_SEPARATION: Final[bool] = True
+PROMOTION_AUTHORITY: Final[str] = "NONE"
+RUNTIME_AUTHORITY_IMPACT: Final[str] = "NONE"
+
+EXPECTED_SURFACE_RESEARCH: Final[str] = "RESEARCH"
+OBSERVED_SURFACE_SHADOW: Final[str] = "SHADOW"
+OBSERVED_SURFACE_PAPER_EXCHANGE: Final[str] = "PAPER_EXCHANGE"
+OBSERVED_SURFACE_TESTNET: Final[str] = "TESTNET"
+OBSERVED_SURFACE_LIVE: Final[str] = "LIVE"
+CANONICAL_OBSERVED_SURFACES: Final[tuple[str, ...]] = (
+    OBSERVED_SURFACE_SHADOW,
+    OBSERVED_SURFACE_PAPER_EXCHANGE,
+    OBSERVED_SURFACE_TESTNET,
+    OBSERVED_SURFACE_LIVE,
+)
+
+DISPOSITION_WITHIN_THRESHOLD: Final[str] = "WITHIN_THRESHOLD"
+DISPOSITION_REJECTED_REALITY_GAP: Final[str] = "REJECTED_REALITY_GAP"
+FAILED_GATE_NOT_TRIGGERED: Final[str] = "NOT_TRIGGERED"
+FAILED_GATE_REALITY_GAP: Final[str] = FAILURE_CLASS_TO_FAILED_GATE[DISPOSITION_REJECTED_REALITY_GAP]
+DIMENSION_WITHIN_THRESHOLD: Final[str] = "WITHIN_THRESHOLD"
+DIMENSION_EXCEEDS_THRESHOLD: Final[str] = "EXCEEDS_THRESHOLD"
+
+if DISPOSITION_REJECTED_REALITY_GAP not in CANONICAL_DISPOSITIONS:
+    raise RuntimeError("REJECTED_REALITY_GAP must remain a Phase 2 disposition")
+
+GAP_DIMENSIONS: Final[tuple[str, ...]] = (
+    "fee",
+    "slippage",
+    "funding",
+    "fill",
+    "latency",
+    "spread",
+    "pnl",
+)
+GAP_DIMENSION_IDENTITY_BINDINGS: Final[Mapping[str, str]] = MappingProxyType(
+    {
+        "fee": "fee_model_digest",
+        "slippage": "slippage_model_digest",
+        "funding": "funding_model_digest",
+    }
+)
+
+_CREATED_AT_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$")
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_UNAVAILABLE_TOKENS = frozenset(
+    {
+        "",
+        "unknown",
+        "unavailable",
+        "n/a",
+        "na",
+        "none",
+        "null",
+        "implicit",
+        "default",
+        "compatible",
+        "zero",
+    }
+)
+_CORE_LOGIC_DIGEST_FIELDS: Final[tuple[str, ...]] = (
+    "trading_decision_core_digest",
+    "market_context_contract_digest",
+    "bull_bear_logic_digest",
+    "state_switch_logic_digest",
+    "survival_logic_digest",
+    "suitability_logic_digest",
+    "double_play_logic_digest",
+    "entry_position_exit_logic_digest",
+)
+_EVIDENCE_KINDS: Final[tuple[str, ...]] = (
+    EVIDENCE_KIND_EXPERIMENT_RECORD,
+    ARTIFACT_KIND_REPO_RELATIVE_REF,
+    ARTIFACT_KIND_STORE_RELATIVE_REF,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class RealityGapValidationError(ValueError):
+    """Fail-closed Canonical Reality Gap Store v1 validation error."""
+
+
+class RealityGapRecordConflictError(RealityGapValidationError):
+    """Same reality_gap_record_id with divergent canonical historical content."""
+
+
+@dataclass(frozen=True)
+class RealityGapDimensionV1:
+    name: str
+    expected: float
+    observed: float
+    threshold: float
+    unit: str
+
+
+@dataclass(frozen=True)
+class CanonicalRealityGapRecordRequestV1:
+    experiment_identity: Mapping[str, Any]
+    observed_surface: str
+    metric_definitions: str
+    threshold_policy_digest: str
+    gap_dimensions: Sequence[RealityGapDimensionV1]
+    evidence_refs: Sequence[Mapping[str, Any]]
+    created_at: str
+    expected_surface: str = EXPECTED_SURFACE_RESEARCH
+    experiment_id: str | None = None
+
+
+def build_canonical_reality_gap_record_v1(
+    request: CanonicalRealityGapRecordRequestV1,
+) -> Mapping[str, Any]:
+    identity = _require_identity(request.experiment_identity)
+    experiment_id = derive_experiment_id_v1(str(identity["identity_digest"]))
+    if request.experiment_id is not None:
+        provided = _require_sha256("experiment_id", request.experiment_id)
+        if provided != experiment_id:
+            raise RealityGapValidationError(
+                "experiment_id is not bound to the Canonical Experiment Identity digest"
+            )
+    expected_surface = _require_expected_surface(request.expected_surface)
+    observed_surface = _require_observed_surface(request.observed_surface)
+    created_at = _require_created_at(request.created_at)
+    metric_definitions = _require_token("metric_definitions", request.metric_definitions)
+    threshold_policy_digest = _require_sha256(
+        "threshold_policy_digest", request.threshold_policy_digest
+    )
+    dimension_results = _evaluate_dimensions(request.gap_dimensions, identity)
+    exceeds = any(item["status"] == DIMENSION_EXCEEDS_THRESHOLD for item in dimension_results)
+    overall_disposition = (
+        DISPOSITION_REJECTED_REALITY_GAP if exceeds else DISPOSITION_WITHIN_THRESHOLD
+    )
+    failed_gate = FAILED_GATE_REALITY_GAP if exceeds else FAILED_GATE_NOT_TRIGGERED
+    evidence_refs = _canonicalize_evidence_refs(request.evidence_refs, experiment_id)
+    body = {
+        "canonical_trading_decision_core_bound": True,
+        "completeness": RECORD_COMPLETENESS_COMPLETE,
+        "created_at": created_at,
+        "digest_algorithm": DIGEST_ALGORITHM,
+        "dimension_results": dimension_results,
+        "evidence_refs": evidence_refs,
+        "expected_surface": expected_surface,
+        "experiment_id": experiment_id,
+        "experiment_identity": identity,
+        "failed_gate": failed_gate,
+        "learning_may_autonomously_replace_core_logic": (
+            LEARNING_MAY_AUTONOMOUSLY_REPLACE_CORE_LOGIC
+        ),
+        "metric_definitions": metric_definitions,
+        "observed_surface": observed_surface,
+        "observed_surface_is_not_authorization": OBSERVED_SURFACE_IS_NOT_AUTHORIZATION,
+        "overall_disposition": overall_disposition,
+        "promotion_authority": PROMOTION_AUTHORITY,
+        "reality_gap_can_arm": REALITY_GAP_CAN_ARM,
+        "reality_gap_can_authorize_canary": REALITY_GAP_CAN_AUTHORIZE_CANARY,
+        "reality_gap_can_create_confirm_token": REALITY_GAP_CAN_CREATE_CONFIRM_TOKEN,
+        "reality_gap_can_enable": REALITY_GAP_CAN_ENABLE,
+        "reality_gap_can_fund": REALITY_GAP_CAN_FUND,
+        "reality_gap_can_increase_leverage": REALITY_GAP_CAN_INCREASE_LEVERAGE,
+        "reality_gap_can_increase_risk": REALITY_GAP_CAN_INCREASE_RISK,
+        "reality_gap_can_mutate_live_config": REALITY_GAP_CAN_MUTATE_LIVE_CONFIG,
+        "reality_gap_can_promote": REALITY_GAP_CAN_PROMOTE,
+        "reality_gap_can_promote_to_live": REALITY_GAP_CAN_PROMOTE_TO_LIVE,
+        "reality_gap_can_submit_order": REALITY_GAP_CAN_SUBMIT_ORDER,
+        "reality_gap_can_use_confirm_token": REALITY_GAP_CAN_USE_CONFIRM_TOKEN,
+        "reality_gap_can_write_live_config": REALITY_GAP_CAN_WRITE_LIVE_CONFIG,
+        "reality_gap_domain": REALITY_GAP_DOMAIN,
+        "reality_gap_store_has_runtime_authority": REALITY_GAP_STORE_HAS_RUNTIME_AUTHORITY,
+        "reality_gap_store_present": REALITY_GAP_STORE_PRESENT,
+        "record_schema_version": SCHEMA_VERSION,
+        "runtime_authority_impact": RUNTIME_AUTHORITY_IMPACT,
+        "self_learning_self_authorizing_separation": (SELF_LEARNING_SELF_AUTHORIZING_SEPARATION),
+        "threshold_policy_digest": threshold_policy_digest,
+    }
+    reality_gap_record_id = derive_reality_gap_record_id_v1(body)
+    record = dict(body)
+    record["reality_gap_record_id"] = reality_gap_record_id
+    record["integrity"] = {
+        "content_sha256": compute_content_sha256(
+            {key: value for key, value in record.items() if key != "integrity"}
+        )
+    }
+    validate_canonical_reality_gap_record_v1(record)
+    frozen = _freeze(record)
+    _LOGGER.info(
+        "canonical_reality_gap_store_v1 built identity=%s disposition=%s surface=%s",
+        reality_gap_record_id,
+        overall_disposition,
+        observed_surface,
+    )
+    return frozen
+
+
+def derive_reality_gap_record_id_v1(record_without_ids: Mapping[str, Any]) -> str:
+    envelope = {
+        "digest_algorithm": DIGEST_ALGORITHM,
+        "digest_domain": f"{REALITY_GAP_DOMAIN}.reality_gap_record_id",
+        "payload": _plain_mapping(record_without_ids),
+        "schema_version": SCHEMA_VERSION,
+    }
+    return compute_content_sha256(envelope)
+
+
+def validate_canonical_reality_gap_record_v1(record: Mapping[str, Any]) -> None:
+    if not isinstance(record, Mapping):
+        raise RealityGapValidationError("reality gap record must be a mapping")
+    record = _plain_mapping(record)
+    if record.get("record_schema_version") != SCHEMA_VERSION:
+        raise RealityGapValidationError("record_schema_version mismatch")
+    if record.get("reality_gap_domain") != REALITY_GAP_DOMAIN:
+        raise RealityGapValidationError("reality_gap_domain mismatch")
+    if record.get("completeness") != RECORD_COMPLETENESS_COMPLETE:
+        raise RealityGapValidationError("non-COMPLETE reality gap records are forbidden")
+    if record.get("digest_algorithm") != DIGEST_ALGORITHM:
+        raise RealityGapValidationError("digest_algorithm mismatch")
+    if record.get("reality_gap_store_present") is not True:
+        raise RealityGapValidationError("reality_gap_store_present must be true")
+    if record.get("reality_gap_store_has_runtime_authority") is not False:
+        raise RealityGapValidationError("reality_gap_store_has_runtime_authority must be false")
+    if record.get("reality_gap_can_mutate_live_config") is not False:
+        raise RealityGapValidationError("reality_gap_can_mutate_live_config must be false")
+    if record.get("reality_gap_can_write_live_config") is not False:
+        raise RealityGapValidationError("reality_gap_can_write_live_config must be false")
+    if record.get("reality_gap_can_promote") is not False:
+        raise RealityGapValidationError("reality_gap_can_promote must be false")
+    if record.get("reality_gap_can_promote_to_live") is not False:
+        raise RealityGapValidationError("reality_gap_can_promote_to_live must be false")
+    if record.get("reality_gap_can_increase_risk") is not False:
+        raise RealityGapValidationError("reality_gap_can_increase_risk must be false")
+    if record.get("reality_gap_can_increase_leverage") is not False:
+        raise RealityGapValidationError("reality_gap_can_increase_leverage must be false")
+    if record.get("reality_gap_can_fund") is not False:
+        raise RealityGapValidationError("reality_gap_can_fund must be false")
+    if record.get("reality_gap_can_submit_order") is not False:
+        raise RealityGapValidationError("reality_gap_can_submit_order must be false")
+    if record.get("reality_gap_can_arm") is not False:
+        raise RealityGapValidationError("reality_gap_can_arm must be false")
+    if record.get("reality_gap_can_enable") is not False:
+        raise RealityGapValidationError("reality_gap_can_enable must be false")
+    if record.get("reality_gap_can_create_confirm_token") is not False:
+        raise RealityGapValidationError("reality_gap_can_create_confirm_token must be false")
+    if record.get("reality_gap_can_use_confirm_token") is not False:
+        raise RealityGapValidationError("reality_gap_can_use_confirm_token must be false")
+    if record.get("reality_gap_can_authorize_canary") is not False:
+        raise RealityGapValidationError("reality_gap_can_authorize_canary must be false")
+    if record.get("learning_may_autonomously_replace_core_logic") is not False:
+        raise RealityGapValidationError(
+            "learning_may_autonomously_replace_core_logic must be false"
+        )
+    if record.get("observed_surface_is_not_authorization") is not True:
+        raise RealityGapValidationError("observed_surface_is_not_authorization must be true")
+    if record.get("self_learning_self_authorizing_separation") is not True:
+        raise RealityGapValidationError("self_learning_self_authorizing_separation must be true")
+    if record.get("promotion_authority") != PROMOTION_AUTHORITY:
+        raise RealityGapValidationError("promotion_authority must be NONE")
+    if record.get("runtime_authority_impact") != RUNTIME_AUTHORITY_IMPACT:
+        raise RealityGapValidationError("runtime_authority_impact must be NONE")
+    if record.get("canonical_trading_decision_core_bound") is not True:
+        raise RealityGapValidationError("canonical_trading_decision_core_bound must be true")
+
+    identity = _require_identity(record.get("experiment_identity"))
+    experiment_id = _require_sha256("experiment_id", record.get("experiment_id"))
+    expected_id = derive_experiment_id_v1(str(identity["identity_digest"]))
+    if experiment_id != expected_id:
+        raise RealityGapValidationError(
+            "experiment_id is not bound to the Canonical Experiment Identity digest"
+        )
+    _require_expected_surface(record.get("expected_surface"))
+    _require_observed_surface(record.get("observed_surface"))
+    _require_created_at(record.get("created_at"))
+    _require_token("metric_definitions", record.get("metric_definitions"))
+    _require_sha256("threshold_policy_digest", record.get("threshold_policy_digest"))
+    _canonicalize_evidence_refs(record.get("evidence_refs"), experiment_id)
+    for field_name in _CORE_LOGIC_DIGEST_FIELDS:
+        _require_sha256(field_name, identity.get(field_name))
+    dimension_results = _require_dimension_results(record.get("dimension_results"), identity)
+    exceeds = any(item["status"] == DIMENSION_EXCEEDS_THRESHOLD for item in dimension_results)
+    overall = record.get("overall_disposition")
+    failed_gate = record.get("failed_gate")
+    if exceeds:
+        if overall != DISPOSITION_REJECTED_REALITY_GAP:
+            raise RealityGapValidationError(
+                "overall_disposition must be REJECTED_REALITY_GAP when a gap exceeds threshold"
+            )
+        if failed_gate != FAILED_GATE_REALITY_GAP:
+            raise RealityGapValidationError("failed_gate must be REALITY_GAP_GATE")
+    else:
+        if overall != DISPOSITION_WITHIN_THRESHOLD:
+            raise RealityGapValidationError(
+                "overall_disposition must be WITHIN_THRESHOLD when every gap is within threshold"
+            )
+        if failed_gate != FAILED_GATE_NOT_TRIGGERED:
+            raise RealityGapValidationError("failed_gate must be NOT_TRIGGERED")
+
+    body = {
+        key: value
+        for key, value in record.items()
+        if key not in {"reality_gap_record_id", "integrity"}
+    }
+    expected_record_id = derive_reality_gap_record_id_v1(body)
+    if record.get("reality_gap_record_id") != expected_record_id:
+        raise RealityGapValidationError("reality_gap_record_id is not bound to canonical content")
+    expected_integrity = compute_content_sha256(
+        {key: value for key, value in record.items() if key != "integrity"}
+    )
+    integrity = record.get("integrity")
+    if not isinstance(integrity, Mapping) or integrity.get("content_sha256") != (
+        expected_integrity
+    ):
+        raise RealityGapValidationError("integrity.content_sha256 mismatch")
+
+
+def canonical_record_payload(record: Mapping[str, Any]) -> dict[str, Any]:
+    return _plain_mapping(record)
+
+
+def freeze_canonical_reality_gap_record_v1(record: Mapping[str, Any]) -> Mapping[str, Any]:
+    validate_canonical_reality_gap_record_v1(record)
+    return _freeze(canonical_record_payload(record))
+
+
+def _evaluate_dimensions(
+    dimensions: Sequence[RealityGapDimensionV1] | Any,
+    identity: Mapping[str, Any],
+) -> list[dict[str, Any]]:
+    if not isinstance(dimensions, Sequence) or isinstance(dimensions, (str, bytes)):
+        raise RealityGapValidationError("gap_dimensions must be a sequence")
+    if not dimensions:
+        raise RealityGapValidationError("at least one gap dimension is required")
+    seen: set[str] = set()
+    results: list[dict[str, Any]] = []
+    for index, item in enumerate(dimensions):
+        if not isinstance(item, RealityGapDimensionV1):
+            raise RealityGapValidationError(
+                f"gap_dimensions[{index}] must be a RealityGapDimensionV1"
+            )
+        name = _require_dimension_name(item.name)
+        if name in seen:
+            raise RealityGapValidationError(f"duplicate gap dimension is forbidden: {name}")
+        seen.add(name)
+        expected = _require_finite_number(f"gap_dimensions[{index}].expected", item.expected)
+        observed = _require_finite_number(f"gap_dimensions[{index}].observed", item.observed)
+        threshold = _require_finite_number(f"gap_dimensions[{index}].threshold", item.threshold)
+        if threshold < 0:
+            raise RealityGapValidationError(f"gap_dimensions[{index}].threshold must be >= 0")
+        unit = _require_token(f"gap_dimensions[{index}].unit", item.unit)
+        delta = observed - expected
+        abs_delta = abs(delta)
+        status = (
+            DIMENSION_EXCEEDS_THRESHOLD if abs_delta > threshold else DIMENSION_WITHIN_THRESHOLD
+        )
+        result: dict[str, Any] = {
+            "abs_delta": abs_delta,
+            "delta": delta,
+            "expected": expected,
+            "name": name,
+            "observed": observed,
+            "status": status,
+            "threshold": threshold,
+            "unit": unit,
+        }
+        identity_field = GAP_DIMENSION_IDENTITY_BINDINGS.get(name)
+        if identity_field is not None:
+            result["identity_digest_field"] = identity_field
+            result["identity_digest"] = _require_sha256(
+                identity_field, identity.get(identity_field)
+            )
+        results.append(result)
+    return results
+
+
+def _require_dimension_results(value: Any, identity: Mapping[str, Any]) -> list[dict[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise RealityGapValidationError("dimension_results must be a sequence")
+    if not value:
+        raise RealityGapValidationError("at least one gap dimension is required")
+    rebuilt: list[RealityGapDimensionV1] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, Mapping):
+            raise RealityGapValidationError(f"dimension_results[{index}] must be a mapping")
+        rebuilt.append(
+            RealityGapDimensionV1(
+                name=str(item.get("name")),
+                expected=_require_finite_number(
+                    f"dimension_results[{index}].expected", item.get("expected")
+                ),
+                observed=_require_finite_number(
+                    f"dimension_results[{index}].observed", item.get("observed")
+                ),
+                threshold=_require_finite_number(
+                    f"dimension_results[{index}].threshold", item.get("threshold")
+                ),
+                unit=str(item.get("unit")),
+            )
+        )
+    expected_results = _evaluate_dimensions(rebuilt, identity)
+    actual = [_plain_mapping(item) for item in value]
+    if actual != expected_results:
+        raise RealityGapValidationError("dimension_results are not canonically derived")
+    return expected_results
+
+
+def _require_identity(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        raise RealityGapValidationError("experiment_identity present and valid is required")
+    identity = _plain_mapping(value)
+    try:
+        validate_canonical_experiment_identity_v1(identity)
+    except CanonicalExperimentIdentityError as exc:
+        raise RealityGapValidationError(
+            f"experiment_identity is not a valid Phase 1 Canonical Experiment Identity: {exc}"
+        ) from exc
+    return identity
+
+
+def _require_sha256(field_name: str, value: Any) -> str:
+    if not isinstance(value, str) or not is_valid_sha256_hex(value):
+        raise RealityGapValidationError(f"{field_name} must be a lowercase sha256 hex digest")
+    return value
+
+
+def _require_created_at(value: Any) -> str:
+    if not isinstance(value, str) or not _CREATED_AT_RE.fullmatch(value):
+        raise RealityGapValidationError(
+            "created_at must be an explicit UTC timestamp ending with Z"
+        )
+    return value
+
+
+def _require_token(field_name: str, value: Any) -> str:
+    if not isinstance(value, str) or not _TOKEN_RE.fullmatch(value):
+        raise RealityGapValidationError(f"{field_name} is missing or malformed")
+    if value.strip().lower() in _UNAVAILABLE_TOKENS:
+        raise RealityGapValidationError(f"{field_name} cannot use implicit unavailable tokens")
+    return value
+
+
+def _require_expected_surface(value: Any) -> str:
+    token = _require_token("expected_surface", value)
+    if token != EXPECTED_SURFACE_RESEARCH:
+        raise RealityGapValidationError("expected_surface must be RESEARCH")
+    return token
+
+
+def _require_observed_surface(value: Any) -> str:
+    token = _require_token("observed_surface", value)
+    if token not in CANONICAL_OBSERVED_SURFACES:
+        raise RealityGapValidationError("observed_surface is unknown or unsupported")
+    return token
+
+
+def _require_dimension_name(value: Any) -> str:
+    token = _require_token("gap dimension name", value)
+    if token not in GAP_DIMENSIONS:
+        raise RealityGapValidationError(f"gap dimension is unknown or unsupported: {token}")
+    return token
+
+
+def _require_finite_number(field_name: str, value: Any) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise RealityGapValidationError(f"{field_name} must be an explicit finite number")
+    number = float(value)
+    if not math.isfinite(number):
+        raise RealityGapValidationError(f"non-finite numeric values are forbidden in {field_name}")
+    return number
+
+
+def _canonicalize_evidence_refs(value: Any, experiment_id: str) -> list[dict[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise RealityGapValidationError("evidence_refs must be a sequence")
+    refs: list[dict[str, Any]] = []
+    seen: set[tuple[str, str]] = set()
+    experiment_bound = False
+    for index, item in enumerate(value):
+        if not isinstance(item, Mapping):
+            raise RealityGapValidationError(f"evidence_refs[{index}] must be a mapping")
+        kind = item.get("kind")
+        if kind not in _EVIDENCE_KINDS:
+            raise RealityGapValidationError(f"evidence_refs[{index}].kind is unsupported")
+        digest = _require_sha256(f"evidence_refs[{index}].digest", item.get("digest"))
+        if kind == EVIDENCE_KIND_EXPERIMENT_RECORD:
+            ref = _require_sha256(f"evidence_refs[{index}].ref", item.get("ref"))
+            if ref == experiment_id:
+                experiment_bound = True
+        else:
+            ref = _require_relative_artifact_ref(f"evidence_refs[{index}].ref", item.get("ref"))
+        extra_keys = set(str(key) for key in item.keys()) - {"kind", "ref", "digest"}
+        if extra_keys:
+            raise RealityGapValidationError(
+                f"evidence_refs[{index}] has unsupported keys: {sorted(extra_keys)}"
+            )
+        key = (str(kind), ref)
+        if key in seen:
+            raise RealityGapValidationError("duplicate evidence_refs are forbidden")
+        seen.add(key)
+        refs.append({"digest": digest, "kind": kind, "ref": ref})
+    if not experiment_bound:
+        raise RealityGapValidationError(
+            "evidence_refs must include the bound EXPERIMENT_RECORD experiment_id"
+        )
+    return refs
+
+
+def _require_relative_artifact_ref(field_name: str, value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise RealityGapValidationError(f"{field_name} must be a non-empty relative ref")
+    ref = value.strip()
+    if ref.strip().lower() in _UNAVAILABLE_TOKENS:
+        raise RealityGapValidationError(f"{field_name} cannot use implicit unavailable tokens")
+    if "\x00" in ref:
+        raise RealityGapValidationError(f"{field_name} contains a NUL byte")
+    if ref.startswith("/") or ref.startswith("\\") or ref.startswith("~"):
+        raise RealityGapValidationError(f"{field_name} absolute or home paths are forbidden")
+    if ":" in ref.split("/", 1)[0] and len(ref.split("/", 1)[0]) <= 2:
+        raise RealityGapValidationError(f"{field_name} drive-qualified paths are forbidden")
+    parts = ref.replace("\\", "/").split("/")
+    if any(part in {"", ".", ".."} for part in parts):
+        raise RealityGapValidationError(
+            f"{field_name} path traversal or empty segments are forbidden"
+        )
+    if "\\" in ref:
+        raise RealityGapValidationError(f"{field_name} must use store-/repo-relative POSIX paths")
+    return ref
+
+
+def _freeze(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({str(key): _freeze(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return [_freeze(item) for item in value]
+    return value
+
+
+def _plain_mapping(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _plain_mapping(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_plain_mapping(item) for item in value]
+    return value
+
+
+__all__ = [
+    "CANONICAL_OBSERVED_SURFACES",
+    "CanonicalRealityGapRecordRequestV1",
+    "DIGEST_ALGORITHM",
+    "DISPOSITION_REJECTED_REALITY_GAP",
+    "DISPOSITION_WITHIN_THRESHOLD",
+    "EVIDENCE_KIND_EXPERIMENT_RECORD",
+    "EXPECTED_SURFACE_RESEARCH",
+    "FAILED_GATE_NOT_TRIGGERED",
+    "FAILED_GATE_REALITY_GAP",
+    "GAP_DIMENSIONS",
+    "GAP_DIMENSION_IDENTITY_BINDINGS",
+    "OBSERVED_SURFACE_IS_NOT_AUTHORIZATION",
+    "OBSERVED_SURFACE_LIVE",
+    "OBSERVED_SURFACE_PAPER_EXCHANGE",
+    "OBSERVED_SURFACE_SHADOW",
+    "OBSERVED_SURFACE_TESTNET",
+    "PROMOTION_AUTHORITY",
+    "REALITY_GAP_CAN_MUTATE_LIVE_CONFIG",
+    "REALITY_GAP_CAN_PROMOTE",
+    "REALITY_GAP_DOMAIN",
+    "REALITY_GAP_STORE_HAS_RUNTIME_AUTHORITY",
+    "REALITY_GAP_STORE_PRESENT",
+    "RECORD_COMPLETENESS_COMPLETE",
+    "RUNTIME_AUTHORITY_IMPACT",
+    "RealityGapDimensionV1",
+    "RealityGapRecordConflictError",
+    "RealityGapValidationError",
+    "SCHEMA_VERSION",
+    "build_canonical_reality_gap_record_v1",
+    "canonical_record_payload",
+    "derive_reality_gap_record_id_v1",
+    "freeze_canonical_reality_gap_record_v1",
+    "validate_canonical_reality_gap_record_v1",
+]

--- a/tests/experiments/test_canonical_reality_gap_store_v1.py
+++ b/tests/experiments/test_canonical_reality_gap_store_v1.py
@@ -1,0 +1,397 @@
+"""Phase 7 Canonical Reality Gap Store v1 contract tests."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import inspect
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping
+
+import pytest
+
+from src.experiments.canonical_experiment_identity_v1 import (
+    CanonicalExperimentIdentityRequestV1,
+    WORKING_TREE_CLEAN,
+    build_canonical_experiment_identity_v1,
+)
+from src.experiments.canonical_experiment_memory_v1 import derive_experiment_id_v1
+from src.experiments.canonical_reality_gap_store_persist_v1 import (
+    RECORD_FILENAME,
+    CanonicalRealityGapStoreV1,
+)
+from src.experiments.canonical_reality_gap_store_v1 import (
+    DISPOSITION_REJECTED_REALITY_GAP,
+    DISPOSITION_WITHIN_THRESHOLD,
+    FAILED_GATE_NOT_TRIGGERED,
+    FAILED_GATE_REALITY_GAP,
+    OBSERVED_SURFACE_IS_NOT_AUTHORIZATION,
+    OBSERVED_SURFACE_LIVE,
+    OBSERVED_SURFACE_SHADOW,
+    PROMOTION_AUTHORITY,
+    REALITY_GAP_CAN_MUTATE_LIVE_CONFIG,
+    REALITY_GAP_CAN_PROMOTE,
+    REALITY_GAP_STORE_HAS_RUNTIME_AUTHORITY,
+    REALITY_GAP_STORE_PRESENT,
+    CanonicalRealityGapRecordRequestV1,
+    RealityGapDimensionV1,
+    RealityGapValidationError,
+    build_canonical_reality_gap_record_v1,
+    canonical_record_payload,
+    validate_canonical_reality_gap_record_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import deterministic_json_dumps
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_MODULE_PATH = REPO_ROOT / "src" / "experiments" / "canonical_reality_gap_store_v1.py"
+STORE_MODULE_PATH = REPO_ROOT / "src" / "experiments" / "canonical_reality_gap_store_persist_v1.py"
+_GIT_SHA = "bc97d43f715305c8b70eb84ddd12fd718f8460a6"
+_CORE_DIGEST_FIELDS = (
+    "trading_decision_core_digest",
+    "market_context_contract_digest",
+    "bull_bear_logic_digest",
+    "state_switch_logic_digest",
+    "survival_logic_digest",
+    "suitability_logic_digest",
+    "double_play_logic_digest",
+    "entry_position_exit_logic_digest",
+)
+_CREATED_AT = "2026-08-17T22:00:00Z"
+
+
+def _digest(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _identity(**overrides: Any) -> Mapping[str, Any]:
+    payload: dict[str, Any] = {
+        "git_sha": _GIT_SHA,
+        "working_tree_status": WORKING_TREE_CLEAN,
+        "strategy_identity": "ma_crossover.v1",
+        "strategy_params": {"slow": 50, "fast": 10},
+        "dataset_digest": _digest("dataset"),
+        "feature_pipeline_digest": _digest("features"),
+        "fee_model_digest": _digest("fee"),
+        "slippage_model_digest": _digest("slippage"),
+        "funding_model_digest": _digest("funding"),
+        "risk_policy_digest": _digest("risk"),
+        "portfolio_digest": _digest("portfolio"),
+        "split_policy_digest": _digest("split"),
+        "market_context_contract_digest": _digest("market-context"),
+        "bull_bear_logic_digest": _digest("bull-bear"),
+        "state_switch_logic_digest": _digest("state-switch"),
+        "survival_logic_digest": _digest("survival"),
+        "suitability_logic_digest": _digest("suitability"),
+        "double_play_logic_digest": _digest("double-play"),
+        "entry_position_exit_logic_digest": _digest("entry-position-exit"),
+        "seed": 7,
+        "environment": {
+            "python_version": "3.11.15",
+            "python_implementation": "CPython",
+        },
+        "parent_lineage_ref": None,
+        "dirty_paths_digest": None,
+    }
+    payload.update(overrides)
+    return build_canonical_experiment_identity_v1(CanonicalExperimentIdentityRequestV1(**payload))
+
+
+def _dimension(
+    name: str = "fee",
+    *,
+    expected: float = 0.001,
+    observed: float = 0.0012,
+    threshold: float = 0.001,
+    unit: str = "ratio",
+) -> RealityGapDimensionV1:
+    return RealityGapDimensionV1(
+        name=name,
+        expected=expected,
+        observed=observed,
+        threshold=threshold,
+        unit=unit,
+    )
+
+
+def _request(
+    identity: Mapping[str, Any] | None = None, **overrides: Any
+) -> CanonicalRealityGapRecordRequestV1:
+    identity = identity or _identity()
+    experiment_id = derive_experiment_id_v1(str(identity["identity_digest"]))
+    payload: dict[str, Any] = {
+        "experiment_identity": identity,
+        "observed_surface": OBSERVED_SURFACE_SHADOW,
+        "metric_definitions": "canonical_robustness_metrics_v1",
+        "threshold_policy_digest": _digest("threshold-policy"),
+        "gap_dimensions": (_dimension(),),
+        "evidence_refs": [
+            {
+                "kind": "EXPERIMENT_RECORD",
+                "ref": experiment_id,
+                "digest": _digest("experiment-record"),
+            }
+        ],
+        "created_at": _CREATED_AT,
+        "expected_surface": "RESEARCH",
+        "experiment_id": None,
+    }
+    payload.update(overrides)
+    return CanonicalRealityGapRecordRequestV1(**payload)
+
+
+def test_valid_record_round_trip_preserves_identity_and_core_digests() -> None:
+    identity = _identity()
+    record = build_canonical_reality_gap_record_v1(_request(identity))
+    assert record["completeness"] == "COMPLETE"
+    assert record["experiment_id"] == derive_experiment_id_v1(str(identity["identity_digest"]))
+    assert canonical_record_payload(record["experiment_identity"]) == canonical_record_payload(
+        identity
+    )
+    for field_name in _CORE_DIGEST_FIELDS:
+        assert record["experiment_identity"][field_name] == identity[field_name]
+    assert record["canonical_trading_decision_core_bound"] is True
+    assert record["reality_gap_store_has_runtime_authority"] is False
+    assert record["observed_surface_is_not_authorization"] is True
+    assert record["dimension_results"][0]["identity_digest"] == identity["fee_model_digest"]
+    validate_canonical_reality_gap_record_v1(record)
+
+
+def test_identical_inputs_are_deterministic() -> None:
+    first = canonical_record_payload(build_canonical_reality_gap_record_v1(_request()))
+    second = canonical_record_payload(build_canonical_reality_gap_record_v1(_request()))
+    assert deterministic_json_dumps(first) == deterministic_json_dumps(second)
+    assert first["reality_gap_record_id"] == second["reality_gap_record_id"]
+
+
+def test_within_threshold_does_not_reject() -> None:
+    record = build_canonical_reality_gap_record_v1(_request())
+    assert record["overall_disposition"] == DISPOSITION_WITHIN_THRESHOLD
+    assert record["failed_gate"] == FAILED_GATE_NOT_TRIGGERED
+    assert record["dimension_results"][0]["status"] == "WITHIN_THRESHOLD"
+
+
+def test_exceeding_threshold_reuses_rejected_reality_gap() -> None:
+    record = build_canonical_reality_gap_record_v1(
+        _request(gap_dimensions=(_dimension(observed=0.01, threshold=0.001),))
+    )
+    assert record["overall_disposition"] == DISPOSITION_REJECTED_REALITY_GAP
+    assert record["failed_gate"] == FAILED_GATE_REALITY_GAP
+    assert record["dimension_results"][0]["status"] == "EXCEEDS_THRESHOLD"
+
+
+def test_mixed_dimensions_reject_when_any_exceeds() -> None:
+    record = build_canonical_reality_gap_record_v1(
+        _request(
+            gap_dimensions=(
+                _dimension("fee", expected=0.001, observed=0.001, threshold=0.001),
+                _dimension("slippage", expected=0.002, observed=0.02, threshold=0.001),
+            )
+        )
+    )
+    statuses = {item["name"]: item["status"] for item in record["dimension_results"]}
+    assert statuses["fee"] == "WITHIN_THRESHOLD"
+    assert statuses["slippage"] == "EXCEEDS_THRESHOLD"
+    assert record["overall_disposition"] == DISPOSITION_REJECTED_REALITY_GAP
+    assert record["dimension_results"][1]["identity_digest_field"] == "slippage_model_digest"
+
+
+def test_missing_or_defaulted_gap_values_fail_closed() -> None:
+    with pytest.raises(RealityGapValidationError, match="at least one gap dimension"):
+        build_canonical_reality_gap_record_v1(_request(gap_dimensions=()))
+    with pytest.raises(RealityGapValidationError, match="unknown or unsupported"):
+        build_canonical_reality_gap_record_v1(_request(gap_dimensions=(_dimension(name="impact"),)))
+    with pytest.raises(RealityGapValidationError, match="implicit unavailable"):
+        build_canonical_reality_gap_record_v1(
+            _request(gap_dimensions=(_dimension(unit="default"),))
+        )
+    with pytest.raises(RealityGapValidationError, match="non-finite"):
+        build_canonical_reality_gap_record_v1(
+            _request(gap_dimensions=(_dimension(expected=float("nan")),))
+        )
+    with pytest.raises(RealityGapValidationError, match="non-finite"):
+        build_canonical_reality_gap_record_v1(
+            _request(gap_dimensions=(_dimension(observed=float("inf")),))
+        )
+    with pytest.raises(RealityGapValidationError, match="threshold must be >= 0"):
+        build_canonical_reality_gap_record_v1(
+            _request(gap_dimensions=(_dimension(threshold=-0.001),))
+        )
+
+
+def test_unknown_observed_surface_and_wrong_expected_surface_fail_closed() -> None:
+    with pytest.raises(RealityGapValidationError, match="expected_surface must be RESEARCH"):
+        build_canonical_reality_gap_record_v1(_request(expected_surface="LIVE"))
+    with pytest.raises(RealityGapValidationError, match="observed_surface is unknown"):
+        build_canonical_reality_gap_record_v1(_request(observed_surface="PRODUCTION"))
+    live_observation = build_canonical_reality_gap_record_v1(
+        _request(observed_surface=OBSERVED_SURFACE_LIVE)
+    )
+    assert live_observation["observed_surface"] == OBSERVED_SURFACE_LIVE
+    assert live_observation["observed_surface_is_not_authorization"] is True
+    assert live_observation["reality_gap_can_submit_order"] is False
+    assert live_observation["reality_gap_can_promote_to_live"] is False
+
+
+def test_append_only_identical_replay_and_divergent_conflict(tmp_path: Path) -> None:
+    store = CanonicalRealityGapStoreV1(tmp_path / "reality-gap")
+    record = build_canonical_reality_gap_record_v1(_request())
+    first = store.append(record)
+    second = store.append(record)
+    assert canonical_record_payload(first) == canonical_record_payload(second)
+    dest = tmp_path / "reality-gap" / str(record["reality_gap_record_id"]) / RECORD_FILENAME
+    original = dest.read_text(encoding="utf-8")
+    later = build_canonical_reality_gap_record_v1(_request(created_at="2026-08-17T23:00:00Z"))
+    stored_later = store.append(later)
+    assert stored_later["reality_gap_record_id"] != record["reality_gap_record_id"]
+    assert dest.read_text(encoding="utf-8") == original
+    assert store.exists(str(record["reality_gap_record_id"])) is True
+    listed = store.list_by_experiment_id(str(record["experiment_id"]))
+    assert {item["reality_gap_record_id"] for item in listed} == {
+        record["reality_gap_record_id"],
+        stored_later["reality_gap_record_id"],
+    }
+
+
+def test_historical_record_not_overwritten_on_conflict(tmp_path: Path) -> None:
+    store = CanonicalRealityGapStoreV1(tmp_path / "reality-gap")
+    record = build_canonical_reality_gap_record_v1(_request())
+    store.append(record)
+    dest = tmp_path / "reality-gap" / str(record["reality_gap_record_id"]) / RECORD_FILENAME
+    original = dest.read_text(encoding="utf-8")
+    mutated = canonical_record_payload(record)
+    mutated["observed_surface"] = OBSERVED_SURFACE_LIVE
+    dest.write_text(deterministic_json_dumps(mutated) + "\n", encoding="utf-8")
+    with pytest.raises(RealityGapValidationError):
+        store.get(str(record["reality_gap_record_id"]))
+    dest.write_text(original, encoding="utf-8")
+    loaded = store.get(str(record["reality_gap_record_id"]))
+    assert canonical_record_payload(loaded) == canonical_record_payload(record)
+    assert dest.read_text(encoding="utf-8") == original
+
+
+def test_evidence_and_experiment_refs_remain_complete() -> None:
+    identity = _identity()
+    record = build_canonical_reality_gap_record_v1(_request(identity))
+    assert record["evidence_refs"][0]["kind"] == "EXPERIMENT_RECORD"
+    assert record["evidence_refs"][0]["ref"] == record["experiment_id"]
+    with pytest.raises(RealityGapValidationError, match="EXPERIMENT_RECORD"):
+        build_canonical_reality_gap_record_v1(
+            _request(
+                identity,
+                evidence_refs=[
+                    {
+                        "kind": "REPO_RELATIVE",
+                        "ref": "docs/ops/specs/CANONICAL_REALITY_GAP_STORE_V1.md",
+                        "digest": _digest("doc"),
+                    }
+                ],
+            )
+        )
+    with pytest.raises(RealityGapValidationError, match="path traversal"):
+        build_canonical_reality_gap_record_v1(
+            _request(
+                identity,
+                evidence_refs=[
+                    {
+                        "kind": "EXPERIMENT_RECORD",
+                        "ref": derive_experiment_id_v1(str(identity["identity_digest"])),
+                        "digest": _digest("experiment-record"),
+                    },
+                    {
+                        "kind": "REPO_RELATIVE",
+                        "ref": "../secrets.env",
+                        "digest": _digest("escape"),
+                    },
+                ],
+            )
+        )
+    with pytest.raises(RealityGapValidationError, match="not bound"):
+        build_canonical_reality_gap_record_v1(_request(experiment_id=_digest("unrelated")))
+
+
+def test_store_does_not_write_failure_memory(tmp_path: Path) -> None:
+    store = CanonicalRealityGapStoreV1(tmp_path / "reality-gap")
+    record = build_canonical_reality_gap_record_v1(
+        _request(gap_dimensions=(_dimension(observed=0.05, threshold=0.001),))
+    )
+    stored = store.append(record)
+    assert stored["overall_disposition"] == DISPOSITION_REJECTED_REALITY_GAP
+    leftover = [
+        path for path in tmp_path.rglob("*") if path.is_file() and "failure_memory" in path.name
+    ]
+    assert leftover == []
+    schema_source = SCHEMA_MODULE_PATH.read_text(encoding="utf-8")
+    persist_source = STORE_MODULE_PATH.read_text(encoding="utf-8")
+    assert "canonical_failure_memory_store_v1" not in schema_source
+    assert "canonical_failure_memory_store_v1" not in persist_source
+
+
+def test_no_runtime_live_config_promotion_or_authority_paths() -> None:
+    for module_path in (SCHEMA_MODULE_PATH, STORE_MODULE_PATH):
+        source = module_path.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        imported: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported.update(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.add(node.module)
+        forbidden_imports = {
+            "src.core.peak_config",
+            "src.governance.promotion_loop",
+            "src.governance.promotion_loop.engine",
+            "src.execution",
+            "scripts.run_learning_apply_cycle",
+            "src.live",
+            "src.trading",
+            "src.trading.master_v2",
+            "src.risk",
+            "src.experiments.canonical_comparison_ssot_v1",
+            "src.experiments.canonical_champion_challenger_v1",
+            "src.meta.learning_loop.comparison_ssot_v1",
+            "src.meta.learning_loop.runtime_observation_feedback_v1",
+            "src.meta.learning_loop.canary_micro_live_readiness_v1",
+            "src.experiments.live_session_registry",
+        }
+        assert forbidden_imports.isdisjoint(imported)
+        for token in (
+            "config/live_overrides",
+            "config/auto/",
+            "load_config_with_live_overrides",
+            "submit_order(",
+            "apply_proposals_to_live_overrides",
+            "write_live_config(",
+            "LIVE_AUTHORIZED",
+            "TESTNET_AUTHORIZED",
+            "FUNDING_AUTHORIZED",
+            "promote_to_live(",
+            "create_confirm_token(",
+            "use_confirm_token(",
+        ):
+            assert token not in source
+        assert "Phase 8" not in source
+        assert "regime-aware" not in source.lower()
+    record = build_canonical_reality_gap_record_v1(_request())
+    assert isinstance(record, MappingProxyType)
+    with pytest.raises(TypeError):
+        record["overall_disposition"] = DISPOSITION_REJECTED_REALITY_GAP  # type: ignore[index]
+    assert REALITY_GAP_STORE_PRESENT is True
+    assert REALITY_GAP_STORE_HAS_RUNTIME_AUTHORITY is False
+    assert REALITY_GAP_CAN_MUTATE_LIVE_CONFIG is False
+    assert REALITY_GAP_CAN_PROMOTE is False
+    assert PROMOTION_AUTHORITY == "NONE"
+    assert OBSERVED_SURFACE_IS_NOT_AUTHORIZATION is True
+    assert record["reality_gap_can_mutate_live_config"] is False
+    assert record["reality_gap_can_submit_order"] is False
+    assert record["reality_gap_can_fund"] is False
+    assert record["reality_gap_can_increase_risk"] is False
+    assert record["reality_gap_can_increase_leverage"] is False
+    assert record["reality_gap_can_authorize_canary"] is False
+    assert record["reality_gap_can_promote_to_live"] is False
+    assert "apply_proposals_to_live_overrides" not in inspect.getsource(
+        build_canonical_reality_gap_record_v1
+    )
+    assert "apply_proposals_to_live_overrides" not in inspect.getsource(
+        CanonicalRealityGapStoreV1.append
+    )


### PR DESCRIPTION
## Summary
- Adds the Phase 7 Canonical Reality Gap Store. Expected-versus-observed research measurements are bound to the Phase 1 experiment identity and Phase 2 `experiment_id`; cost dimensions reuse the identity fee/slippage/funding digests.
- Exceeding an explicit threshold reuses the Phase 2/3 token `REJECTED_REALITY_GAP` / `REALITY_GAP_GATE`. The store does not append Failure Memory, rank candidates, swap a Champion, or authorize SHADOW/PAPER_EXCHANGE/TESTNET/LIVE.
- Does not implement Phase 8 Regime-Aware Evaluation. No live-config, promotion-apply, risk, leverage, funding, order, canary, or authority-surface change.

## Test plan
- [x] `uv run python -m pytest tests/experiments/test_canonical_reality_gap_store_v1.py -q`
- [x] Phase 1–6 regression: identity, memory, failure memory, robustness, comparison SSOT, champion-challenger
- [x] Selector `PR_BOUNDED_FULL` (`category_central_src_requires_full`) plus bounded CI contract targets
- [x] `ruff format --check` / `ruff check` on the new files
- [x] Docs token policy and docs reference targets on the new spec


Made with [Cursor](https://cursor.com)