### PR TITLE
fix(ci): handle expired registry artifacts deterministically

### DIFF
--- a/.github/workflows/ci-operator-verify-registry.yml
+++ b/.github/workflows/ci-operator-verify-registry.yml
@@ -45,4 +45,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          scripts/ops/verify_from_registry.sh docs/ops/registry/LATEST_PHASE_M_SMOKE.pointer --download
+          set -euo pipefail
+          # pull_request: proven historical artifact expiry is lifecycle hygiene,
+          # not a product/verification regression. workflow_dispatch stays strict.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            scripts/ops/verify_from_registry.sh docs/ops/registry/LATEST_PHASE_M_SMOKE.pointer --download --allow-expired
+          else
+            scripts/ops/verify_from_registry.sh docs/ops/registry/LATEST_PHASE_M_SMOKE.pointer --download
+          fi

--- a/scripts/ops/verify_from_registry.sh
+++ b/scripts/ops/verify_from_registry.sh
@@ -2,10 +2,11 @@
 set -euo pipefail
 
 # Operator UX:
-#   scripts/ops/verify_from_registry.sh <pointer> [--download] [--pack]
+#   scripts/ops/verify_from_registry.sh <pointer> [--download] [--allow-expired] [--pack]
 #
 # Examples:
 #   scripts/ops/verify_from_registry.sh docs/ops/registry/LATEST_PHASE_M_SMOKE.pointer --download
+#   scripts/ops/verify_from_registry.sh docs/ops/registry/LATEST_PHASE_M_SMOKE.pointer --download --allow-expired
 #   scripts/ops/verify_from_registry.sh docs/ops/registry/LATEST_PHASE_M_SMOKE.pointer --download --pack
 #
 # Safety rails:
@@ -27,10 +28,12 @@ fi
 
 DOWNLOAD="NO"
 PACK="NO"
+ALLOW_EXPIRED="NO"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --download) DOWNLOAD="YES" ;;
+    --allow-expired) ALLOW_EXPIRED="YES" ;;
     --pack) PACK="YES" ;;
     *) echo "ERR: unknown arg: $1" >&2; exit 2 ;;
   esac
@@ -56,6 +59,9 @@ fi
 ARGS=("${PTR}" --out-base "${OUT_BASE}")
 if [[ "${DOWNLOAD}" == "YES" ]]; then
   ARGS+=(--download)
+fi
+if [[ "${ALLOW_EXPIRED}" == "YES" ]]; then
+  ARGS+=(--allow-expired)
 fi
 if [[ -n "${PACK_OUT}" ]]; then
   ARGS+=(--pack-out "${PACK_OUT}")

--- a/scripts/ops/verify_registry_pointer_artifacts.py
+++ b/scripts/ops/verify_registry_pointer_artifacts.py
@@ -3,20 +3,71 @@
 Portable verifier: reads pointer, validates telemetry invariants (download optional).
 
 NO-LIVE: local filesystem / optional gh artifact download for audit — not a trading path.
+
+When --download is set, GitHub Actions artifact *metadata* is classified before
+any download:
+
+  REGISTRY_POINTER_STATUS=AVAILABLE
+  REGISTRY_POINTER_STATUS=EXPIRED
+  REGISTRY_POINTER_STATUS=INVALID
+  REGISTRY_POINTER_STATUS=UNAVAILABLE_UNKNOWN
+
+EXPIRED is proven only when the artifacts API returns a non-empty list and every
+artifact has expired=true. Download-error text is never treated as expiry.
 """
 
 from __future__ import annotations
 
 import argparse
 import json
+import os
+import re
 import shutil
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
 FALLBACK_CODE = "AUDIT_MANIFEST_NO_DECISION_CONTEXT"
 VALID_ACTIONS = {"ALLOW", "NO_TRADE"}
+
+STATUS_AVAILABLE = "AVAILABLE"
+STATUS_EXPIRED = "EXPIRED"
+STATUS_INVALID = "INVALID"
+STATUS_UNAVAILABLE_UNKNOWN = "UNAVAILABLE_UNKNOWN"
+
+_HTTP_STATUS_RE = re.compile(r"HTTP\s+(\d{3})", re.IGNORECASE)
+
+
+class ArtifactFetchError(Exception):
+    """Metadata API failure. Never classified as EXPIRED."""
+
+    def __init__(self, message: str, *, kind: str, http_status: Optional[int] = None) -> None:
+        super().__init__(message)
+        self.kind = kind
+        self.http_status = http_status
+
+
+class ArtifactDownloadError(Exception):
+    """Download failure after metadata classified AVAILABLE."""
+
+    def __init__(self, message: str, *, returncode: int) -> None:
+        super().__init__(message)
+        self.returncode = returncode
+
+
+@dataclass(frozen=True)
+class ArtifactRecord:
+    name: str
+    expired: bool
+    artifact_id: Optional[int] = None
+    expires_at: Optional[str] = None
+    created_at: Optional[str] = None
+
+
+FetchArtifacts = Callable[[str, str], List[ArtifactRecord]]
+DownloadRun = Callable[[str, Path], None]
 
 
 def parse_pointer(path: Path) -> Dict[str, str]:
@@ -31,19 +82,137 @@ def parse_pointer(path: Path) -> Dict[str, str]:
     return d
 
 
-def run(cmd: List[str]) -> None:
-    p = subprocess.run(cmd, check=False, text=True, capture_output=True)
-    if p.returncode != 0:
-        sys.stderr.write(p.stdout)
-        sys.stderr.write(p.stderr)
-        raise SystemExit(p.returncode)
+def resolve_repo(pointer: Dict[str, str]) -> str:
+    repo = (pointer.get("repo") or "").strip()
+    if repo:
+        return repo
+    env_repo = (os.environ.get("GITHUB_REPOSITORY") or "").strip()
+    if env_repo:
+        return env_repo
+    return ""
 
 
-def maybe_download(run_id: str, out_dir: Path) -> None:
-    out_dir.mkdir(parents=True, exist_ok=True)
-    target = out_dir / run_id
-    target.mkdir(parents=True, exist_ok=True)
-    run(["gh", "run", "download", run_id, "-D", str(target)])
+def classify_artifact_records(records: Sequence[ArtifactRecord]) -> str:
+    """Classify from metadata records only. Empty list is not expiry proof."""
+    if not records:
+        return STATUS_UNAVAILABLE_UNKNOWN
+    if all(record.expired for record in records):
+        return STATUS_EXPIRED
+    return STATUS_AVAILABLE
+
+
+def _http_status_from_gh_error(text: str) -> Optional[int]:
+    match = _HTTP_STATUS_RE.search(text)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def _fetch_error_kind(http_status: Optional[int], text: str) -> str:
+    lowered = text.lower()
+    if http_status in {401, 403}:
+        return "auth"
+    if http_status == 404:
+        return "not_found"
+    if "bad credentials" in lowered or "authentication" in lowered:
+        return "auth"
+    if http_status is not None:
+        return "api"
+    return "api"
+
+
+def _records_from_payload_obj(obj: object) -> List[ArtifactRecord]:
+    if isinstance(obj, dict) and "artifacts" in obj:
+        items = obj["artifacts"]
+    elif isinstance(obj, list):
+        items = obj
+    elif isinstance(obj, dict) and ("name" in obj or "expired" in obj):
+        items = [obj]
+    else:
+        raise ArtifactFetchError(
+            f"unexpected artifacts API payload type: {type(obj).__name__}",
+            kind="parse",
+        )
+    if not isinstance(items, list):
+        raise ArtifactFetchError("artifacts field is not a list", kind="parse")
+    records: List[ArtifactRecord] = []
+    for item in items:
+        if not isinstance(item, dict):
+            raise ArtifactFetchError("artifact entry is not an object", kind="parse")
+        expired_raw = item.get("expired")
+        # Only explicit JSON true counts as expired. Missing/false → available.
+        expired = expired_raw is True
+        artifact_id = item.get("id")
+        records.append(
+            ArtifactRecord(
+                name=str(item.get("name") or ""),
+                expired=expired,
+                artifact_id=artifact_id if isinstance(artifact_id, int) else None,
+                expires_at=str(item["expires_at"]) if item.get("expires_at") else None,
+                created_at=str(item["created_at"]) if item.get("created_at") else None,
+            )
+        )
+    return records
+
+
+def parse_artifacts_api_payload(raw: str) -> List[ArtifactRecord]:
+    text = raw.strip()
+    if not text:
+        raise ArtifactFetchError("empty artifacts API payload", kind="parse")
+    decoder = json.JSONDecoder()
+    idx = 0
+    records: List[ArtifactRecord] = []
+    length = len(text)
+    while idx < length:
+        while idx < length and text[idx].isspace():
+            idx += 1
+        if idx >= length:
+            break
+        try:
+            obj, end = decoder.raw_decode(text, idx)
+        except json.JSONDecodeError as exc:
+            raise ArtifactFetchError(
+                f"artifacts API JSON parse error: {exc}", kind="parse"
+            ) from exc
+        records.extend(_records_from_payload_obj(obj))
+        idx = end
+    return records
+
+
+def fetch_run_artifact_records(run_id: str, repo: str) -> List[ArtifactRecord]:
+    cmd = [
+        "gh",
+        "api",
+        f"repos/{repo}/actions/runs/{run_id}/artifacts",
+        "--paginate",
+    ]
+    proc = subprocess.run(cmd, check=False, text=True, capture_output=True)
+    if proc.returncode != 0:
+        combined = ((proc.stderr or "") + "\n" + (proc.stdout or "")).strip()
+        http_status = _http_status_from_gh_error(combined)
+        kind = _fetch_error_kind(http_status, combined)
+        raise ArtifactFetchError(
+            combined or f"gh api exit {proc.returncode}",
+            kind=kind,
+            http_status=http_status,
+        )
+    return parse_artifacts_api_payload(proc.stdout)
+
+
+def download_run_artifacts(run_id: str, dest_dir: Path) -> None:
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    proc = subprocess.run(
+        ["gh", "run", "download", run_id, "-D", str(dest_dir)],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        combined = ((proc.stderr or "") + "\n" + (proc.stdout or "")).strip()
+        raise ArtifactDownloadError(
+            combined or f"gh run download exit {proc.returncode}",
+            returncode=proc.returncode,
+        )
 
 
 def find_telemetry_summaries(root: Path) -> List[Path]:
@@ -91,54 +260,29 @@ def write_sha256sums(pack_dir: Path) -> Path:
     return sums
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:
-    ap = argparse.ArgumentParser(
-        description=(
-            "Verify registry pointer artifacts and telemetry_summary.json invariants. "
-            "NO-LIVE: local audit helper — not a trading or execution path."
-        ),
-    )
-    ap.add_argument("pointer", type=Path, help="docs/ops/registry/*.pointer")
-    ap.add_argument(
-        "--out-base",
-        type=Path,
-        default=Path("out/ops/gh_runs"),
-        help="download base dir",
-    )
-    ap.add_argument(
-        "--download",
-        action="store_true",
-        help="download artifacts via gh run download",
-    )
-    ap.add_argument(
-        "--pack-out",
-        type=Path,
-        default=None,
-        help="optional evidence pack output dir",
-    )
-    args = ap.parse_args(argv)
+def _emit_status_line(status: str) -> None:
+    print(f"REGISTRY_POINTER_STATUS={status}")
 
-    ptr = args.pointer
-    if not ptr.exists():
-        print(f"ERR: pointer not found: {ptr}", file=sys.stderr)
-        return 1
 
-    d = parse_pointer(ptr)
-    run_id = d.get("run_id")
-    if not run_id:
-        print("ERR: pointer missing run_id=", file=sys.stderr)
-        return 1
+def _emit_expired_diagnostics(run_id: str, records: Sequence[ArtifactRecord]) -> None:
+    print("REGISTRY_POINTER_EXPIRED=true")
+    print(f"REGISTRY_POINTER_RUN_ID={run_id}")
+    print(f"REGISTRY_POINTER_EXPIRED_COUNT={sum(1 for r in records if r.expired)}")
+    print(f"REGISTRY_POINTER_AVAILABLE_COUNT={sum(1 for r in records if not r.expired)}")
+    expires_at = next((r.expires_at for r in records if r.expires_at), None)
+    if expires_at:
+        print(f"REGISTRY_POINTER_EXPIRES_AT={expires_at}")
+    names = ",".join(r.name for r in records if r.name)
+    if names:
+        print(f"REGISTRY_POINTER_ARTIFACT_NAMES={names}")
 
-    artifacts_root = args.out_base / run_id
-    if args.download or not artifacts_root.exists():
-        if not args.download and not artifacts_root.exists():
-            print(
-                f"ERR: artifacts missing at {artifacts_root}. Re-run with --download.",
-                file=sys.stderr,
-            )
-            return 1
-        maybe_download(run_id, args.out_base)
 
+def _gha_warning(title: str, message: str) -> None:
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        print(f"::warning title={title}::{message}")
+
+
+def _verify_summaries(artifacts_root: Path) -> int:
     summaries = find_telemetry_summaries(artifacts_root)
     if not summaries:
         print(
@@ -160,6 +304,133 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return 3
 
     print(f"OK: {len(summaries)} telemetry_summary.json validated under {artifacts_root}")
+    return 0
+
+
+def main(
+    argv: Optional[Sequence[str]] = None,
+    *,
+    fetch_artifacts: Optional[FetchArtifacts] = None,
+    download_run: Optional[DownloadRun] = None,
+) -> int:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Verify registry pointer artifacts and telemetry_summary.json invariants. "
+            "NO-LIVE: local audit helper — not a trading or execution path."
+        ),
+    )
+    ap.add_argument("pointer", type=Path, help="docs/ops/registry/*.pointer")
+    ap.add_argument(
+        "--out-base",
+        type=Path,
+        default=Path("out/ops/gh_runs"),
+        help="download base dir",
+    )
+    ap.add_argument(
+        "--download",
+        action="store_true",
+        help="download artifacts via gh run download",
+    )
+    ap.add_argument(
+        "--allow-expired",
+        action="store_true",
+        help=(
+            "treat proven REGISTRY_POINTER_EXPIRED as a non-failing lifecycle state "
+            "(pull_request hygiene). Default/manual/workflow_dispatch stays fail-closed."
+        ),
+    )
+    ap.add_argument(
+        "--pack-out",
+        type=Path,
+        default=None,
+        help="optional evidence pack output dir",
+    )
+    args = ap.parse_args(argv)
+
+    ptr = args.pointer
+    if not ptr.exists():
+        _emit_status_line(STATUS_INVALID)
+        print(f"ERR: pointer not found: {ptr}", file=sys.stderr)
+        return 1
+
+    d = parse_pointer(ptr)
+    run_id = d.get("run_id")
+    if not run_id:
+        _emit_status_line(STATUS_INVALID)
+        print("ERR: pointer missing run_id=", file=sys.stderr)
+        return 1
+
+    artifacts_root = args.out_base / run_id
+    fetcher = fetch_artifacts or fetch_run_artifact_records
+    downloader = download_run or download_run_artifacts
+
+    if args.download:
+        repo = resolve_repo(d)
+        if not repo:
+            _emit_status_line(STATUS_INVALID)
+            print(
+                "ERR: pointer missing repo= and GITHUB_REPOSITORY is unset",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            records = fetcher(run_id, repo)
+        except ArtifactFetchError as exc:
+            _emit_status_line(STATUS_UNAVAILABLE_UNKNOWN)
+            print(
+                f"ERR: artifact metadata fetch failed ({exc.kind}): {exc}",
+                file=sys.stderr,
+            )
+            return 1
+
+        status = classify_artifact_records(records)
+        _emit_status_line(status)
+        print(f"REGISTRY_POINTER_RUN_ID={run_id}")
+        print(f"REGISTRY_POINTER_ARTIFACT_COUNT={len(records)}")
+        print(f"REGISTRY_POINTER_EXPIRED_COUNT={sum(1 for r in records if r.expired)}")
+        print(f"REGISTRY_POINTER_AVAILABLE_COUNT={sum(1 for r in records if not r.expired)}")
+
+        if status == STATUS_EXPIRED:
+            _emit_expired_diagnostics(run_id, records)
+            expires_at = next((r.expires_at for r in records if r.expires_at), "unknown")
+            detail = (
+                f"pinned historical artifacts for run_id={run_id} are expired "
+                f"(expires_at={expires_at}); not a product/verification regression"
+            )
+            if args.allow_expired:
+                print("REGISTRY_POINTER_EXPIRED_ALLOWED=true")
+                print(f"INFO: {detail}; skipping download and invariant verification")
+                _gha_warning("REGISTRY_POINTER_EXPIRED", detail)
+                return 0
+            print(f"ERR: {detail}. Re-run with --allow-expired for PR hygiene.", file=sys.stderr)
+            return 1
+
+        if status != STATUS_AVAILABLE:
+            print(
+                "ERR: registry pointer artifacts are not available "
+                f"(status={status}, count={len(records)})",
+                file=sys.stderr,
+            )
+            return 1
+
+        try:
+            downloader(run_id, artifacts_root)
+        except ArtifactDownloadError as exc:
+            print(
+                "ERR: artifact metadata AVAILABLE but download failed: " + str(exc),
+                file=sys.stderr,
+            )
+            return 1
+    elif not artifacts_root.exists():
+        print(
+            f"ERR: artifacts missing at {artifacts_root}. Re-run with --download.",
+            file=sys.stderr,
+        )
+        return 1
+
+    verify_rc = _verify_summaries(artifacts_root)
+    if verify_rc != 0:
+        return verify_rc
 
     if args.pack_out:
         pack = args.pack_out

--- a/tests/ops/test_verify_registry_pointer_artifacts_smoke.py
+++ b/tests/ops/test_verify_registry_pointer_artifacts_smoke.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 _SCRIPT = ROOT / "scripts" / "ops" / "verify_registry_pointer_artifacts.py"
+_WORKFLOW = ROOT / ".github" / "workflows" / "ci-operator-verify-registry.yml"
+_WRAPPER = ROOT / "scripts" / "ops" / "verify_from_registry.sh"
 
 
 def test_verify_registry_pointer_artifacts_help_lists_no_live() -> None:
@@ -21,6 +23,7 @@ def test_verify_registry_pointer_artifacts_help_lists_no_live() -> None:
     assert p.returncode == 0, p.stderr
     # argparse may wrap the description across lines (e.g. "NO-\nLIVE")
     assert "NO-LIVE" in p.stdout.replace("\n", "")
+    assert "--allow-expired" in p.stdout
 
 
 def test_verify_registry_pointer_artifacts_main_returns_1_missing_pointer(tmp_path: Path) -> None:
@@ -30,6 +33,13 @@ def test_verify_registry_pointer_artifacts_main_returns_1_missing_pointer(tmp_pa
     missing = tmp_path / "missing.pointer"
     code = v.main([str(missing)])
     assert code == 1
+
+
+def _import_verifier():
+    sys.path.insert(0, str(ROOT / "scripts" / "ops"))
+    import verify_registry_pointer_artifacts as v  # noqa: E402
+
+    return v
 
 
 def _run_script_with_out_base(pointer: Path, out_base: Path) -> subprocess.CompletedProcess[str]:
@@ -69,6 +79,48 @@ def _write_invalid_fallback_reason_telemetry_summary(path: Path) -> None:
     path.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
 
 
+def _write_pointer(path: Path, run_id: str, repo: str = "rauterfrank-ui/Peak_Trade") -> None:
+    path.write_text(f"run_id={run_id}\nrepo={repo}\n", encoding="utf-8")
+
+
+def _expired_records(v):
+    return [
+        v.ArtifactRecord(
+            name="gh-paper-tests-audit-evidence-py3.9",
+            expired=True,
+            artifact_id=7095102369,
+            expires_at="2026-08-17T20:51:09Z",
+            created_at="2026-05-19T20:52:44Z",
+        ),
+        v.ArtifactRecord(
+            name="gh-paper-tests-audit-evidence-py3.10",
+            expired=True,
+            artifact_id=7095103681,
+            expires_at="2026-08-17T20:51:09Z",
+            created_at="2026-05-19T20:52:48Z",
+        ),
+        v.ArtifactRecord(
+            name="gh-paper-tests-audit-evidence-py3.11",
+            expired=True,
+            artifact_id=7095099640,
+            expires_at="2026-08-17T20:51:09Z",
+            created_at="2026-05-19T20:52:36Z",
+        ),
+    ]
+
+
+def _available_records(v):
+    return [
+        v.ArtifactRecord(
+            name="gh-paper-tests-audit-evidence-py3.11",
+            expired=False,
+            artifact_id=1,
+            expires_at="2026-12-01T00:00:00Z",
+            created_at="2026-08-18T00:00:00Z",
+        )
+    ]
+
+
 def test_verify_registry_pointer_artifacts_offline_success_with_valid_telemetry(
     tmp_path: Path,
 ) -> None:
@@ -100,3 +152,273 @@ def test_verify_registry_pointer_artifacts_telemetry_invariant_violation_exit_3(
     assert proc.returncode == 3
     assert "FAIL: telemetry invariants violated" in proc.stderr
     assert "fallback code present in reason_codes" in proc.stderr
+
+
+def test_classify_artifact_records_expired_available_empty() -> None:
+    v = _import_verifier()
+    assert v.classify_artifact_records(_expired_records(v)) == v.STATUS_EXPIRED
+    assert v.classify_artifact_records(_available_records(v)) == v.STATUS_AVAILABLE
+    mixed = _expired_records(v) + _available_records(v)
+    assert v.classify_artifact_records(mixed) == v.STATUS_AVAILABLE
+    assert v.classify_artifact_records([]) == v.STATUS_UNAVAILABLE_UNKNOWN
+
+
+def test_parse_artifacts_api_payload_uses_explicit_expired_true_only() -> None:
+    v = _import_verifier()
+    payload = json.dumps(
+        {
+            "total_count": 2,
+            "artifacts": [
+                {"id": 1, "name": "a", "expired": True, "expires_at": "2026-08-17T20:51:09Z"},
+                {"id": 2, "name": "b", "expired": False},
+            ],
+        }
+    )
+    records = v.parse_artifacts_api_payload(payload)
+    assert [r.expired for r in records] == [True, False]
+    missing_field = json.dumps({"artifacts": [{"id": 3, "name": "c"}]})
+    assert v.parse_artifacts_api_payload(missing_field)[0].expired is False
+
+
+def test_malformed_pointer_missing_run_id_is_invalid(tmp_path: Path) -> None:
+    v = _import_verifier()
+    pointer = tmp_path / "fixture.pointer"
+    pointer.write_text("repo=rauterfrank-ui/Peak_Trade\n", encoding="utf-8")
+    code = v.main([str(pointer), "--download", "--out-base", str(tmp_path / "out")])
+    assert code == 1
+
+
+def test_malformed_pointer_missing_file_is_invalid(tmp_path: Path) -> None:
+    v = _import_verifier()
+    missing = tmp_path / "missing.pointer"
+    code = v.main(
+        [str(missing), "--download", "--out-base", str(tmp_path / "out")],
+        fetch_artifacts=lambda _rid, _repo: [],
+        download_run=lambda _rid, _dest: (_ for _ in ()).throw(AssertionError("download")),
+    )
+    assert code == 1
+
+
+def test_expired_artifacts_explicit_status_strict_fails_without_download(
+    tmp_path: Path,
+) -> None:
+    v = _import_verifier()
+    pointer = tmp_path / "fixture.pointer"
+    _write_pointer(pointer, "26124538678")
+    downloaded: list[str] = []
+
+    def fetch(_run_id: str, _repo: str):
+        return _expired_records(v)
+
+    def download(run_id: str, _dest: Path) -> None:
+        downloaded.append(run_id)
+
+    code = v.main(
+        [str(pointer), "--download", "--out-base", str(tmp_path / "out")],
+        fetch_artifacts=fetch,
+        download_run=download,
+    )
+    assert code == 1
+    assert downloaded == []
+
+
+def test_expired_artifacts_allow_expired_is_controlled_success(tmp_path: Path, capsys) -> None:
+    v = _import_verifier()
+    pointer = tmp_path / "fixture.pointer"
+    _write_pointer(pointer, "26124538678")
+    downloaded: list[str] = []
+
+    def fetch(_run_id: str, _repo: str):
+        return _expired_records(v)
+
+    def download(run_id: str, _dest: Path) -> None:
+        downloaded.append(run_id)
+
+    code = v.main(
+        [
+            str(pointer),
+            "--download",
+            "--allow-expired",
+            "--out-base",
+            str(tmp_path / "out"),
+        ],
+        fetch_artifacts=fetch,
+        download_run=download,
+    )
+    captured = capsys.readouterr()
+    assert code == 0
+    assert downloaded == []
+    assert "REGISTRY_POINTER_STATUS=EXPIRED" in captured.out
+    assert "REGISTRY_POINTER_EXPIRED=true" in captured.out
+    assert "REGISTRY_POINTER_EXPIRED_ALLOWED=true" in captured.out
+    assert "2026-08-17T20:51:09Z" in captured.out
+
+
+def test_unknown_missing_artifacts_fail_closed(tmp_path: Path) -> None:
+    v = _import_verifier()
+    pointer = tmp_path / "fixture.pointer"
+    _write_pointer(pointer, "26124538678")
+    downloaded: list[str] = []
+
+    code = v.main(
+        [
+            str(pointer),
+            "--download",
+            "--allow-expired",
+            "--out-base",
+            str(tmp_path / "out"),
+        ],
+        fetch_artifacts=lambda _rid, _repo: [],
+        download_run=lambda run_id, _dest: downloaded.append(run_id),
+    )
+    assert code == 1
+    assert downloaded == []
+
+
+def test_auth_fetch_failure_is_not_classified_expired(tmp_path: Path, capsys) -> None:
+    v = _import_verifier()
+    pointer = tmp_path / "fixture.pointer"
+    _write_pointer(pointer, "26124538678")
+
+    def fetch(_run_id: str, _repo: str):
+        raise v.ArtifactFetchError(
+            "HTTP 403: Resource not accessible", kind="auth", http_status=403
+        )
+
+    code = v.main(
+        [
+            str(pointer),
+            "--download",
+            "--allow-expired",
+            "--out-base",
+            str(tmp_path / "out"),
+        ],
+        fetch_artifacts=fetch,
+        download_run=lambda _rid, _dest: (_ for _ in ()).throw(AssertionError("download")),
+    )
+    captured = capsys.readouterr()
+    assert code == 1
+    assert "REGISTRY_POINTER_STATUS=UNAVAILABLE_UNKNOWN" in captured.out
+    assert "REGISTRY_POINTER_EXPIRED=true" not in captured.out
+    assert "artifact metadata fetch failed (auth)" in captured.err
+
+
+def test_available_artifact_downloads_and_verifies(tmp_path: Path, capsys) -> None:
+    v = _import_verifier()
+    run_id = "26124538678"
+    pointer = tmp_path / "fixture.pointer"
+    _write_pointer(pointer, run_id)
+    out_base = tmp_path / "out"
+
+    def fetch(_run_id: str, _repo: str):
+        return _available_records(v)
+
+    def download(got_run_id: str, dest: Path) -> None:
+        assert got_run_id == run_id
+        dest.mkdir(parents=True, exist_ok=True)
+        _write_valid_telemetry_summary(dest / "telemetry_summary.json")
+
+    code = v.main(
+        [str(pointer), "--download", "--out-base", str(out_base)],
+        fetch_artifacts=fetch,
+        download_run=download,
+    )
+    captured = capsys.readouterr()
+    assert code == 0
+    assert "REGISTRY_POINTER_STATUS=AVAILABLE" in captured.out
+    assert "OK: 1 telemetry_summary.json validated" in captured.out
+
+
+def test_available_metadata_but_download_failure_fails_closed(tmp_path: Path) -> None:
+    v = _import_verifier()
+    pointer = tmp_path / "fixture.pointer"
+    _write_pointer(pointer, "26124538678")
+
+    def fetch(_run_id: str, _repo: str):
+        return _available_records(v)
+
+    def download(_run_id: str, _dest: Path) -> None:
+        raise v.ArtifactDownloadError("no valid artifacts found to download", returncode=1)
+
+    code = v.main(
+        [
+            str(pointer),
+            "--download",
+            "--allow-expired",
+            "--out-base",
+            str(tmp_path / "out"),
+        ],
+        fetch_artifacts=fetch,
+        download_run=download,
+    )
+    assert code == 1
+
+
+def test_available_download_without_telemetry_fails_closed(tmp_path: Path) -> None:
+    v = _import_verifier()
+    pointer = tmp_path / "fixture.pointer"
+    _write_pointer(pointer, "26124538678")
+
+    def fetch(_run_id: str, _repo: str):
+        return _available_records(v)
+
+    def download(_run_id: str, dest: Path) -> None:
+        dest.mkdir(parents=True, exist_ok=True)
+        (dest / "README.txt").write_text("no telemetry here\n", encoding="utf-8")
+
+    code = v.main(
+        [str(pointer), "--download", "--out-base", str(tmp_path / "out")],
+        fetch_artifacts=fetch,
+        download_run=download,
+    )
+    assert code == 1
+
+
+def test_available_download_with_invalid_telemetry_still_exit_3(tmp_path: Path) -> None:
+    v = _import_verifier()
+    pointer = tmp_path / "fixture.pointer"
+    _write_pointer(pointer, "26124538678")
+
+    def fetch(_run_id: str, _repo: str):
+        return _available_records(v)
+
+    def download(_run_id: str, dest: Path) -> None:
+        dest.mkdir(parents=True, exist_ok=True)
+        _write_invalid_fallback_reason_telemetry_summary(dest / "telemetry_summary.json")
+
+    code = v.main(
+        [str(pointer), "--download", "--out-base", str(tmp_path / "out")],
+        fetch_artifacts=fetch,
+        download_run=download,
+    )
+    assert code == 3
+
+
+def test_download_error_text_is_not_used_as_expiry_classification() -> None:
+    v = _import_verifier()
+    # Metadata remaining available must stay AVAILABLE even if a later download
+    # message looks like the historical expiry symptom.
+    records = _available_records(v)
+    assert v.classify_artifact_records(records) == v.STATUS_AVAILABLE
+
+
+def test_workflow_allows_expired_only_on_pull_request() -> None:
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    assert "github.event_name" in text
+    assert "--allow-expired" in text
+    assert "pull_request" in text
+    assert "workflow_dispatch" in text
+    assert (
+        "scripts/ops/verify_from_registry.sh docs/ops/registry/LATEST_PHASE_M_SMOKE.pointer --download --allow-expired"
+        in text
+    )
+    assert (
+        "scripts/ops/verify_from_registry.sh docs/ops/registry/LATEST_PHASE_M_SMOKE.pointer --download\n"
+        in text
+    )
+
+
+def test_verify_from_registry_wrapper_forwards_allow_expired() -> None:
+    text = _WRAPPER.read_text(encoding="utf-8")
+    assert "--allow-expired) ALLOW_EXPIRED=" in text
+    assert "ARGS+=(--allow-expired)" in text


### PR DESCRIPTION
## Summary
- Historical `operator-verify` redness is GitHub artifact retention (90-day expiry of pinned run `26124538678` at `2026-08-17T20:51:09Z`), not a product regression. PR #5940 is not causal.
- The verifier now classifies artifact **metadata** before download (`AVAILABLE` / `EXPIRED` / `INVALID` / `UNAVAILABLE_UNKNOWN`). Proven `REGISTRY_POINTER_EXPIRED` is a pull_request lifecycle state (exit 0, visible warning). `workflow_dispatch` stays fail-closed.
- Unknown download, auth, missing-run, corrupt/missing telemetry, and invariant failures remain fail-closed. Pointer was not refreshed; no `workflow_dispatch` producer was started; required checks and branch protection are unchanged.

## Test plan
- [x] `uv run pytest tests/ops/test_verify_registry_pointer_artifacts_smoke.py`
- [x] `ruff format --check` / `ruff check` on changed Python files
- [ ] Confirm PR `operator-verify` is no longer a false-red product fail (expected: `REGISTRY_POINTER_STATUS=EXPIRED` + exit 0)
- [ ] Confirm `workflow_dispatch` of this workflow still fails closed on the same expired pointer
- [ ] Confirm required checks / branch protection are untouched


Made with [Cursor](https://cursor.com)