### PR TITLE
research: add canonical advanced search v1

### DIFF
--- a/docs/ops/specs/CANONICAL_ADVANCED_SEARCH_V1.md
+++ b/docs/ops/specs/CANONICAL_ADVANCED_SEARCH_V1.md
@@ -1,0 +1,299 @@
+# Canonical Advanced Search v1
+
+Contract for Peak_Trade Phase 12 Advanced Search.
+
+```text
+SCHEMA_VERSION=canonical_advanced_search_v1
+ADVANCED_SEARCH_DOMAIN=peak_trade.canonical_advanced_search.v1
+ADVANCED_SEARCH_PRESENT=true
+ADVANCED_SEARCH_AUTHORITY=RESEARCH_ONLY
+SEARCH_IS_AUTHORITY_MECHANISM=false
+SEARCH_HAS_RUNTIME_AUTHORITY=false
+SEARCH_CAN_MUTATE_LIVE_CONFIG=false
+SEARCH_CAN_PROMOTE=false
+PROMOTION_AUTHORITY=NONE
+SELF_LEARNING_SELF_AUTHORIZING_SEPARATION=true
+SELF_LEARNING_NOT_SELF_AUTHORIZING=true
+BEST_SHARPE_IS_NOT_AUTO_WINNER=true
+PHASE_13_STARTED=false
+```
+
+Owner:
+
+- `src&#47;experiments&#47;canonical_advanced_search_v1.py` — propose research candidates only
+
+Reuse, do not replace:
+
+```text
+Phase 1  src.experiments.canonical_experiment_identity_v1     REUSE identity
+Phase 2  src.experiments.canonical_experiment_memory_v1       REUSE experiment_id
+Phase 3  src.experiments.canonical_failure_memory_v1          REUSE fingerprint and duplicate assessment
+Phase 4  robustness_suite_version / robustness_policy_digest  REUSE tokens
+Phase 7  src.experiments.canonical_reality_gap_store_v1       REUSE gap records as signals
+Phase 10 canonical_automated_offline_research_loop_v1         REUSE as request target, not executor
+Phase 11 src.experiments.canonical_meta_learning_v1           REUSE research_proposals as priority signals
+```
+
+```text
+Phase 5  src.experiments.canonical_comparison_ssot_v1         NOT_APPLICABLE as ranking authority
+Phase 6  src.experiments.canonical_champion_challenger_v1     NOT_APPLICABLE as ranking authority
+Phase 8  src.experiments.canonical_regime_aware_evaluation_v1 NOT_APPLICABLE as calculator
+Phase 9  src.experiments.canonical_portfolio_learning_v1      NOT_APPLICABLE
+src.meta.learning_loop.comparison_ssot_v1                    NOT_APPLICABLE
+src.governance.promotion_loop.engine                          NOT_APPLICABLE
+src.live.live_gates                                           NOT_APPLICABLE
+src.experiments.canonical_automated_offline_research_loop_v1  NOT_APPLICABLE as executor
+```
+
+```text
+ADVANCED_SEARCH == SEARCH_MECHANISM
+ADVANCED_SEARCH != AUTHORITY_MECHANISM
+SEARCH_SCORE != CANONICAL_CHAMPION_CHALLENGER_RANKING
+BEST_SHARPE != AUTO_WINNER
+```
+
+This layer does not invent identity, comparability, metrics, robustness, failure, or ranking truth. It proposes identity-bound research candidates. It does not start Phase 13, live, canary, funding, order submit, confirm tokens, productive config write, or autonomous promotion.
+
+## Authority
+
+```text
+SELF_LEARNING != SELF_AUTHORIZING
+ADVANCED_SEARCH_AUTHORITY=RESEARCH_ONLY
+```
+
+Search may create research candidates, hypotheses, parameter-region proposals, search evidence, and offline-experiment requests. Search may consume Phase-11 priority signals. Search must not authoritatively promote experiments, candidates, or champions.
+
+## Supported search mechanism
+
+This contract implements exactly one mechanism:
+
+```text
+BOUNDED_DETERMINISTIC_CONSTRAINED_REGION_SEARCH
+```
+
+The method enumerates a declared discrete search space in canonical order, applies fail-closed identity / constraint / failure-memory gates, and uses Phase-11 signals only as documented priority weights.
+
+The following method tokens are recognized and fail closed as unsupported:
+
+```text
+BAYESIAN_OPTIMIZATION
+OPTUNA
+EVOLUTIONARY_SEARCH
+GENETIC_ALGORITHM
+ML_BASED_SEARCH
+AGENTIC_HYPOTHESIS_GENERATION
+REINFORCEMENT_LEARNING
+```
+
+Unknown methods fail closed. No hidden global random state is used. The bound `seed` is part of search identity even though this method is deterministic.
+
+## Shape
+
+A COMPLETE record evaluates one explicit search request against a Phase-1 identity template plus optional Phase-3 failure records, Phase-7 reality-gap records, and Phase-11 research proposals.
+
+```text
+SEARCH_SPACE_VALIDATION
+CONSTRAINT_ENFORCEMENT
+IDENTITY_BINDING
+FAILURE_MEMORY_ASSESSMENT
+META_LEARNING_PRIORITY_BINDING
+CANDIDATE_PROPOSAL
+OFFLINE_EXPERIMENT_REQUEST
+SEARCH_EVIDENCE
+```
+
+Silent step omission is forbidden. Every generated candidate is represented in evidence, including rejected and deprioritized candidates.
+
+```text
+SEARCH_CAN_CREATE_RESEARCH_CANDIDATES=true
+SEARCH_CAN_CREATE_HYPOTHESES=true
+SEARCH_CAN_PROPOSE_PARAMETER_REGIONS=true
+SEARCH_CAN_USE_META_LEARNING_SIGNALS=true
+SEARCH_CAN_REQUEST_OFFLINE_EXPERIMENTS=true
+```
+
+```text
+OFFLINE_EXPERIMENT_REQUEST != run Phase 10 loop
+OFFLINE_EXPERIMENT_REQUEST != write config
+OFFLINE_EXPERIMENT_REQUEST != execute robustness
+```
+
+## Identity binding
+
+Every candidate must be bound with `build_canonical_experiment_identity_v1` before storage. The identity template supplies every critical binding. Search may vary only declared research-parameter axes that already exist on the template.
+
+No implicit:
+
+```text
+fees
+slippage
+funding
+dataset versions
+split policies
+risk policies
+portfolio definitions
+seeds
+core-logic versions
+```
+
+A candidate without a COMPLETE identity is rejected fail-closed and is never proposed.
+
+Frozen template fields must remain identical on every candidate identity:
+
+```text
+fee_model_digest
+slippage_model_digest
+funding_model_digest
+cost_model_digest
+risk_policy_digest
+portfolio_digest
+split_policy_digest
+dataset_digest
+feature_pipeline_digest
+strategy_identity
+seed
+git_sha
+trading_decision_core_digest and core-logic component digests
+```
+
+`strategy_params_digest` and `identity_digest` may change with the proposed parameters.
+
+## Constraints and Goodhart safety
+
+Risk, cost, data, robustness, and authority limits are constraints, not optimizer objectives.
+
+Forbidden search axes include risk, leverage, turnover, tail risk, liquidity, fill, fee, slippage, funding, holdout, split, dataset, enable, arm, live, testnet, order, canary, confirm token, promotion, and core-logic surfaces.
+
+```text
+SEARCH_CAN_WRITE_LIVE_CONFIG=false
+SEARCH_CAN_WRITE_TESTNET_CONFIG=false
+SEARCH_CAN_INCREASE_RISK=false
+SEARCH_CAN_INCREASE_LEVERAGE=false
+SEARCH_CAN_FUND=false
+SEARCH_CAN_SUBMIT_ORDER=false
+SEARCH_CAN_ARM=false
+SEARCH_CAN_ENABLE=false
+SEARCH_CAN_CREATE_CONFIRM_TOKEN=false
+SEARCH_CAN_USE_CONFIRM_TOKEN=false
+SEARCH_CAN_AUTHORIZE_CANARY=false
+SEARCH_CAN_PROMOTE_TO_LIVE=false
+SEARCH_CAN_REPLACE_PRODUCTIVE_CHAMPION=false
+SEARCH_CAN_AUTONOMOUSLY_REPLACE_CORE_LOGIC=false
+```
+
+Search priority is not canonical ranking. Incomparable or unevaluated candidates are never ranked. Robustness is not shortened. Promotion gates are not redefined.
+
+## Failure Memory and duplicates
+
+Before a candidate may be proposed, Phase 3 is assessed for:
+
+```text
+exact hypothesis duplicate
+hypothesis fingerprint
+known rejected parameter region
+known failure class
+known robustness failure
+known reality-gap failure
+```
+
+```text
+DUPLICATE_DETECTED != AUTOMATIC_RESEARCH_BAN
+```
+
+Allowed actions remain the Phase-3 set: `WARN` / `ANNOTATE` / `PRIORITIZE` / `DEPRIORITIZE` / `REQUIRE_EXPLICIT_RETEST_REASON`. Failure Memory may deprioritize or warn. It must not silently omit a candidate. A duplicate without `retest_reason` is an explicit `REJECTED_DUPLICATE_WITHOUT_RETEST` evidence row, not a proposed candidate.
+
+## Meta-Learning binding
+
+```text
+META_LEARNING_OUTPUT_REUSE=research_proposals
+SEARCH_PRIORITY_REUSE=PRIORITIZE_RESEARCH|DEPRIORITIZE_RESEARCH|INVESTIGATE|RETEST_WITH_EXPLICIT_REASON
+FAILURE_SIGNAL_REUSE=Phase 3 records
+ROBUSTNESS_SIGNAL_REUSE=Phase 3 REJECTED_* robustness classes
+REALITY_GAP_SIGNAL_REUSE=Phase 7 records
+```
+
+Meta-Learning may change search priority. It does not create authority. Signals without a bound `meta_learning_identity` fail closed.
+
+## Determinism
+
+Search identity binds:
+
+```text
+search_method
+search_method_version
+search_space_digest
+objective_definition/version
+constraint_definition/version
+seed
+budget
+parent hypothesis/reference
+input evidence refs
+generated candidate refs
+```
+
+Identical lineage-bound inputs yield an identical result.
+
+## Canonical evidence fields
+
+```text
+search_identity
+search_method
+search_method_version
+search_space
+objective
+constraint
+seed
+budget
+parent_hypothesis_id
+candidates
+hypotheses
+parameter_region_proposals
+offline_experiment_requests
+duplicate_assessments
+search_evidence
+overall_status
+created_at
+```
+
+Candidate statuses:
+
+```text
+PROPOSED
+BUDGET_EXCLUDED
+DEPRIORITIZED_KNOWN_FAILURE
+REJECTED_DUPLICATE_WITHOUT_RETEST
+REJECTED_IDENTITY
+REJECTED_CONSTRAINT
+```
+
+`SEARCH_COMPLETE` is not promotion, not Champion swap, and not runtime authority.
+
+## What this layer cannot do
+
+```text
+SEARCH_IS_AUTHORITY_MECHANISM=false
+SEARCH_HAS_RUNTIME_AUTHORITY=false
+SEARCH_CAN_MUTATE_LIVE_CONFIG=false
+SEARCH_CAN_WRITE_LIVE_CONFIG=false
+SEARCH_CAN_WRITE_TESTNET_CONFIG=false
+SEARCH_CAN_PROMOTE=false
+AUTONOMOUS_CHAMPION_SWAP=false
+AUTONOMOUS_PROMOTION=false
+SEARCH_CAN_INCREASE_RISK=false
+SEARCH_CAN_INCREASE_LEVERAGE=false
+SEARCH_CAN_FUND=false
+SEARCH_CAN_SUBMIT_ORDER=false
+SEARCH_CAN_ARM=false
+SEARCH_CAN_ENABLE=false
+SEARCH_CAN_CREATE_CONFIRM_TOKEN=false
+SEARCH_CAN_USE_CONFIRM_TOKEN=false
+SEARCH_CAN_AUTHORIZE_CANARY=false
+SEARCH_CAN_PROMOTE_TO_LIVE=false
+SEARCH_CAN_REPLACE_PRODUCTIVE_CHAMPION=false
+LEARNING_MAY_AUTONOMOUSLY_REPLACE_CORE_LOGIC=false
+HISTORICAL_RECORD_MUTATION=false
+PRODUCTIVE_CONFIG_MUTATION=false
+PHASE_13_STARTED=false
+```
+
+Phase 12 does not start Phase 13, live, canary, funding, order submit, confirm tokens, productive config write, or autonomous promotion.

--- a/src/experiments/canonical_advanced_search_v1.py
+++ b/src/experiments/canonical_advanced_search_v1.py
@@ -1,0 +1,1515 @@
+"""Phase 12 Canonical Advanced Search v1 (research proposals only).
+
+Enumerates a declared discrete search space, binds every candidate to
+Phase 1 identity, consults Phase 3 / Phase 7 / Phase 11 signals, and
+emits research candidates plus offline-experiment requests. This layer
+does not rank, promote, write config, fund, or submit orders.
+"""
+
+from __future__ import annotations
+
+import itertools
+import logging
+import math
+import re
+from dataclasses import dataclass, replace
+from types import MappingProxyType
+from typing import Any, Final, Mapping, Sequence
+
+from src.experiments.canonical_experiment_identity_v1 import (
+    CanonicalExperimentIdentityError,
+    CanonicalExperimentIdentityRequestV1,
+    canonicalize_mapping,
+    build_canonical_experiment_identity_v1,
+    validate_canonical_experiment_identity_v1,
+)
+from src.experiments.canonical_experiment_memory_v1 import derive_experiment_id_v1
+from src.experiments.canonical_failure_memory_v1 import (
+    SCHEMA_VERSION as FAILURE_MEMORY_VERSION,
+    assess_duplicate_hypothesis_v1,
+    derive_hypothesis_fingerprint_v1,
+    validate_canonical_failure_memory_record_v1,
+)
+from src.experiments.canonical_meta_learning_v1 import (
+    CANONICAL_PROPOSAL_KINDS,
+    META_LEARNING_AUTHORITY,
+    PROPOSAL_DEPRIORITIZE_RESEARCH,
+    PROPOSAL_INVESTIGATE,
+    PROPOSAL_PRIORITIZE_RESEARCH,
+    PROPOSAL_RETEST,
+    PROMOTION_AUTHORITY as META_PROMOTION_AUTHORITY,
+    SCHEMA_VERSION as META_LEARNING_SCHEMA_VERSION,
+)
+from src.experiments.canonical_reality_gap_store_v1 import (
+    DISPOSITION_REJECTED_REALITY_GAP,
+    SCHEMA_VERSION as REALITY_GAP_VERSION,
+    validate_canonical_reality_gap_record_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import (
+    classify_patch_target,
+    compute_content_sha256,
+    is_valid_sha256_hex,
+)
+
+SCHEMA_VERSION: Final[str] = "canonical_advanced_search_v1"
+ADVANCED_SEARCH_DOMAIN: Final[str] = "peak_trade.canonical_advanced_search.v1"
+DIGEST_ALGORITHM: Final[str] = "sha256"
+RECORD_COMPLETENESS_COMPLETE: Final[str] = "COMPLETE"
+IDENTITY_SCHEMA_VERSION: Final[str] = "canonical_experiment_identity_v1"
+EXPERIMENT_MEMORY_SCHEMA_VERSION: Final[str] = "canonical_experiment_memory_v1"
+ROBUSTNESS_SUITE_VERSION: Final[str] = "canonical_robustness_suite_v1"
+OFFLINE_LOOP_SCHEMA_VERSION: Final[str] = "canonical_automated_offline_research_loop_v1"
+SEARCH_METHOD_VERSION: Final[str] = "canonical_advanced_search_method_v1"
+OBJECTIVE_VERSION: Final[str] = "canonical_advanced_search_objective_v1"
+CONSTRAINT_VERSION: Final[str] = "canonical_advanced_search_constraint_v1"
+OBJECTIVE_ID: Final[str] = "SEARCH_PRIORITY_INFORMATION_GAIN_V1"
+CONSTRAINT_ID: Final[str] = "SEARCH_AUTHORITY_AND_COST_INVARIANT_V1"
+
+ADVANCED_SEARCH_PRESENT: Final[bool] = True
+ADVANCED_SEARCH_AUTHORITY: Final[str] = "RESEARCH_ONLY"
+SEARCH_IS_AUTHORITY_MECHANISM: Final[bool] = False
+SEARCH_HAS_RUNTIME_AUTHORITY: Final[bool] = False
+SEARCH_CAN_CREATE_RESEARCH_CANDIDATES: Final[bool] = True
+SEARCH_CAN_CREATE_HYPOTHESES: Final[bool] = True
+SEARCH_CAN_PROPOSE_PARAMETER_REGIONS: Final[bool] = True
+SEARCH_CAN_USE_META_LEARNING_SIGNALS: Final[bool] = True
+SEARCH_CAN_REQUEST_OFFLINE_EXPERIMENTS: Final[bool] = True
+SEARCH_CAN_MUTATE_LIVE_CONFIG: Final[bool] = False
+SEARCH_CAN_WRITE_LIVE_CONFIG: Final[bool] = False
+SEARCH_CAN_WRITE_TESTNET_CONFIG: Final[bool] = False
+SEARCH_CAN_INCREASE_RISK: Final[bool] = False
+SEARCH_CAN_INCREASE_LEVERAGE: Final[bool] = False
+SEARCH_CAN_FUND: Final[bool] = False
+SEARCH_CAN_SUBMIT_ORDER: Final[bool] = False
+SEARCH_CAN_ARM: Final[bool] = False
+SEARCH_CAN_ENABLE: Final[bool] = False
+SEARCH_CAN_CREATE_CONFIRM_TOKEN: Final[bool] = False
+SEARCH_CAN_USE_CONFIRM_TOKEN: Final[bool] = False
+SEARCH_CAN_AUTHORIZE_CANARY: Final[bool] = False
+SEARCH_CAN_PROMOTE: Final[bool] = False
+SEARCH_CAN_PROMOTE_TO_LIVE: Final[bool] = False
+SEARCH_CAN_REPLACE_PRODUCTIVE_CHAMPION: Final[bool] = False
+SEARCH_CAN_AUTONOMOUSLY_REPLACE_CORE_LOGIC: Final[bool] = False
+AUTONOMOUS_CHAMPION_SWAP: Final[bool] = False
+AUTONOMOUS_PROMOTION: Final[bool] = False
+LEARNING_MAY_AUTONOMOUSLY_REPLACE_CORE_LOGIC: Final[bool] = False
+SELF_LEARNING_SELF_AUTHORIZING_SEPARATION: Final[bool] = True
+SELF_LEARNING_NOT_SELF_AUTHORIZING: Final[bool] = True
+HISTORICAL_RECORD_MUTATION: Final[bool] = False
+PRODUCTIVE_CONFIG_MUTATION: Final[bool] = False
+BEST_SHARPE_IS_NOT_AUTO_WINNER: Final[bool] = True
+PROMOTION_AUTHORITY: Final[str] = "NONE"
+RUNTIME_AUTHORITY_IMPACT: Final[str] = "NONE"
+PHASE_13_STARTED: Final[bool] = False
+
+SEARCH_METHOD_BOUNDED_DETERMINISTIC_CONSTRAINED_REGION_SEARCH: Final[str] = (
+    "BOUNDED_DETERMINISTIC_CONSTRAINED_REGION_SEARCH"
+)
+SUPPORTED_SEARCH_METHODS: Final[tuple[str, ...]] = (
+    SEARCH_METHOD_BOUNDED_DETERMINISTIC_CONSTRAINED_REGION_SEARCH,
+)
+UNSUPPORTED_SEARCH_METHODS: Final[tuple[str, ...]] = (
+    "BAYESIAN_OPTIMIZATION",
+    "OPTUNA",
+    "EVOLUTIONARY_SEARCH",
+    "GENETIC_ALGORITHM",
+    "ML_BASED_SEARCH",
+    "AGENTIC_HYPOTHESIS_GENERATION",
+    "REINFORCEMENT_LEARNING",
+)
+
+LINEAGE_KIND_ROOT: Final[str] = "ROOT"
+LINEAGE_KIND_PARENT_BOUND: Final[str] = "PARENT_BOUND"
+CANONICAL_LINEAGE_KINDS: Final[tuple[str, ...]] = (LINEAGE_KIND_ROOT, LINEAGE_KIND_PARENT_BOUND)
+
+STATUS_PROPOSED: Final[str] = "PROPOSED"
+STATUS_BUDGET_EXCLUDED: Final[str] = "BUDGET_EXCLUDED"
+STATUS_DEPRIORITIZED_KNOWN_FAILURE: Final[str] = "DEPRIORITIZED_KNOWN_FAILURE"
+STATUS_REJECTED_DUPLICATE_WITHOUT_RETEST: Final[str] = "REJECTED_DUPLICATE_WITHOUT_RETEST"
+STATUS_REJECTED_IDENTITY: Final[str] = "REJECTED_IDENTITY"
+STATUS_REJECTED_CONSTRAINT: Final[str] = "REJECTED_CONSTRAINT"
+CANONICAL_CANDIDATE_STATUSES: Final[tuple[str, ...]] = (
+    STATUS_PROPOSED,
+    STATUS_BUDGET_EXCLUDED,
+    STATUS_DEPRIORITIZED_KNOWN_FAILURE,
+    STATUS_REJECTED_DUPLICATE_WITHOUT_RETEST,
+    STATUS_REJECTED_IDENTITY,
+    STATUS_REJECTED_CONSTRAINT,
+)
+OVERALL_COMPLETE: Final[str] = "SEARCH_COMPLETE"
+OFFLINE_REQUEST_KIND: Final[str] = "OFFLINE_EXPERIMENT_REQUEST"
+
+ROBUSTNESS_FAILURE_CLASSES: Final[frozenset[str]] = frozenset(
+    {
+        "REJECTED_OVERFIT",
+        "REJECTED_TAIL_RISK",
+        "REJECTED_COST_SENSITIVITY",
+        "REJECTED_REGIME_CONCENTRATION",
+        "REJECTED_DATA_QUALITY",
+        "REJECTED_REPRODUCIBILITY",
+    }
+)
+FROZEN_IDENTITY_FIELDS: Final[tuple[str, ...]] = (
+    "bull_bear_logic_digest",
+    "cost_model_digest",
+    "dataset_digest",
+    "double_play_logic_digest",
+    "entry_position_exit_logic_digest",
+    "environment_digest",
+    "feature_pipeline_digest",
+    "fee_model_digest",
+    "funding_model_digest",
+    "git_sha",
+    "market_context_contract_digest",
+    "portfolio_digest",
+    "risk_policy_digest",
+    "seed",
+    "slippage_model_digest",
+    "split_policy_digest",
+    "state_switch_logic_digest",
+    "strategy_identity",
+    "suitability_logic_digest",
+    "survival_logic_digest",
+    "trading_decision_core_digest",
+    "working_tree_status",
+)
+FORBIDDEN_SEARCH_AXIS_TOKENS: Final[frozenset[str]] = frozenset(
+    {
+        "arm",
+        "armed",
+        "canary",
+        "capital",
+        "champion",
+        "confirm_token",
+        "dataset",
+        "enable",
+        "enabled",
+        "execution",
+        "fee",
+        "fees",
+        "fill",
+        "fund",
+        "funding",
+        "holdout",
+        "kill_switch",
+        "leverage",
+        "liquidity",
+        "live",
+        "order",
+        "orders",
+        "promotion",
+        "risk",
+        "routing",
+        "sizing",
+        "slippage",
+        "split",
+        "stop",
+        "tail",
+        "tail_risk",
+        "testnet",
+        "turnover",
+    }
+)
+PRIORITY_PRIORITIZE: Final[int] = 20
+PRIORITY_INVESTIGATE: Final[int] = 10
+PRIORITY_NEUTRAL: Final[int] = 0
+PRIORITY_DEPRIORITIZE: Final[int] = -20
+PRIORITY_DUPLICATE_WARN: Final[int] = -5
+
+_CREATED_AT_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?Z$")
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9._:-]{1,128}$")
+_AXIS_NAME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
+_UNAVAILABLE_TOKENS = frozenset(
+    {
+        "",
+        "unknown",
+        "unavailable",
+        "n/a",
+        "na",
+        "none",
+        "null",
+        "implicit",
+        "default",
+        "compatible",
+        "zero",
+    }
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AdvancedSearchValidationError(ValueError):
+    """Fail-closed Canonical Advanced Search v1 validation error."""
+
+
+@dataclass(frozen=True)
+class SearchAxisV1:
+    name: str
+    values: Sequence[Any]
+
+
+@dataclass(frozen=True)
+class SearchSpaceV1:
+    search_space_id: str
+    axes: Sequence[SearchAxisV1]
+
+
+@dataclass(frozen=True)
+class SearchObjectiveV1:
+    objective_id: str
+    objective_version: str
+    sharpe_is_not_auto_winner: bool
+    search_score_is_not_canonical_ranking: bool
+
+
+@dataclass(frozen=True)
+class SearchConstraintV1:
+    constraint_id: str
+    constraint_version: str
+    cannot_increase_risk: bool
+    cannot_increase_leverage: bool
+    cannot_write_live_config: bool
+    cannot_write_testnet_config: bool
+    cannot_submit_order: bool
+    cannot_fund: bool
+    cannot_arm: bool
+    cannot_enable: bool
+    cannot_create_or_use_confirm_token: bool
+    cannot_authorize_canary: bool
+    cannot_promote: bool
+    search_score_is_not_canonical_ranking: bool
+
+
+@dataclass(frozen=True)
+class CanonicalAdvancedSearchRequestV1:
+    identity_template: CanonicalExperimentIdentityRequestV1
+    search_space: SearchSpaceV1
+    search_method: str
+    search_method_version: str
+    seed: int
+    budget: int
+    search_space_cardinality_limit: int
+    objective: SearchObjectiveV1
+    constraint: SearchConstraintV1
+    created_at: str
+    parent_hypothesis_id: str
+    lineage_kind: str
+    hypothesis_kind: str
+    strategy_family: str
+    regime: str
+    robustness_policy_digest: str
+    parent_experiment_identity: Mapping[str, Any] | None = None
+    failure_records: Sequence[Mapping[str, Any]] = ()
+    reality_gap_records: Sequence[Mapping[str, Any]] = ()
+    meta_learning_signals: Sequence[Mapping[str, Any]] = ()
+    meta_learning_identity: str | None = None
+    retest_reason: str | None = None
+
+
+def canonical_advanced_search_objective_v1() -> SearchObjectiveV1:
+    return SearchObjectiveV1(
+        objective_id=OBJECTIVE_ID,
+        objective_version=OBJECTIVE_VERSION,
+        sharpe_is_not_auto_winner=True,
+        search_score_is_not_canonical_ranking=True,
+    )
+
+
+def canonical_advanced_search_constraint_v1() -> SearchConstraintV1:
+    return SearchConstraintV1(
+        constraint_id=CONSTRAINT_ID,
+        constraint_version=CONSTRAINT_VERSION,
+        cannot_increase_risk=True,
+        cannot_increase_leverage=True,
+        cannot_write_live_config=True,
+        cannot_write_testnet_config=True,
+        cannot_submit_order=True,
+        cannot_fund=True,
+        cannot_arm=True,
+        cannot_enable=True,
+        cannot_create_or_use_confirm_token=True,
+        cannot_authorize_canary=True,
+        cannot_promote=True,
+        search_score_is_not_canonical_ranking=True,
+    )
+
+
+def build_canonical_advanced_search_v1(
+    request: CanonicalAdvancedSearchRequestV1,
+) -> Mapping[str, Any]:
+    created_at = _require_created_at(request.created_at)
+    search_method = _require_search_method(request.search_method)
+    search_method_version = _require_token("search_method_version", request.search_method_version)
+    if search_method_version != SEARCH_METHOD_VERSION:
+        raise AdvancedSearchValidationError("search_method_version mismatch")
+    seed = _require_seed(request.seed)
+    budget = _require_positive_int("budget", request.budget)
+    cardinality_limit = _require_positive_int(
+        "search_space_cardinality_limit", request.search_space_cardinality_limit
+    )
+    objective = _canonicalize_objective(request.objective)
+    constraint = _canonicalize_constraint(request.constraint)
+    parent_hypothesis_id = _require_token("parent_hypothesis_id", request.parent_hypothesis_id)
+    lineage_kind = _require_enum("lineage_kind", request.lineage_kind, CANONICAL_LINEAGE_KINDS)
+    hypothesis_kind = _require_token("hypothesis_kind", request.hypothesis_kind)
+    strategy_family = _require_token("strategy_family", request.strategy_family)
+    regime = _require_token("regime", request.regime)
+    robustness_policy_digest = _require_sha256(
+        "robustness_policy_digest", request.robustness_policy_digest
+    )
+    retest_reason = _optional_retest_reason(request.retest_reason)
+    search_space, search_space_digest, combinations = _canonicalize_search_space(
+        request.search_space, cardinality_limit=cardinality_limit
+    )
+    template_identity = _build_template_identity(request.identity_template)
+    parent_identity = _canonicalize_parent_identity(
+        request.parent_experiment_identity, lineage_kind=lineage_kind
+    )
+    failure_records = _canonicalize_failure_records(
+        request.failure_records, template_identity=template_identity
+    )
+    gap_records = _canonicalize_gap_records(
+        request.reality_gap_records, template_identity=template_identity
+    )
+    meta_signals = _canonicalize_meta_signals(
+        request.meta_learning_signals,
+        meta_learning_identity=request.meta_learning_identity,
+    )
+    candidates = [
+        _evaluate_combination(
+            combination,
+            identity_template=request.identity_template,
+            template_identity=template_identity,
+            parent_identity=parent_identity,
+            lineage_kind=lineage_kind,
+            parent_hypothesis_id=parent_hypothesis_id,
+            hypothesis_kind=hypothesis_kind,
+            strategy_family=strategy_family,
+            regime=regime,
+            robustness_policy_digest=robustness_policy_digest,
+            search_space_id=str(search_space["search_space_id"]),
+            failure_records=failure_records,
+            gap_records=gap_records,
+            meta_signals=meta_signals,
+            retest_reason=retest_reason,
+        )
+        for combination in combinations
+    ]
+    _assign_proposal_budget(candidates, budget=budget)
+    proposed = [item for item in candidates if item["status"] == STATUS_PROPOSED]
+    hypotheses = [_hypothesis_projection(item) for item in proposed]
+    parameter_region_proposals = [
+        {
+            "hypothesis_id": item["hypothesis_id"],
+            "parameter_region": item["parameter_region"],
+            "status": item["status"],
+        }
+        for item in candidates
+    ]
+    offline_experiment_requests = [
+        item["offline_experiment_request"]
+        for item in proposed
+        if item["offline_experiment_request"] is not None
+    ]
+    input_lineage = {
+        "contract_versions": {
+            "advanced_search": SCHEMA_VERSION,
+            "experiment_identity": IDENTITY_SCHEMA_VERSION,
+            "experiment_memory": EXPERIMENT_MEMORY_SCHEMA_VERSION,
+            "failure_memory": FAILURE_MEMORY_VERSION,
+            "meta_learning": META_LEARNING_SCHEMA_VERSION,
+            "offline_research_loop": OFFLINE_LOOP_SCHEMA_VERSION,
+            "reality_gap_store": REALITY_GAP_VERSION,
+            "robustness_suite": ROBUSTNESS_SUITE_VERSION,
+        },
+        "failure_record_ids": [item["failure_record_id"] for item in failure_records],
+        "generated_candidate_refs": [item["candidate_ref"] for item in candidates],
+        "identity_digest": template_identity["identity_digest"],
+        "meta_learning_identity": request.meta_learning_identity,
+        "parent_experiment_id": (
+            derive_experiment_id_v1(str(parent_identity["identity_digest"]))
+            if parent_identity is not None
+            else None
+        ),
+        "parent_hypothesis_id": parent_hypothesis_id,
+        "reality_gap_record_ids": [item["reality_gap_record_id"] for item in gap_records],
+    }
+    body = {
+        "advanced_search_authority": ADVANCED_SEARCH_AUTHORITY,
+        "advanced_search_domain": ADVANCED_SEARCH_DOMAIN,
+        "advanced_search_present": ADVANCED_SEARCH_PRESENT,
+        "autonomous_champion_swap": AUTONOMOUS_CHAMPION_SWAP,
+        "autonomous_promotion": AUTONOMOUS_PROMOTION,
+        "best_sharpe_is_not_auto_winner": BEST_SHARPE_IS_NOT_AUTO_WINNER,
+        "budget": budget,
+        "candidates": candidates,
+        "champion_experiment_id": None,
+        "completeness": RECORD_COMPLETENESS_COMPLETE,
+        "constraint": constraint,
+        "created_at": created_at,
+        "digest_algorithm": DIGEST_ALGORITHM,
+        "duplicate_assessments": [item["duplicate_assessment"] for item in candidates],
+        "historical_record_mutation": HISTORICAL_RECORD_MUTATION,
+        "hypotheses": hypotheses,
+        "input_lineage": input_lineage,
+        "learning_may_autonomously_replace_core_logic": (
+            LEARNING_MAY_AUTONOMOUSLY_REPLACE_CORE_LOGIC
+        ),
+        "objective": objective,
+        "offline_experiment_requests": offline_experiment_requests,
+        "overall_status": OVERALL_COMPLETE,
+        "parameter_region_proposals": parameter_region_proposals,
+        "phase_13_started": PHASE_13_STARTED,
+        "productive_config_mutation": PRODUCTIVE_CONFIG_MUTATION,
+        "promotion_authority": PROMOTION_AUTHORITY,
+        "ranked_experiment_ids": [],
+        "runtime_authority_impact": RUNTIME_AUTHORITY_IMPACT,
+        "schema_version": SCHEMA_VERSION,
+        "search_can_arm": SEARCH_CAN_ARM,
+        "search_can_authorize_canary": SEARCH_CAN_AUTHORIZE_CANARY,
+        "search_can_autonomously_replace_core_logic": (SEARCH_CAN_AUTONOMOUSLY_REPLACE_CORE_LOGIC),
+        "search_can_create_confirm_token": SEARCH_CAN_CREATE_CONFIRM_TOKEN,
+        "search_can_create_hypotheses": SEARCH_CAN_CREATE_HYPOTHESES,
+        "search_can_create_research_candidates": SEARCH_CAN_CREATE_RESEARCH_CANDIDATES,
+        "search_can_enable": SEARCH_CAN_ENABLE,
+        "search_can_fund": SEARCH_CAN_FUND,
+        "search_can_increase_leverage": SEARCH_CAN_INCREASE_LEVERAGE,
+        "search_can_increase_risk": SEARCH_CAN_INCREASE_RISK,
+        "search_can_mutate_live_config": SEARCH_CAN_MUTATE_LIVE_CONFIG,
+        "search_can_promote": SEARCH_CAN_PROMOTE,
+        "search_can_promote_to_live": SEARCH_CAN_PROMOTE_TO_LIVE,
+        "search_can_propose_parameter_regions": SEARCH_CAN_PROPOSE_PARAMETER_REGIONS,
+        "search_can_replace_productive_champion": SEARCH_CAN_REPLACE_PRODUCTIVE_CHAMPION,
+        "search_can_request_offline_experiments": SEARCH_CAN_REQUEST_OFFLINE_EXPERIMENTS,
+        "search_can_submit_order": SEARCH_CAN_SUBMIT_ORDER,
+        "search_can_use_confirm_token": SEARCH_CAN_USE_CONFIRM_TOKEN,
+        "search_can_use_meta_learning_signals": SEARCH_CAN_USE_META_LEARNING_SIGNALS,
+        "search_can_write_live_config": SEARCH_CAN_WRITE_LIVE_CONFIG,
+        "search_can_write_testnet_config": SEARCH_CAN_WRITE_TESTNET_CONFIG,
+        "search_evidence": {
+            "candidate_count": len(candidates),
+            "deprioritized_known_failure_count": _count_status(
+                candidates, STATUS_DEPRIORITIZED_KNOWN_FAILURE
+            ),
+            "proposed_count": len(proposed),
+            "rejected_constraint_count": _count_status(candidates, STATUS_REJECTED_CONSTRAINT),
+            "rejected_duplicate_count": _count_status(
+                candidates, STATUS_REJECTED_DUPLICATE_WITHOUT_RETEST
+            ),
+            "rejected_identity_count": _count_status(candidates, STATUS_REJECTED_IDENTITY),
+            "search_score_is_not_canonical_ranking": True,
+        },
+        "search_has_runtime_authority": SEARCH_HAS_RUNTIME_AUTHORITY,
+        "search_is_authority_mechanism": SEARCH_IS_AUTHORITY_MECHANISM,
+        "search_method": search_method,
+        "search_method_version": search_method_version,
+        "search_space": search_space,
+        "search_space_digest": search_space_digest,
+        "seed": seed,
+        "self_learning_not_self_authorizing": SELF_LEARNING_NOT_SELF_AUTHORIZING,
+        "self_learning_self_authorizing_separation": SELF_LEARNING_SELF_AUTHORIZING_SEPARATION,
+        "supported_search_mechanisms": list(SUPPORTED_SEARCH_METHODS),
+    }
+    search_identity = derive_search_identity_v1(body)
+    record = dict(body)
+    record["search_identity"] = search_identity
+    record["integrity"] = {
+        "content_sha256": compute_content_sha256(
+            {key: value for key, value in record.items() if key != "integrity"}
+        )
+    }
+    validate_canonical_advanced_search_v1(record)
+    frozen = _freeze(record)
+    _LOGGER.info(
+        "canonical_advanced_search_v1 built identity=%s proposed=%s authority=%s",
+        search_identity,
+        len(proposed),
+        ADVANCED_SEARCH_AUTHORITY,
+    )
+    return frozen
+
+
+def derive_search_identity_v1(record_without_ids: Mapping[str, Any]) -> str:
+    payload = {
+        key: value
+        for key, value in _plain_mapping(record_without_ids).items()
+        if key not in {"search_identity", "integrity"}
+    }
+    envelope = {
+        "digest_algorithm": DIGEST_ALGORITHM,
+        "digest_domain": f"{ADVANCED_SEARCH_DOMAIN}.search_identity",
+        "payload": payload,
+        "schema_version": SCHEMA_VERSION,
+    }
+    return compute_content_sha256(envelope)
+
+
+def canonical_record_payload_v1(record: Mapping[str, Any]) -> dict[str, Any]:
+    return _plain_mapping(record)
+
+
+def validate_canonical_advanced_search_v1(record: Mapping[str, Any]) -> None:
+    if not isinstance(record, Mapping):
+        raise AdvancedSearchValidationError("advanced-search record must be a mapping")
+    payload = _plain_mapping(record)
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        raise AdvancedSearchValidationError("schema_version mismatch")
+    if payload.get("advanced_search_domain") != ADVANCED_SEARCH_DOMAIN:
+        raise AdvancedSearchValidationError("advanced_search_domain mismatch")
+    if payload.get("completeness") != RECORD_COMPLETENESS_COMPLETE:
+        raise AdvancedSearchValidationError("non-COMPLETE advanced-search records are forbidden")
+    if payload.get("advanced_search_authority") != ADVANCED_SEARCH_AUTHORITY:
+        raise AdvancedSearchValidationError("advanced_search_authority must be RESEARCH_ONLY")
+    if payload.get("promotion_authority") != PROMOTION_AUTHORITY:
+        raise AdvancedSearchValidationError("promotion_authority must be NONE")
+    if payload.get("search_is_authority_mechanism") is not False:
+        raise AdvancedSearchValidationError("search_is_authority_mechanism must be false")
+    if payload.get("search_has_runtime_authority") is not False:
+        raise AdvancedSearchValidationError("search_has_runtime_authority must be false")
+    if payload.get("ranked_experiment_ids") != []:
+        raise AdvancedSearchValidationError("ranked_experiment_ids must remain empty")
+    if payload.get("champion_experiment_id") is not None:
+        raise AdvancedSearchValidationError("champion_experiment_id must be null")
+    if payload.get("phase_13_started") is not False:
+        raise AdvancedSearchValidationError("phase_13_started must be false")
+    if payload.get("historical_record_mutation") is not False:
+        raise AdvancedSearchValidationError("historical_record_mutation must be false")
+    if payload.get("productive_config_mutation") is not False:
+        raise AdvancedSearchValidationError("productive_config_mutation must be false")
+    if payload.get("best_sharpe_is_not_auto_winner") is not True:
+        raise AdvancedSearchValidationError("best_sharpe_is_not_auto_winner must be true")
+    if payload.get("search_method") not in SUPPORTED_SEARCH_METHODS:
+        raise AdvancedSearchValidationError("unsupported search_method")
+    if payload.get("search_can_promote") is not False:
+        raise AdvancedSearchValidationError("search_can_promote must be false")
+    if payload.get("search_can_write_live_config") is not False:
+        raise AdvancedSearchValidationError("search_can_write_live_config must be false")
+    if payload.get("search_can_increase_risk") is not False:
+        raise AdvancedSearchValidationError("search_can_increase_risk must be false")
+    if payload.get("search_can_increase_leverage") is not False:
+        raise AdvancedSearchValidationError("search_can_increase_leverage must be false")
+    if payload.get("search_can_submit_order") is not False:
+        raise AdvancedSearchValidationError("search_can_submit_order must be false")
+    if payload.get("search_can_fund") is not False:
+        raise AdvancedSearchValidationError("search_can_fund must be false")
+    if payload.get("search_can_authorize_canary") is not False:
+        raise AdvancedSearchValidationError("search_can_authorize_canary must be false")
+    if payload.get("search_can_create_confirm_token") is not False:
+        raise AdvancedSearchValidationError("search_can_create_confirm_token must be false")
+    if payload.get("search_can_use_confirm_token") is not False:
+        raise AdvancedSearchValidationError("search_can_use_confirm_token must be false")
+    if payload.get("search_can_autonomously_replace_core_logic") is not False:
+        raise AdvancedSearchValidationError(
+            "search_can_autonomously_replace_core_logic must be false"
+        )
+    candidates = payload.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        raise AdvancedSearchValidationError("candidates must be a non-empty list")
+    for candidate in candidates:
+        if candidate.get("status") not in CANONICAL_CANDIDATE_STATUSES:
+            raise AdvancedSearchValidationError("candidate status is not canonical")
+        if candidate.get("search_score_is_not_canonical_ranking") is not True:
+            raise AdvancedSearchValidationError(
+                "search_score_is_not_canonical_ranking must be true"
+            )
+        if candidate.get("status") == STATUS_PROPOSED:
+            if candidate.get("offline_experiment_request") is None:
+                raise AdvancedSearchValidationError(
+                    "proposed candidates must request an offline experiment"
+                )
+            if candidate.get("offline_experiment_request", {}).get("executed") is not False:
+                raise AdvancedSearchValidationError("offline experiment request must not execute")
+            if candidate.get("offline_experiment_request", {}).get("loop_started") is not False:
+                raise AdvancedSearchValidationError(
+                    "offline experiment request must not start loop"
+                )
+        else:
+            if candidate.get("offline_experiment_request") is not None:
+                raise AdvancedSearchValidationError(
+                    "non-proposed candidates must not request offline experiments"
+                )
+    expected_identity = derive_search_identity_v1(
+        {key: value for key, value in payload.items() if key != "integrity"}
+    )
+    if payload.get("search_identity") != expected_identity:
+        raise AdvancedSearchValidationError("search_identity is not bound to canonical content")
+    expected_integrity = compute_content_sha256(
+        {key: value for key, value in payload.items() if key != "integrity"}
+    )
+    integrity = payload.get("integrity")
+    if not isinstance(integrity, Mapping) or integrity.get("content_sha256") != expected_integrity:
+        raise AdvancedSearchValidationError("integrity.content_sha256 mismatch")
+
+
+def _evaluate_combination(
+    combination: Mapping[str, Any],
+    *,
+    identity_template: CanonicalExperimentIdentityRequestV1,
+    template_identity: Mapping[str, Any],
+    parent_identity: Mapping[str, Any] | None,
+    lineage_kind: str,
+    parent_hypothesis_id: str,
+    hypothesis_kind: str,
+    strategy_family: str,
+    regime: str,
+    robustness_policy_digest: str,
+    search_space_id: str,
+    failure_records: Sequence[Mapping[str, Any]],
+    gap_records: Sequence[Mapping[str, Any]],
+    meta_signals: Sequence[Mapping[str, Any]],
+    retest_reason: str | None,
+) -> dict[str, Any]:
+    parameter_region = canonicalize_mapping(combination)
+    hypothesis_id = _candidate_hypothesis_id(parent_hypothesis_id, parameter_region)
+    constraint_reason = _constraint_violation(parameter_region)
+    if constraint_reason is not None:
+        return _rejected_candidate(
+            hypothesis_id=hypothesis_id,
+            parameter_region=parameter_region,
+            status=STATUS_REJECTED_CONSTRAINT,
+            reason=constraint_reason,
+            search_space_id=search_space_id,
+            hypothesis_kind=hypothesis_kind,
+            strategy_family=strategy_family,
+        )
+    try:
+        candidate_identity = _bind_candidate_identity(
+            identity_template,
+            parameter_region=parameter_region,
+            parent_identity=parent_identity,
+            lineage_kind=lineage_kind,
+        )
+        _assert_frozen_identity(template_identity, candidate_identity)
+    except (AdvancedSearchValidationError, CanonicalExperimentIdentityError) as exc:
+        return _rejected_candidate(
+            hypothesis_id=hypothesis_id,
+            parameter_region=parameter_region,
+            status=STATUS_REJECTED_IDENTITY,
+            reason=str(exc),
+            search_space_id=search_space_id,
+            hypothesis_kind=hypothesis_kind,
+            strategy_family=strategy_family,
+        )
+    experiment_id = derive_experiment_id_v1(str(candidate_identity["identity_digest"]))
+    parent_lineage_ref = _parent_lineage_ref(candidate_identity)
+    fingerprint = derive_hypothesis_fingerprint_v1(
+        identity_digest=str(candidate_identity["identity_digest"]),
+        hypothesis_id=hypothesis_id,
+        parameter_region=parameter_region,
+        regime=regime,
+        robustness_policy_digest=robustness_policy_digest,
+        parent_lineage_ref=parent_lineage_ref,
+    )
+    duplicate_assessment = _plain_mapping(
+        assess_duplicate_hypothesis_v1(
+            failure_records,
+            hypothesis_fingerprint=fingerprint,
+            parameter_region=parameter_region,
+        )
+    )
+    failure_signals = _failure_signals(
+        failure_records,
+        gap_records=gap_records,
+        parameter_region=parameter_region,
+        identity=candidate_identity,
+    )
+    if (
+        duplicate_assessment.get("detected") is True
+        and "REQUIRE_EXPLICIT_RETEST_REASON" in duplicate_assessment.get("actions", [])
+        and retest_reason is None
+    ):
+        return _candidate_body(
+            hypothesis_id=hypothesis_id,
+            parameter_region=parameter_region,
+            status=STATUS_REJECTED_DUPLICATE_WITHOUT_RETEST,
+            reason="duplicate hypothesis requires an explicit retest_reason",
+            search_space_id=search_space_id,
+            hypothesis_kind=hypothesis_kind,
+            strategy_family=strategy_family,
+            identity=candidate_identity,
+            experiment_id=experiment_id,
+            fingerprint=fingerprint,
+            duplicate_assessment=duplicate_assessment,
+            failure_signals=failure_signals,
+            priority_score=PRIORITY_NEUTRAL,
+            matched_signals=(),
+        )
+    if failure_signals["known_failure"] and retest_reason is None:
+        return _candidate_body(
+            hypothesis_id=hypothesis_id,
+            parameter_region=parameter_region,
+            status=STATUS_DEPRIORITIZED_KNOWN_FAILURE,
+            reason=str(failure_signals["reason"]),
+            search_space_id=search_space_id,
+            hypothesis_kind=hypothesis_kind,
+            strategy_family=strategy_family,
+            identity=candidate_identity,
+            experiment_id=experiment_id,
+            fingerprint=fingerprint,
+            duplicate_assessment=duplicate_assessment,
+            failure_signals=failure_signals,
+            priority_score=PRIORITY_DEPRIORITIZE,
+            matched_signals=(),
+        )
+    matched_signals, priority_score = _priority_from_signals(
+        meta_signals,
+        strategy_family=strategy_family,
+        search_space_id=search_space_id,
+        hypothesis_kind=hypothesis_kind,
+        parameter_region=parameter_region,
+        duplicate_assessment=duplicate_assessment,
+    )
+    return _candidate_body(
+        hypothesis_id=hypothesis_id,
+        parameter_region=parameter_region,
+        status=STATUS_PROPOSED,
+        reason="eligible research candidate",
+        search_space_id=search_space_id,
+        hypothesis_kind=hypothesis_kind,
+        strategy_family=strategy_family,
+        identity=candidate_identity,
+        experiment_id=experiment_id,
+        fingerprint=fingerprint,
+        duplicate_assessment=duplicate_assessment,
+        failure_signals=failure_signals,
+        priority_score=priority_score,
+        matched_signals=matched_signals,
+        offline_experiment_request=_offline_request(
+            hypothesis_id=hypothesis_id,
+            experiment_id=experiment_id,
+            identity_digest=str(candidate_identity["identity_digest"]),
+            parameter_region=parameter_region,
+            regime=regime,
+        ),
+    )
+
+
+def _assign_proposal_budget(candidates: list[dict[str, Any]], *, budget: int) -> None:
+    eligible = [item for item in candidates if item["status"] == STATUS_PROPOSED]
+    eligible.sort(
+        key=lambda item: (-int(item["search_priority_score"]), str(item["hypothesis_id"]))
+    )
+    for index, item in enumerate(eligible):
+        if index < budget:
+            continue
+        item["status"] = STATUS_BUDGET_EXCLUDED
+        item["reason"] = "eligible candidate excluded by explicit search budget"
+        item["offline_experiment_request"] = None
+
+
+def _bind_candidate_identity(
+    template: CanonicalExperimentIdentityRequestV1,
+    *,
+    parameter_region: Mapping[str, Any],
+    parent_identity: Mapping[str, Any] | None,
+    lineage_kind: str,
+) -> Mapping[str, Any]:
+    template_params = canonicalize_mapping(template.strategy_params)
+    missing = [key for key in parameter_region if key not in template_params]
+    if missing:
+        raise AdvancedSearchValidationError(
+            f"search axes are not bound on the identity template: {sorted(missing)}"
+        )
+    strategy_params = dict(template_params)
+    strategy_params.update(parameter_region)
+    parent_lineage_ref = template.parent_lineage_ref
+    if lineage_kind == LINEAGE_KIND_PARENT_BOUND:
+        assert parent_identity is not None
+        parent_lineage_ref = str(parent_identity["identity_digest"])
+    request = replace(
+        template,
+        strategy_params=strategy_params,
+        parent_lineage_ref=parent_lineage_ref,
+    )
+    identity = build_canonical_experiment_identity_v1(request)
+    validate_canonical_experiment_identity_v1(identity)
+    return _plain_mapping(identity)
+
+
+def _build_template_identity(
+    template: CanonicalExperimentIdentityRequestV1,
+) -> dict[str, Any]:
+    try:
+        identity = build_canonical_experiment_identity_v1(template)
+    except CanonicalExperimentIdentityError as exc:
+        raise AdvancedSearchValidationError(
+            f"identity template is not a COMPLETE Canonical Experiment Identity: {exc}"
+        ) from exc
+    validate_canonical_experiment_identity_v1(identity)
+    _reject_forbidden_param_keys("identity_template.strategy_params", template.strategy_params)
+    return _plain_mapping(identity)
+
+
+def _assert_frozen_identity(
+    template_identity: Mapping[str, Any], candidate_identity: Mapping[str, Any]
+) -> None:
+    for field_name in FROZEN_IDENTITY_FIELDS:
+        if template_identity.get(field_name) != candidate_identity.get(field_name):
+            raise AdvancedSearchValidationError(
+                f"search mutated frozen identity field {field_name}"
+            )
+
+
+def _canonicalize_search_space(
+    space: SearchSpaceV1, *, cardinality_limit: int
+) -> tuple[dict[str, Any], str, list[dict[str, Any]]]:
+    search_space_id = _require_token("search_space_id", space.search_space_id)
+    if not isinstance(space.axes, Sequence) or isinstance(space.axes, (str, bytes)):
+        raise AdvancedSearchValidationError("search_space.axes must be a sequence")
+    if not space.axes:
+        raise AdvancedSearchValidationError("search_space.axes must not be empty")
+    axes: list[dict[str, Any]] = []
+    seen_names: set[str] = set()
+    value_lists: list[list[Any]] = []
+    names: list[str] = []
+    for index, axis in enumerate(space.axes):
+        if not isinstance(axis, SearchAxisV1):
+            raise AdvancedSearchValidationError(f"search_space.axes[{index}] must be SearchAxisV1")
+        name = _require_axis_name(axis.name)
+        if name in seen_names:
+            raise AdvancedSearchValidationError(f"duplicate search axis: {name}")
+        seen_names.add(name)
+        values = _canonicalize_axis_values(name, axis.values)
+        axes.append({"name": name, "values": values})
+        names.append(name)
+        value_lists.append(values)
+    axes.sort(key=lambda item: str(item["name"]))
+    names = [str(item["name"]) for item in axes]
+    value_lists = [list(item["values"]) for item in axes]
+    product = list(itertools.product(*value_lists))
+    if not product:
+        raise AdvancedSearchValidationError("search space produced no combinations")
+    if len(product) > cardinality_limit:
+        raise AdvancedSearchValidationError(
+            "search space cardinality exceeds search_space_cardinality_limit"
+        )
+    combinations = [
+        {name: value for name, value in zip(names, row, strict=True)} for row in product
+    ]
+    combinations.sort(key=lambda item: tuple((key, repr(item[key])) for key in names))
+    payload = {"axes": axes, "search_space_id": search_space_id}
+    digest = compute_content_sha256(
+        {
+            "digest_algorithm": DIGEST_ALGORITHM,
+            "digest_domain": f"{ADVANCED_SEARCH_DOMAIN}.search_space",
+            "payload": payload,
+            "schema_version": SCHEMA_VERSION,
+        }
+    )
+    return payload, digest, combinations
+
+
+def _canonicalize_axis_values(name: str, values: Sequence[Any]) -> list[Any]:
+    if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
+        raise AdvancedSearchValidationError(f"search axis {name} values must be a sequence")
+    if not values:
+        raise AdvancedSearchValidationError(f"search axis {name} values must not be empty")
+    canonical: list[Any] = []
+    seen: set[str] = set()
+    for value in values:
+        item = _canonicalize_axis_value(name, value)
+        marker = repr(item)
+        if marker in seen:
+            raise AdvancedSearchValidationError(f"search axis {name} has duplicate values")
+        seen.add(marker)
+        canonical.append(item)
+    return canonical
+
+
+def _canonicalize_axis_value(name: str, value: Any) -> Any:
+    if isinstance(value, bool) or value is None:
+        raise AdvancedSearchValidationError(f"search axis {name} values must not be bool or null")
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise AdvancedSearchValidationError(f"search axis {name} values must be finite")
+        return value
+    if isinstance(value, str):
+        return _require_token(f"search axis {name} value", value)
+    raise AdvancedSearchValidationError(
+        f"search axis {name} values must be int, finite float, or canonical tokens"
+    )
+
+
+def _require_axis_name(value: Any) -> str:
+    name = _require_token("search axis name", value)
+    if _AXIS_NAME_RE.fullmatch(name) is None:
+        raise AdvancedSearchValidationError(f"search axis name is not canonical: {name}")
+    _reject_forbidden_param_keys("search axis", {name: True})
+    allowed, reason = classify_patch_target(name)
+    if not allowed:
+        raise AdvancedSearchValidationError(f"search axis is a forbidden surface: {reason}")
+    return name
+
+
+def _reject_forbidden_param_keys(field_name: str, payload: Mapping[str, Any]) -> None:
+    if not isinstance(payload, Mapping):
+        raise AdvancedSearchValidationError(f"{field_name} must be a mapping")
+    for raw_key in payload:
+        key = str(raw_key).strip().lower()
+        normalized = key.replace("-", "_")
+        if normalized in FORBIDDEN_SEARCH_AXIS_TOKENS:
+            raise AdvancedSearchValidationError(
+                f"{field_name} contains forbidden search dimension {raw_key}"
+            )
+        for token in FORBIDDEN_SEARCH_AXIS_TOKENS:
+            if (
+                normalized == token
+                or normalized.startswith(f"{token}_")
+                or f"_{token}_" in (f"_{normalized}_")
+            ):
+                raise AdvancedSearchValidationError(
+                    f"{field_name} contains forbidden search dimension {raw_key}"
+                )
+
+
+def _constraint_violation(parameter_region: Mapping[str, Any]) -> str | None:
+    try:
+        _reject_forbidden_param_keys("parameter_region", parameter_region)
+    except AdvancedSearchValidationError as exc:
+        return str(exc)
+    return None
+
+
+def _canonicalize_objective(objective: SearchObjectiveV1) -> dict[str, Any]:
+    if objective.objective_id != OBJECTIVE_ID:
+        raise AdvancedSearchValidationError("objective_id mismatch")
+    if objective.objective_version != OBJECTIVE_VERSION:
+        raise AdvancedSearchValidationError("objective_version mismatch")
+    if objective.sharpe_is_not_auto_winner is not True:
+        raise AdvancedSearchValidationError("sharpe_is_not_auto_winner must be true")
+    if objective.search_score_is_not_canonical_ranking is not True:
+        raise AdvancedSearchValidationError("search_score_is_not_canonical_ranking must be true")
+    return {
+        "objective_id": OBJECTIVE_ID,
+        "objective_version": OBJECTIVE_VERSION,
+        "search_score_is_not_canonical_ranking": True,
+        "sharpe_is_not_auto_winner": True,
+    }
+
+
+def _canonicalize_constraint(constraint: SearchConstraintV1) -> dict[str, Any]:
+    if constraint.constraint_id != CONSTRAINT_ID:
+        raise AdvancedSearchValidationError("constraint_id mismatch")
+    if constraint.constraint_version != CONSTRAINT_VERSION:
+        raise AdvancedSearchValidationError("constraint_version mismatch")
+    required_true = (
+        "cannot_increase_risk",
+        "cannot_increase_leverage",
+        "cannot_write_live_config",
+        "cannot_write_testnet_config",
+        "cannot_submit_order",
+        "cannot_fund",
+        "cannot_arm",
+        "cannot_enable",
+        "cannot_create_or_use_confirm_token",
+        "cannot_authorize_canary",
+        "cannot_promote",
+        "search_score_is_not_canonical_ranking",
+    )
+    payload = {name: getattr(constraint, name) for name in required_true}
+    for name, value in payload.items():
+        if value is not True:
+            raise AdvancedSearchValidationError(f"{name} must be true")
+    return {
+        "cannot_arm": True,
+        "cannot_authorize_canary": True,
+        "cannot_create_or_use_confirm_token": True,
+        "cannot_enable": True,
+        "cannot_fund": True,
+        "cannot_increase_leverage": True,
+        "cannot_increase_risk": True,
+        "cannot_promote": True,
+        "cannot_submit_order": True,
+        "cannot_write_live_config": True,
+        "cannot_write_testnet_config": True,
+        "constraint_id": CONSTRAINT_ID,
+        "constraint_version": CONSTRAINT_VERSION,
+        "search_score_is_not_canonical_ranking": True,
+    }
+
+
+def _canonicalize_parent_identity(
+    value: Mapping[str, Any] | None, *, lineage_kind: str
+) -> dict[str, Any] | None:
+    if lineage_kind == LINEAGE_KIND_ROOT:
+        if value is not None:
+            raise AdvancedSearchValidationError(
+                "ROOT search must not supply parent_experiment_identity"
+            )
+        return None
+    if value is None:
+        raise AdvancedSearchValidationError(
+            "PARENT_BOUND search requires parent_experiment_identity"
+        )
+    validate_canonical_experiment_identity_v1(value)
+    return _plain_mapping(value)
+
+
+def _canonicalize_failure_records(
+    records: Sequence[Mapping[str, Any]], *, template_identity: Mapping[str, Any]
+) -> list[dict[str, Any]]:
+    if not isinstance(records, Sequence) or isinstance(records, (str, bytes)):
+        raise AdvancedSearchValidationError("failure_records must be a sequence")
+    bound: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, item in enumerate(records):
+        try:
+            validate_canonical_failure_memory_record_v1(item)
+        except Exception as exc:
+            raise AdvancedSearchValidationError(
+                f"failure_records[{index}] is not a COMPLETE Phase 3 record"
+            ) from exc
+        payload = _plain_mapping(item)
+        _assert_signal_identity_compatible(
+            template_identity,
+            payload["experiment_identity"],
+            field_name=f"failure_records[{index}]",
+        )
+        record_id = str(payload["failure_record_id"])
+        if record_id in seen:
+            raise AdvancedSearchValidationError("duplicate failure_record_id")
+        seen.add(record_id)
+        bound.append(payload)
+    bound.sort(key=lambda item: str(item["failure_record_id"]))
+    return bound
+
+
+def _canonicalize_gap_records(
+    records: Sequence[Mapping[str, Any]], *, template_identity: Mapping[str, Any]
+) -> list[dict[str, Any]]:
+    if not isinstance(records, Sequence) or isinstance(records, (str, bytes)):
+        raise AdvancedSearchValidationError("reality_gap_records must be a sequence")
+    bound: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, item in enumerate(records):
+        try:
+            validate_canonical_reality_gap_record_v1(item)
+        except Exception as exc:
+            raise AdvancedSearchValidationError(
+                f"reality_gap_records[{index}] is not a COMPLETE Phase 7 record"
+            ) from exc
+        payload = _plain_mapping(item)
+        _assert_signal_identity_compatible(
+            template_identity,
+            payload["experiment_identity"],
+            field_name=f"reality_gap_records[{index}]",
+        )
+        record_id = str(payload["reality_gap_record_id"])
+        if record_id in seen:
+            raise AdvancedSearchValidationError("duplicate reality_gap_record_id")
+        seen.add(record_id)
+        bound.append(payload)
+    bound.sort(key=lambda item: str(item["reality_gap_record_id"]))
+    return bound
+
+
+def _assert_signal_identity_compatible(
+    template_identity: Mapping[str, Any], signal_identity: Mapping[str, Any], *, field_name: str
+) -> None:
+    comparable_fields = tuple(
+        field for field in FROZEN_IDENTITY_FIELDS if field not in {"seed", "environment_digest"}
+    )
+    for field_name_key in comparable_fields:
+        if template_identity.get(field_name_key) != signal_identity.get(field_name_key):
+            raise AdvancedSearchValidationError(
+                f"{field_name} is not comparable on frozen identity field {field_name_key}"
+            )
+
+
+def _canonicalize_meta_signals(
+    signals: Sequence[Mapping[str, Any]], *, meta_learning_identity: str | None
+) -> list[dict[str, Any]]:
+    if not isinstance(signals, Sequence) or isinstance(signals, (str, bytes)):
+        raise AdvancedSearchValidationError("meta_learning_signals must be a sequence")
+    if not signals:
+        if meta_learning_identity is not None:
+            raise AdvancedSearchValidationError(
+                "meta_learning_identity must be omitted when no signals are supplied"
+            )
+        return []
+    identity = _require_sha256("meta_learning_identity", meta_learning_identity)
+    bound: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, item in enumerate(signals):
+        if not isinstance(item, Mapping):
+            raise AdvancedSearchValidationError(f"meta_learning_signals[{index}] must be a mapping")
+        payload = _plain_mapping(item)
+        kind = payload.get("kind")
+        if kind not in CANONICAL_PROPOSAL_KINDS:
+            raise AdvancedSearchValidationError("meta-learning signal kind is not canonical")
+        if payload.get("authority") != META_LEARNING_AUTHORITY:
+            raise AdvancedSearchValidationError(
+                "meta-learning signal authority must be RESEARCH_ONLY"
+            )
+        if payload.get("promotion_authority") != META_PROMOTION_AUTHORITY:
+            raise AdvancedSearchValidationError("meta-learning signal cannot promote")
+        if payload.get("applies_to_champion") is not False:
+            raise AdvancedSearchValidationError("meta-learning signal cannot apply to champion")
+        proposal_id = _require_sha256(
+            f"meta_learning_signals[{index}].proposal_id", payload.get("proposal_id")
+        )
+        if proposal_id in seen:
+            raise AdvancedSearchValidationError("duplicate meta-learning proposal_id")
+        seen.add(proposal_id)
+        bound.append(
+            {
+                "applies_to_champion": False,
+                "authority": META_LEARNING_AUTHORITY,
+                "kind": kind,
+                "meta_learning_identity": identity,
+                "promotion_authority": META_PROMOTION_AUTHORITY,
+                "proposal_id": proposal_id,
+                "question_id": _require_token(
+                    f"meta_learning_signals[{index}].question_id", payload.get("question_id")
+                ),
+                "reason": _require_token(
+                    f"meta_learning_signals[{index}].reason", payload.get("reason")
+                ),
+                "target": _require_token(
+                    f"meta_learning_signals[{index}].target", payload.get("target")
+                ),
+                "target_kind": _require_token(
+                    f"meta_learning_signals[{index}].target_kind", payload.get("target_kind")
+                ),
+            }
+        )
+    bound.sort(key=lambda item: str(item["proposal_id"]))
+    return bound
+
+
+def _failure_signals(
+    failure_records: Sequence[Mapping[str, Any]],
+    *,
+    gap_records: Sequence[Mapping[str, Any]],
+    parameter_region: Mapping[str, Any],
+    identity: Mapping[str, Any],
+) -> dict[str, Any]:
+    region_matches = [
+        item for item in failure_records if item.get("parameter_region") == parameter_region
+    ]
+    failure_classes = sorted({str(item.get("failure_class")) for item in region_matches})
+    robustness_failures = [item for item in failure_classes if item in ROBUSTNESS_FAILURE_CLASSES]
+    reality_gap_failures = [item for item in failure_classes if item == "REJECTED_REALITY_GAP"]
+    gap_hits = [
+        item
+        for item in gap_records
+        if item.get("overall_disposition") == DISPOSITION_REJECTED_REALITY_GAP
+        and item.get("experiment_identity", {}).get("strategy_params_digest")
+        == identity.get("strategy_params_digest")
+    ]
+    known_failure = bool(region_matches or gap_hits)
+    reasons: list[str] = []
+    if region_matches:
+        reasons.append("known rejected parameter region")
+    if robustness_failures:
+        reasons.append("known robustness failure")
+    if reality_gap_failures or gap_hits:
+        reasons.append("known reality-gap failure")
+    if failure_classes:
+        reasons.append("known failure class")
+    return {
+        "failure_classes": failure_classes,
+        "known_failure": known_failure,
+        "known_failure_class": bool(failure_classes),
+        "known_reality_gap_failure": bool(reality_gap_failures or gap_hits),
+        "known_rejected_parameter_region": bool(region_matches),
+        "known_robustness_failure": bool(robustness_failures),
+        "matching_failure_record_ids": [item["failure_record_id"] for item in region_matches],
+        "matching_reality_gap_record_ids": [item["reality_gap_record_id"] for item in gap_hits],
+        "reason": "; ".join(reasons) if reasons else "no known failure",
+    }
+
+
+def _priority_from_signals(
+    signals: Sequence[Mapping[str, Any]],
+    *,
+    strategy_family: str,
+    search_space_id: str,
+    hypothesis_kind: str,
+    parameter_region: Mapping[str, Any],
+    duplicate_assessment: Mapping[str, Any],
+) -> tuple[list[str], int]:
+    score = PRIORITY_NEUTRAL
+    matched: list[str] = []
+    for signal in signals:
+        if not _signal_applies(
+            signal,
+            strategy_family=strategy_family,
+            search_space_id=search_space_id,
+            hypothesis_kind=hypothesis_kind,
+            parameter_region=parameter_region,
+        ):
+            continue
+        matched.append(str(signal["proposal_id"]))
+        kind = signal["kind"]
+        if kind == PROPOSAL_PRIORITIZE_RESEARCH:
+            score += PRIORITY_PRIORITIZE
+        elif kind == PROPOSAL_INVESTIGATE:
+            score += PRIORITY_INVESTIGATE
+        elif kind == PROPOSAL_DEPRIORITIZE_RESEARCH:
+            score += PRIORITY_DEPRIORITIZE
+        elif kind == PROPOSAL_RETEST:
+            score += PRIORITY_INVESTIGATE
+    if duplicate_assessment.get("detected") is True:
+        score += PRIORITY_DUPLICATE_WARN
+    return matched, score
+
+
+def _signal_applies(
+    signal: Mapping[str, Any],
+    *,
+    strategy_family: str,
+    search_space_id: str,
+    hypothesis_kind: str,
+    parameter_region: Mapping[str, Any],
+) -> bool:
+    target = str(signal["target"])
+    target_kind = str(signal["target_kind"])
+    if target_kind == "strategy_family":
+        return target == strategy_family
+    if target_kind == "search_space_id":
+        return target == search_space_id
+    if target_kind == "hypothesis_kind":
+        return target == hypothesis_kind
+    if target_kind == "parameter_region":
+        return target in {str(value) for value in parameter_region.values()} or target in {
+            f"{key}={value}" for key, value in parameter_region.items()
+        }
+    return target in {strategy_family, search_space_id, hypothesis_kind}
+
+
+def _offline_request(
+    *,
+    hypothesis_id: str,
+    experiment_id: str,
+    identity_digest: str,
+    parameter_region: Mapping[str, Any],
+    regime: str,
+) -> dict[str, Any]:
+    return {
+        "executed": False,
+        "experiment_id": experiment_id,
+        "identity_digest": identity_digest,
+        "loop_started": False,
+        "parameter_region": dict(parameter_region),
+        "regime": regime,
+        "request_kind": OFFLINE_REQUEST_KIND,
+        "schema_version": OFFLINE_LOOP_SCHEMA_VERSION,
+        "selected_hypothesis_id": hypothesis_id,
+    }
+
+
+def _candidate_hypothesis_id(parent_hypothesis_id: str, parameter_region: Mapping[str, Any]) -> str:
+    region_digest = compute_content_sha256(
+        {
+            "digest_algorithm": DIGEST_ALGORITHM,
+            "digest_domain": f"{ADVANCED_SEARCH_DOMAIN}.parameter_region",
+            "payload": dict(parameter_region),
+            "schema_version": SCHEMA_VERSION,
+        }
+    )
+    candidate = f"{parent_hypothesis_id}.{region_digest[:12]}"
+    return _require_token("hypothesis_id", candidate)
+
+
+def _candidate_body(
+    *,
+    hypothesis_id: str,
+    parameter_region: Mapping[str, Any],
+    status: str,
+    reason: str,
+    search_space_id: str,
+    hypothesis_kind: str,
+    strategy_family: str,
+    identity: Mapping[str, Any] | None = None,
+    experiment_id: str | None = None,
+    fingerprint: str | None = None,
+    duplicate_assessment: Mapping[str, Any] | None = None,
+    failure_signals: Mapping[str, Any] | None = None,
+    priority_score: int = PRIORITY_NEUTRAL,
+    matched_signals: Sequence[str] = (),
+    offline_experiment_request: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    candidate_ref = compute_content_sha256(
+        {
+            "digest_algorithm": DIGEST_ALGORITHM,
+            "digest_domain": f"{ADVANCED_SEARCH_DOMAIN}.candidate_ref",
+            "payload": {
+                "hypothesis_id": hypothesis_id,
+                "parameter_region": dict(parameter_region),
+            },
+            "schema_version": SCHEMA_VERSION,
+        }
+    )
+    return {
+        "candidate_ref": candidate_ref,
+        "duplicate_assessment": dict(
+            duplicate_assessment or {"actions": ["NONE"], "detected": False}
+        ),
+        "experiment_id": experiment_id,
+        "experiment_identity": identity,
+        "failure_signals": dict(failure_signals or {"known_failure": False}),
+        "hypothesis_fingerprint": fingerprint,
+        "hypothesis_id": hypothesis_id,
+        "hypothesis_kind": hypothesis_kind,
+        "matched_meta_learning_proposal_ids": list(matched_signals),
+        "offline_experiment_request": (
+            dict(offline_experiment_request) if offline_experiment_request is not None else None
+        ),
+        "parameter_region": dict(parameter_region),
+        "reason": reason,
+        "search_priority_score": int(priority_score),
+        "search_score_is_not_canonical_ranking": True,
+        "search_space_id": search_space_id,
+        "status": status,
+        "strategy_family": strategy_family,
+    }
+
+
+def _rejected_candidate(
+    *,
+    hypothesis_id: str,
+    parameter_region: Mapping[str, Any],
+    status: str,
+    reason: str,
+    search_space_id: str,
+    hypothesis_kind: str,
+    strategy_family: str,
+) -> dict[str, Any]:
+    return _candidate_body(
+        hypothesis_id=hypothesis_id,
+        parameter_region=parameter_region,
+        status=status,
+        reason=reason,
+        search_space_id=search_space_id,
+        hypothesis_kind=hypothesis_kind,
+        strategy_family=strategy_family,
+    )
+
+
+def _hypothesis_projection(candidate: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "experiment_id": candidate["experiment_id"],
+        "hypothesis_fingerprint": candidate["hypothesis_fingerprint"],
+        "hypothesis_id": candidate["hypothesis_id"],
+        "hypothesis_kind": candidate["hypothesis_kind"],
+        "identity_digest": candidate["experiment_identity"]["identity_digest"],
+        "parameter_region": candidate["parameter_region"],
+        "status": candidate["status"],
+    }
+
+
+def _parent_lineage_ref(identity: Mapping[str, Any]) -> str | None:
+    parent_lineage = identity.get("parent_lineage")
+    if isinstance(parent_lineage, Mapping):
+        ref = parent_lineage.get("parent_lineage_ref")
+        if isinstance(ref, str):
+            return ref
+    return None
+
+
+def _count_status(candidates: Sequence[Mapping[str, Any]], status: str) -> int:
+    return sum(1 for item in candidates if item.get("status") == status)
+
+
+def _require_search_method(value: Any) -> str:
+    method = _require_token("search_method", value)
+    if method in UNSUPPORTED_SEARCH_METHODS:
+        raise AdvancedSearchValidationError(
+            f"search_method is unsupported in this contract: {method}"
+        )
+    if method not in SUPPORTED_SEARCH_METHODS:
+        raise AdvancedSearchValidationError(f"unknown search_method: {method}")
+    return method
+
+
+def _require_created_at(value: Any) -> str:
+    if not isinstance(value, str) or _CREATED_AT_RE.fullmatch(value) is None:
+        raise AdvancedSearchValidationError("created_at must be a canonical UTC timestamp")
+    return value
+
+
+def _require_token(field_name: str, value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise AdvancedSearchValidationError(f"{field_name} must be a non-empty string")
+    token = value.strip()
+    if token.lower() in _UNAVAILABLE_TOKENS:
+        raise AdvancedSearchValidationError(f"{field_name} cannot use implicit unavailable tokens")
+    if _TOKEN_RE.fullmatch(token) is None:
+        raise AdvancedSearchValidationError(f"{field_name} is not a canonical token")
+    return token
+
+
+def _require_enum(field_name: str, value: Any, allowed: Sequence[str]) -> str:
+    token = _require_token(field_name, value)
+    if token not in allowed:
+        raise AdvancedSearchValidationError(f"{field_name} must be one of {list(allowed)}")
+    return token
+
+
+def _require_positive_int(field_name: str, value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise AdvancedSearchValidationError(f"{field_name} must be a positive int")
+    return value
+
+
+def _require_seed(value: Any) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise AdvancedSearchValidationError("seed must be an explicit int")
+    return value
+
+
+def _require_sha256(field_name: str, value: Any) -> str:
+    if not isinstance(value, str) or not is_valid_sha256_hex(value):
+        raise AdvancedSearchValidationError(f"{field_name} must be 64-char lowercase sha256 hex")
+    return value
+
+
+def _optional_retest_reason(value: Any) -> str | None:
+    if value is None:
+        return None
+    return _require_token("retest_reason", value)
+
+
+def _freeze(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({str(key): _freeze(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return [_freeze(item) for item in value]
+    return value
+
+
+def _plain_mapping(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _plain_mapping(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_plain_mapping(item) for item in value]
+    return value
+
+
+__all__ = [
+    "ADVANCED_SEARCH_AUTHORITY",
+    "ADVANCED_SEARCH_PRESENT",
+    "AUTONOMOUS_PROMOTION",
+    "AdvancedSearchValidationError",
+    "BEST_SHARPE_IS_NOT_AUTO_WINNER",
+    "CanonicalAdvancedSearchRequestV1",
+    "PHASE_13_STARTED",
+    "PROMOTION_AUTHORITY",
+    "SEARCH_CAN_PROMOTE",
+    "SEARCH_HAS_RUNTIME_AUTHORITY",
+    "SEARCH_IS_AUTHORITY_MECHANISM",
+    "SEARCH_METHOD_BOUNDED_DETERMINISTIC_CONSTRAINED_REGION_SEARCH",
+    "SUPPORTED_SEARCH_METHODS",
+    "SearchAxisV1",
+    "SearchConstraintV1",
+    "SearchObjectiveV1",
+    "SearchSpaceV1",
+    "build_canonical_advanced_search_v1",
+    "canonical_advanced_search_constraint_v1",
+    "canonical_advanced_search_objective_v1",
+    "canonical_record_payload_v1",
+    "validate_canonical_advanced_search_v1",
+]

--- a/tests/experiments/test_canonical_advanced_search_v1.py
+++ b/tests/experiments/test_canonical_advanced_search_v1.py
@@ -1,0 +1,560 @@
+"""Phase 12 Canonical Advanced Search v1 contract tests."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+import inspect
+from dataclasses import replace
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping
+
+import pytest
+
+from src.experiments.canonical_advanced_search_v1 import (
+    ADVANCED_SEARCH_AUTHORITY,
+    ADVANCED_SEARCH_PRESENT,
+    AUTONOMOUS_PROMOTION,
+    AdvancedSearchValidationError,
+    BEST_SHARPE_IS_NOT_AUTO_WINNER,
+    CanonicalAdvancedSearchRequestV1,
+    PHASE_13_STARTED,
+    PROMOTION_AUTHORITY,
+    SEARCH_CAN_PROMOTE,
+    SEARCH_HAS_RUNTIME_AUTHORITY,
+    SEARCH_IS_AUTHORITY_MECHANISM,
+    SEARCH_METHOD_BOUNDED_DETERMINISTIC_CONSTRAINED_REGION_SEARCH,
+    STATUS_BUDGET_EXCLUDED,
+    STATUS_DEPRIORITIZED_KNOWN_FAILURE,
+    STATUS_PROPOSED,
+    STATUS_REJECTED_DUPLICATE_WITHOUT_RETEST,
+    SUPPORTED_SEARCH_METHODS,
+    SearchAxisV1,
+    SearchSpaceV1,
+    build_canonical_advanced_search_v1,
+    canonical_advanced_search_constraint_v1,
+    canonical_advanced_search_objective_v1,
+    canonical_record_payload_v1,
+    validate_canonical_advanced_search_v1,
+)
+from src.experiments.canonical_experiment_identity_v1 import (
+    CanonicalExperimentIdentityRequestV1,
+    WORKING_TREE_CLEAN,
+    build_canonical_experiment_identity_v1,
+)
+from src.experiments.canonical_experiment_memory_v1 import derive_experiment_id_v1
+from src.experiments.canonical_failure_memory_v1 import (
+    CanonicalFailureMemoryRecordRequestV1,
+    build_canonical_failure_memory_record_v1,
+)
+from src.experiments.canonical_meta_learning_v1 import (
+    META_LEARNING_AUTHORITY,
+    PROPOSAL_PRIORITIZE_RESEARCH,
+    PROMOTION_AUTHORITY as META_PROMOTION_AUTHORITY,
+    QUESTION_STRATEGY_FAMILY_OOS_SURVIVAL,
+)
+from src.experiments.canonical_reality_gap_store_v1 import (
+    CanonicalRealityGapRecordRequestV1,
+    OBSERVED_SURFACE_SHADOW,
+    RealityGapDimensionV1,
+    build_canonical_reality_gap_record_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import deterministic_json_dumps
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "src" / "experiments" / "canonical_advanced_search_v1.py"
+_GIT_SHA = "fc059d1285be55e433a9ca59e89ce187e7a4b363"
+_CREATED_AT = "2026-08-18T15:00:00Z"
+_EVIDENCE_AT = "2026-08-18T14:00:00Z"
+_PARENT_HYPOTHESIS_ID = "hyp.ma-crossover.v1"
+
+
+def _digest(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _identity_request(**overrides: Any) -> CanonicalExperimentIdentityRequestV1:
+    payload: dict[str, Any] = {
+        "git_sha": _GIT_SHA,
+        "working_tree_status": WORKING_TREE_CLEAN,
+        "strategy_identity": "ma_crossover.v1",
+        "strategy_params": {"fast": 10, "slow": 50},
+        "dataset_digest": _digest("dataset"),
+        "feature_pipeline_digest": _digest("features"),
+        "fee_model_digest": _digest("fee"),
+        "slippage_model_digest": _digest("slippage"),
+        "funding_model_digest": _digest("funding"),
+        "risk_policy_digest": _digest("risk"),
+        "portfolio_digest": _digest("portfolio"),
+        "split_policy_digest": _digest("split"),
+        "market_context_contract_digest": _digest("market-context"),
+        "bull_bear_logic_digest": _digest("bull-bear"),
+        "state_switch_logic_digest": _digest("state-switch"),
+        "survival_logic_digest": _digest("survival"),
+        "suitability_logic_digest": _digest("suitability"),
+        "double_play_logic_digest": _digest("double-play"),
+        "entry_position_exit_logic_digest": _digest("entry-position-exit"),
+        "seed": 12,
+        "environment": {
+            "python_version": "3.11.15",
+            "python_implementation": "CPython",
+        },
+        "parent_lineage_ref": None,
+        "dirty_paths_digest": None,
+    }
+    payload.update(overrides)
+    return CanonicalExperimentIdentityRequestV1(**payload)
+
+
+def _identity(**overrides: Any) -> Mapping[str, Any]:
+    return build_canonical_experiment_identity_v1(_identity_request(**overrides))
+
+
+def _space(**overrides: Any) -> SearchSpaceV1:
+    payload: dict[str, Any] = {
+        "search_space_id": "search.ma.v1",
+        "axes": (
+            SearchAxisV1(name="fast", values=(10, 15)),
+            SearchAxisV1(name="slow", values=(50, 100)),
+        ),
+    }
+    payload.update(overrides)
+    return SearchSpaceV1(**payload)
+
+
+def _signal(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "applies_to_champion": False,
+        "authority": META_LEARNING_AUTHORITY,
+        "kind": PROPOSAL_PRIORITIZE_RESEARCH,
+        "promotion_authority": META_PROMOTION_AUTHORITY,
+        "proposal_id": _digest("proposal.ma-crossover"),
+        "question_id": QUESTION_STRATEGY_FAMILY_OOS_SURVIVAL,
+        "reason": "prioritize-ma-crossover-family",
+        "target": "ma_crossover",
+        "target_kind": "strategy_family",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _failure(
+    identity: Mapping[str, Any],
+    *,
+    hypothesis_id: str = _PARENT_HYPOTHESIS_ID,
+    failure_class: str = "REJECTED_OVERFIT",
+    parameter_region: Mapping[str, Any] | None = None,
+) -> Mapping[str, Any]:
+    experiment_id = derive_experiment_id_v1(str(identity["identity_digest"]))
+    gate = {
+        "REJECTED_OVERFIT": "OVERFIT_GATE",
+        "REJECTED_TAIL_RISK": "TAIL_RISK_GATE",
+        "REJECTED_REALITY_GAP": "REALITY_GAP_GATE",
+    }[failure_class]
+    return build_canonical_failure_memory_record_v1(
+        CanonicalFailureMemoryRecordRequestV1(
+            experiment_identity=identity,
+            hypothesis_id=hypothesis_id,
+            failure_class=failure_class,
+            failed_gate=gate,
+            rejection_reason=failure_class,
+            regime="high_vol",
+            parameter_region=dict(parameter_region or {"fast": 15, "slow": 50}),
+            cost_sensitivity={"fee_stress": 0.25},
+            instability_indicators={"fold_sign_flips": 3},
+            evidence_refs=[
+                {
+                    "kind": "EXPERIMENT_RECORD",
+                    "ref": experiment_id,
+                    "digest": _digest(f"experiment-record-{experiment_id}"),
+                }
+            ],
+            created_at=_EVIDENCE_AT,
+            robustness_policy_digest=_digest("robustness-policy"),
+        )
+    )
+
+
+def _gap(identity: Mapping[str, Any]) -> Mapping[str, Any]:
+    experiment_id = derive_experiment_id_v1(str(identity["identity_digest"]))
+    return build_canonical_reality_gap_record_v1(
+        CanonicalRealityGapRecordRequestV1(
+            experiment_identity=identity,
+            observed_surface=OBSERVED_SURFACE_SHADOW,
+            metric_definitions="canonical_robustness_metrics_v1",
+            threshold_policy_digest=_digest("threshold-policy"),
+            gap_dimensions=(
+                RealityGapDimensionV1(
+                    name="fee",
+                    expected=0.001,
+                    observed=0.02,
+                    threshold=0.001,
+                    unit="ratio",
+                ),
+            ),
+            evidence_refs=[
+                {
+                    "kind": "EXPERIMENT_RECORD",
+                    "ref": experiment_id,
+                    "digest": _digest(f"gap-record-{experiment_id}"),
+                }
+            ],
+            created_at=_EVIDENCE_AT,
+        )
+    )
+
+
+def _request(**overrides: Any) -> CanonicalAdvancedSearchRequestV1:
+    payload: dict[str, Any] = {
+        "identity_template": _identity_request(),
+        "search_space": _space(),
+        "search_method": SEARCH_METHOD_BOUNDED_DETERMINISTIC_CONSTRAINED_REGION_SEARCH,
+        "search_method_version": "canonical_advanced_search_method_v1",
+        "seed": 12,
+        "budget": 4,
+        "search_space_cardinality_limit": 16,
+        "objective": canonical_advanced_search_objective_v1(),
+        "constraint": canonical_advanced_search_constraint_v1(),
+        "created_at": _CREATED_AT,
+        "parent_hypothesis_id": _PARENT_HYPOTHESIS_ID,
+        "lineage_kind": "ROOT",
+        "hypothesis_kind": "trend_following",
+        "strategy_family": "ma_crossover",
+        "regime": "high_vol",
+        "robustness_policy_digest": _digest("robustness-policy"),
+    }
+    payload.update(overrides)
+    return CanonicalAdvancedSearchRequestV1(**payload)
+
+
+def test_deterministic_search_proposal_generation() -> None:
+    first = build_canonical_advanced_search_v1(_request())
+    second = build_canonical_advanced_search_v1(_request())
+    validate_canonical_advanced_search_v1(first)
+    assert first["search_identity"] == second["search_identity"]
+    assert canonical_record_payload_v1(first) == canonical_record_payload_v1(second)
+    assert deterministic_json_dumps(canonical_record_payload_v1(first)) == deterministic_json_dumps(
+        canonical_record_payload_v1(second)
+    )
+    assert first["search_method"] == SEARCH_METHOD_BOUNDED_DETERMINISTIC_CONSTRAINED_REGION_SEARCH
+    assert first["supported_search_mechanisms"] == list(SUPPORTED_SEARCH_METHODS)
+    assert len(first["candidates"]) == 4
+    assert {item["status"] for item in first["candidates"]} == {STATUS_PROPOSED}
+    assert first["overall_status"] == "SEARCH_COMPLETE"
+    assert first["ranked_experiment_ids"] == []
+    assert first["champion_experiment_id"] is None
+
+
+def test_canonical_identity_binding_is_required() -> None:
+    record = build_canonical_advanced_search_v1(_request())
+    template = _identity()
+    for candidate in record["candidates"]:
+        identity = candidate["experiment_identity"]
+        assert identity["completeness"] == "COMPLETE"
+        assert identity["fee_model_digest"] == template["fee_model_digest"]
+        assert identity["slippage_model_digest"] == template["slippage_model_digest"]
+        assert identity["funding_model_digest"] == template["funding_model_digest"]
+        assert identity["risk_policy_digest"] == template["risk_policy_digest"]
+        assert identity["split_policy_digest"] == template["split_policy_digest"]
+        assert identity["trading_decision_core_digest"] == template["trading_decision_core_digest"]
+        assert identity["seed"] == 12
+        assert candidate["experiment_id"] == derive_experiment_id_v1(
+            str(identity["identity_digest"])
+        )
+        assert candidate["hypothesis_fingerprint"]
+    missing_fee = replace(_identity_request(), fee_model_digest="unavailable")
+    with pytest.raises(
+        AdvancedSearchValidationError, match="COMPLETE Canonical Experiment Identity"
+    ):
+        build_canonical_advanced_search_v1(_request(identity_template=missing_fee))
+
+
+def test_search_space_validation_fails_closed() -> None:
+    with pytest.raises(AdvancedSearchValidationError, match="forbidden search dimension"):
+        build_canonical_advanced_search_v1(
+            _request(
+                search_space=_space(
+                    axes=(
+                        SearchAxisV1(name="leverage", values=(1, 2)),
+                        SearchAxisV1(name="fast", values=(10, 15)),
+                    )
+                )
+            )
+        )
+    with pytest.raises(AdvancedSearchValidationError, match="cardinality exceeds"):
+        build_canonical_advanced_search_v1(_request(search_space_cardinality_limit=3))
+    with pytest.raises(AdvancedSearchValidationError, match="duplicate search axis"):
+        build_canonical_advanced_search_v1(
+            _request(
+                search_space=_space(
+                    axes=(
+                        SearchAxisV1(name="fast", values=(10, 15)),
+                        SearchAxisV1(name="fast", values=(20, 25)),
+                    )
+                )
+            )
+        )
+
+
+def test_constraint_enforcement_rejects_authority_relaxation() -> None:
+    loose = replace(canonical_advanced_search_constraint_v1(), cannot_increase_risk=False)
+    with pytest.raises(AdvancedSearchValidationError, match="cannot_increase_risk must be true"):
+        build_canonical_advanced_search_v1(_request(constraint=loose))
+    loose_objective = replace(
+        canonical_advanced_search_objective_v1(), sharpe_is_not_auto_winner=False
+    )
+    with pytest.raises(
+        AdvancedSearchValidationError, match="sharpe_is_not_auto_winner must be true"
+    ):
+        build_canonical_advanced_search_v1(_request(objective=loose_objective))
+
+
+def test_failure_memory_known_region_is_deprioritized_not_silently_omitted() -> None:
+    failed_identity = _identity(strategy_params={"fast": 15, "slow": 50})
+    record = build_canonical_advanced_search_v1(
+        _request(failure_records=(_failure(failed_identity),))
+    )
+    statuses = {item["parameter_region"]["fast"]: item["status"] for item in record["candidates"]}
+    by_region = {
+        (item["parameter_region"]["fast"], item["parameter_region"]["slow"]): item
+        for item in record["candidates"]
+    }
+    known = by_region[(15, 50)]
+    assert known["status"] == STATUS_DEPRIORITIZED_KNOWN_FAILURE
+    assert known["failure_signals"]["known_rejected_parameter_region"] is True
+    assert known["failure_signals"]["known_robustness_failure"] is True
+    assert known["offline_experiment_request"] is None
+    assert any(item["status"] == STATUS_PROPOSED for item in record["candidates"])
+    assert record["search_evidence"]["deprioritized_known_failure_count"] == 1
+    assert statuses[10] == STATUS_PROPOSED
+
+
+def test_duplicate_hypothesis_without_retest_is_rejected() -> None:
+    baseline = build_canonical_advanced_search_v1(_request())
+    proposed = next(item for item in baseline["candidates"] if item["status"] == STATUS_PROPOSED)
+    identity = proposed["experiment_identity"]
+    record = build_canonical_advanced_search_v1(
+        _request(
+            failure_records=(
+                _failure(
+                    identity,
+                    hypothesis_id=str(proposed["hypothesis_id"]),
+                    parameter_region=proposed["parameter_region"],
+                ),
+            )
+        )
+    )
+    duplicate = next(
+        item for item in record["candidates"] if item["hypothesis_id"] == proposed["hypothesis_id"]
+    )
+    assert duplicate["status"] == STATUS_REJECTED_DUPLICATE_WITHOUT_RETEST
+    assert duplicate["duplicate_assessment"]["detected"] is True
+    assert duplicate["duplicate_assessment"]["automatic_research_ban"] is False
+    retried = build_canonical_advanced_search_v1(
+        _request(
+            failure_records=(
+                _failure(
+                    identity,
+                    hypothesis_id=str(proposed["hypothesis_id"]),
+                    parameter_region=proposed["parameter_region"],
+                ),
+            ),
+            retest_reason="explicit-retest-after-policy-review",
+        )
+    )
+    retried_match = next(
+        item for item in retried["candidates"] if item["hypothesis_id"] == proposed["hypothesis_id"]
+    )
+    assert retried_match["status"] in {STATUS_PROPOSED, STATUS_BUDGET_EXCLUDED}
+
+
+def test_meta_learning_signals_bind_and_change_priority_not_authority() -> None:
+    record = build_canonical_advanced_search_v1(
+        _request(
+            meta_learning_signals=(_signal(),),
+            meta_learning_identity=_digest("meta-learning-record"),
+        )
+    )
+    assert record["input_lineage"]["meta_learning_identity"] == _digest("meta-learning-record")
+    assert all(item["search_priority_score"] == 20 for item in record["candidates"])
+    assert all(item["matched_meta_learning_proposal_ids"] for item in record["candidates"])
+    assert record["search_can_promote"] is False
+    assert record["search_is_authority_mechanism"] is False
+    with pytest.raises(AdvancedSearchValidationError, match="meta_learning_identity"):
+        build_canonical_advanced_search_v1(_request(meta_learning_signals=(_signal(),)))
+
+
+def test_budget_excludes_without_silent_omission() -> None:
+    record = build_canonical_advanced_search_v1(_request(budget=1))
+    statuses = [item["status"] for item in record["candidates"]]
+    assert statuses.count(STATUS_PROPOSED) == 1
+    assert statuses.count(STATUS_BUDGET_EXCLUDED) == 3
+    assert len(record["offline_experiment_requests"]) == 1
+    assert len(record["parameter_region_proposals"]) == 4
+    proposed = next(item for item in record["candidates"] if item["status"] == STATUS_PROPOSED)
+    assert proposed["offline_experiment_request"]["executed"] is False
+    assert proposed["offline_experiment_request"]["loop_started"] is False
+    assert proposed["offline_experiment_request"]["schema_version"] == (
+        "canonical_automated_offline_research_loop_v1"
+    )
+
+
+def test_reality_gap_signal_deprioritizes_matching_region() -> None:
+    gap_identity = _identity(strategy_params={"fast": 10, "slow": 100})
+    record = build_canonical_advanced_search_v1(_request(reality_gap_records=(_gap(gap_identity),)))
+    by_region = {
+        (item["parameter_region"]["fast"], item["parameter_region"]["slow"]): item
+        for item in record["candidates"]
+    }
+    hit = by_region[(10, 100)]
+    assert hit["status"] == STATUS_DEPRIORITIZED_KNOWN_FAILURE
+    assert hit["failure_signals"]["known_reality_gap_failure"] is True
+
+
+def test_unknown_and_unsupported_methods_fail_closed() -> None:
+    with pytest.raises(AdvancedSearchValidationError, match="unsupported"):
+        build_canonical_advanced_search_v1(_request(search_method="OPTUNA"))
+    with pytest.raises(AdvancedSearchValidationError, match="unknown search_method"):
+        build_canonical_advanced_search_v1(_request(search_method="RANDOM_WALK"))
+    with pytest.raises(AdvancedSearchValidationError, match="must be a positive int"):
+        build_canonical_advanced_search_v1(_request(budget=0))
+
+
+def test_parent_bound_lineage_requires_parent_identity() -> None:
+    parent = _identity(strategy_identity="parent.ma.v1")
+    with pytest.raises(AdvancedSearchValidationError, match="parent_experiment_identity"):
+        build_canonical_advanced_search_v1(_request(lineage_kind="PARENT_BOUND"))
+    record = build_canonical_advanced_search_v1(
+        _request(lineage_kind="PARENT_BOUND", parent_experiment_identity=parent)
+    )
+    for candidate in record["candidates"]:
+        assert candidate["experiment_identity"]["parent_lineage"]["kind"] == "PARENT_BOUND"
+        assert (
+            candidate["experiment_identity"]["parent_lineage"]["parent_lineage_ref"]
+            == parent["identity_digest"]
+        )
+
+
+def test_no_autonomous_promotion_live_config_or_authority_paths() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+    forbidden_imports = {
+        "src.core.peak_config",
+        "src.governance.promotion_loop",
+        "src.governance.promotion_loop.engine",
+        "src.execution",
+        "src.live",
+        "src.live.live_gates",
+        "src.risk",
+        "src.trading",
+        "src.trading.master_v2",
+        "src.experiments.canonical_champion_challenger_v1",
+        "src.experiments.canonical_comparison_ssot_v1",
+        "src.experiments.canonical_portfolio_learning_v1",
+        "src.experiments.canonical_regime_aware_evaluation_v1",
+        "src.experiments.canonical_automated_offline_research_loop_v1",
+        "src.experiments.canonical_robustness_suite_v1",
+        "src.meta.learning_loop.comparison_ssot_v1",
+        "src.meta.learning_loop.bridge",
+        "src.meta.learning_loop.emitter",
+        "src.meta.learning_loop.canary_micro_live_readiness_v1",
+        "src.meta.learning_loop.autonomous_non_live_orchestration_plan_v1",
+    }
+    assert forbidden_imports.isdisjoint(imported)
+    for token in (
+        "config/live_overrides",
+        "config/auto/",
+        "load_config_with_live_overrides",
+        "submit_order(",
+        "apply_proposals_to_live_overrides",
+        "write_live_config(",
+        "LIVE_AUTHORIZED=true",
+        "TESTNET_AUTHORIZED=true",
+        "FUNDING_AUTHORIZED",
+        "promote_to_live(",
+        "create_confirm_token(",
+        "use_confirm_token(",
+        "BEST_SHARPE =>",
+        "rank_comparable_candidates_v1",
+        "run_canonical_automated_offline_research_loop_v1",
+        "random.seed",
+        "numpy.random",
+    ):
+        assert token not in source
+    record = build_canonical_advanced_search_v1(_request())
+    assert isinstance(record, MappingProxyType)
+    with pytest.raises(TypeError):
+        record["overall_status"] = "SEARCH_COMPLETE"  # type: ignore[index]
+    cloned = copy.deepcopy(canonical_record_payload_v1(record))
+    cloned["search_can_promote"] = True
+    with pytest.raises(AdvancedSearchValidationError, match="search_can_promote must be false"):
+        validate_canonical_advanced_search_v1(cloned)
+    assert ADVANCED_SEARCH_PRESENT is True
+    assert SEARCH_HAS_RUNTIME_AUTHORITY is False
+    assert SEARCH_IS_AUTHORITY_MECHANISM is False
+    assert SEARCH_CAN_PROMOTE is False
+    assert AUTONOMOUS_PROMOTION is False
+    assert PROMOTION_AUTHORITY == "NONE"
+    assert ADVANCED_SEARCH_AUTHORITY == "RESEARCH_ONLY"
+    assert BEST_SHARPE_IS_NOT_AUTO_WINNER is True
+    assert PHASE_13_STARTED is False
+    assert record["search_can_submit_order"] is False
+    assert record["search_can_fund"] is False
+    assert record["search_can_increase_risk"] is False
+    assert record["search_can_increase_leverage"] is False
+    assert record["search_can_authorize_canary"] is False
+    assert record["search_can_promote_to_live"] is False
+    assert record["search_can_write_live_config"] is False
+    assert record["search_can_write_testnet_config"] is False
+    assert record["search_can_create_confirm_token"] is False
+    assert record["search_can_use_confirm_token"] is False
+    assert record["search_can_arm"] is False
+    assert record["search_can_enable"] is False
+    assert record["search_can_replace_productive_champion"] is False
+    assert record["learning_may_autonomously_replace_core_logic"] is False
+    assert record["phase_13_started"] is False
+    assert "apply_proposals_to_live_overrides" not in inspect.getsource(
+        build_canonical_advanced_search_v1
+    )
+
+
+def test_phase_1_to_11_authority_invariants_remain_fail_closed() -> None:
+    from src.experiments.canonical_automated_offline_research_loop_v1 import (
+        AUTOMATED_RUNTIME_AUTHORITY,
+        RESEARCH_LOOP_CAN_PROMOTE,
+        RESEARCH_LOOP_HAS_RUNTIME_AUTHORITY,
+    )
+    from src.experiments.canonical_champion_challenger_v1 import AUTONOMOUS_CHAMPION_SWAP
+    from src.experiments.canonical_comparison_ssot_v1 import COMPARISON_SSOT_CAN_PROMOTE
+    from src.experiments.canonical_experiment_identity_v1 import (
+        EXPERIMENT_IDENTITY_HAS_RUNTIME_AUTHORITY,
+    )
+    from src.experiments.canonical_meta_learning_v1 import (
+        META_LEARNING_CAN_PROMOTE,
+        META_LEARNING_HAS_RUNTIME_AUTHORITY,
+        PHASE_12_STARTED,
+    )
+    from src.experiments.canonical_portfolio_learning_v1 import (
+        AUTONOMOUS_ALLOCATION_APPLY,
+        PORTFOLIO_LEARNING_CAN_PROMOTE,
+    )
+
+    assert EXPERIMENT_IDENTITY_HAS_RUNTIME_AUTHORITY is False
+    assert COMPARISON_SSOT_CAN_PROMOTE is False
+    assert AUTONOMOUS_CHAMPION_SWAP is False
+    assert RESEARCH_LOOP_HAS_RUNTIME_AUTHORITY is False
+    assert RESEARCH_LOOP_CAN_PROMOTE is False
+    assert AUTOMATED_RUNTIME_AUTHORITY is False
+    assert AUTONOMOUS_ALLOCATION_APPLY is False
+    assert PORTFOLIO_LEARNING_CAN_PROMOTE is False
+    assert META_LEARNING_HAS_RUNTIME_AUTHORITY is False
+    assert META_LEARNING_CAN_PROMOTE is False
+    assert PHASE_12_STARTED is False


### PR DESCRIPTION
## Summary
- Adds Self-Learning Phase 12 Canonical Advanced Search: a research-only contract that enumerates a declared discrete search space, binds every candidate to Canonical Experiment Identity, consults Failure Memory / Reality Gap / Meta-Learning signals, and emits research candidates plus offline-experiment requests.
- Implements exactly one search mechanism, `BOUNDED_DETERMINISTIC_CONSTRAINED_REGION_SEARCH`. Bayesian/Optuna/evolutionary/ML/agentic/RL tokens fail closed as unsupported. Search score is not Champion–Challenger ranking. `BEST_SHARPE != AUTO_WINNER`.
- Reuses Phase 1 identity, Phase 2 experiment_id, Phase 3 fingerprint/duplicate assessment, Phase 4 robustness tokens, Phase 7 gap records, Phase 10 as request target (not executor), and Phase 11 research proposals as priority signals. Does not create a second identity, comparison, robustness, ranking, or promotion authority. No live/testnet/order/funding/canary/confirm-token/config-write authority. Phase 13 is not started.

## Test plan
- [x] `uv run pytest tests/experiments/test_canonical_advanced_search_v1.py`
- [x] Related Phase 11 contract tests (`tests/experiments/test_canonical_meta_learning_v1.py`)
- [x] Selector `PR_BOUNDED_FULL` (`category_central_src_requires_full`) path-equivalent targets (729 passed, 36.55s)
- [x] ruff format/check, docs token policy, docs reference targets
- [ ] GitHub required checks on this PR


Made with [Cursor](https://cursor.com)