### PR TITLE
research: add identity admission to package-n i16

### DIFF
--- a/docs/ops/specs/CANONICAL_EXPERIMENT_IDENTITY_TO_PACKAGE_N_I16_PROMOTION_ADMISSION_V1.md
+++ b/docs/ops/specs/CANONICAL_EXPERIMENT_IDENTITY_TO_PACKAGE_N_I16_PROMOTION_ADMISSION_V1.md
@@ -1,0 +1,121 @@
+# Canonical Experiment Identity to Package-N I16 Promotion Admission v1
+
+Contract for Peak_Trade Identity Admission. This is not Self-Learning Phase 13.
+
+```text
+SCHEMA_VERSION=canonical_experiment_identity_to_package_n_i16_promotion_admission_v1
+ADMISSION_DOMAIN=peak_trade.canonical_experiment_identity_to_package_n_i16_promotion_admission.v1
+ADMISSION_PRESENT=true
+ADMISSION_AUTHORITY=RESEARCH_EVIDENCE_PARENT_ONLY
+PROMOTION_AUTHORITY=NONE
+PROMOTION_APPLY_ALLOWED=false
+BOUNDED_AUTO_ALLOWED=false
+I16_ASSESSMENT_CONSUMABLE_WHEN_ADMITTED=true
+PACKAGE_N_HASH_REINTERPRETATION_FORBIDDEN=true
+SELF_LEARNING_SELF_AUTHORIZING_SEPARATION=true
+SELF_LEARNING_NOT_SELF_AUTHORIZING=true
+```
+
+Owner:
+
+- `src&#47;experiments&#47;canonical_experiment_identity_to_package_n_i16_promotion_admission_v1.py` — admit research-evidence parent only
+
+Reuse, do not replace:
+
+```text
+Phase 1   src.experiments.canonical_experiment_identity_v1              REUSE COMPLETE identity
+Package N src.experiments.experiment_identity_manifest_v1               REUSE experiment_identity_id unchanged
+I16 join  src.governance.promotion_loop.i16_remaining_planes_join_attachment_v1  REUSE Package-N SHA256 assessment surface
+I82 id    src.experiments.cross_lane_identity_join_v1.is_package_n_sha256_canonical_id  REUSE
+```
+
+```text
+src.governance.promotion_loop.engine.apply_proposals_to_live_overrides  NOT_APPLICABLE
+src.governance.promotion_loop.engine                                     NOT_APPLICABLE as apply&#47;authority
+src.meta.learning_loop.comparison_ssot_v1                                NOT_APPLICABLE
+src.experiments.canonical_champion_challenger_v1                         NOT_APPLICABLE
+src.live.live_gates                                                      NOT_APPLICABLE
+```
+
+This layer does not invent identity, does not recompute Package-N hashes, and does not promote. It attaches a Phase-1 COMPLETE identity as a research-evidence parent onto an existing Package-N `experiment_identity_id` so `manual_only` I16 assessment may consume that parent.
+
+## Shape
+
+```text
+PHASE_1_COMPLETE_VALIDATION
+PACKAGE_N_MANIFEST_VALIDATION
+PLANE_SEPARATION
+COMPARABLE_DIMENSION_CHECK
+UNSUPPORTED_PROJECTION_GUARD
+HASH_REINTERPRETATION_GUARD
+AUTHORITY_BOUNDARY
+I16_ASSESSMENT_ATTACHMENT
+ADMISSION_EVIDENCE
+```
+
+```text
+Canonical Phase-1 Identity COMPLETE
+        ↓
+explicit compatibility&#47;admission mapping
+        ↓
+existing Package-N experiment_identity_id remains unchanged
+        ↓
+manual_only I16 assessment may consume admitted research-evidence parent
+```
+
+## Fail closed
+
+Any of the following yields a typed `REJECTED_*` result, never `ADMITTED`:
+
+```text
+missing dimension
+incompatible dimension
+ambiguous identity
+unsupported projection
+hash reinterpretation required
+non-COMPLETE Phase-1 identity
+invalid Package-N identity
+requested apply
+requested bounded_auto or any mode other than manual_only
+```
+
+Package N remains an incomplete historical projection. Completeness of Phase 1 does not make Package N complete. Claiming that Package N already encodes Phase-1 fee&#47;seed&#47;split&#47;core&#47;git dimensions is `REJECTED_UNSUPPORTED_PROJECTION`.
+
+## Comparable dimension
+
+The only overlapping comparable dimension in this contract is strategy identity:
+
+```text
+phase1.strategy_identity == package_n.identity_config.strategy_name
+```
+
+Mismatch is `REJECTED_INCOMPATIBLE_DIMENSION`. No silent aliasing, version stripping, or case folding.
+
+## Authority
+
+```text
+PROMOTION_AUTHORITY=NONE
+PROMOTION_APPLY_ALLOWED=false
+I16_ASSESSMENT_CONSUMABLE != APPLY
+I16_ASSESSMENT_CONSUMABLE != bounded_auto
+ADMITTED != PROMOTED
+ADMITTED != LIVE
+```
+
+`ADMITTED` means only that I16 `manual_only` assessment may read the research-evidence parent. It does not write live overrides, arm, fund, submit orders, swap a Champion, or authorize canary.
+
+## Non-effects
+
+```text
+LIVE_AUTHORIZED=false
+TESTNET_AUTHORIZED=false
+ORDER_EFFECT=false
+ACCOUNT_MUTATION_EFFECT=false
+MULTI_FUTURE_AUTH_EFFECT=false
+FUNDING_AUTH_EFFECT=false
+PROMOTION_APPLY_EFFECT=false
+I82_FULL_MIGRATION=false
+MD5_REMOVAL=false
+IDENTITY_BACKFILL=false
+G14_PRODUCTIVE_AUTHORITY=false
+```

--- a/src/experiments/canonical_experiment_identity_to_package_n_i16_promotion_admission_v1.py
+++ b/src/experiments/canonical_experiment_identity_to_package_n_i16_promotion_admission_v1.py
@@ -1,0 +1,457 @@
+"""Canonical Experiment Identity to Package-N I16 promotion admission v1.
+
+Attaches a Phase-1 COMPLETE identity as a research-evidence parent onto an
+existing Package-N experiment_identity_id for manual_only I16 assessment.
+Does not recompute Package-N hashes, apply promotions, or grant runtime
+authority.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Final, Mapping
+
+from src.experiments.canonical_experiment_identity_v1 import (
+    COMPLETENESS_COMPLETE,
+    CanonicalExperimentIdentityError,
+    IDENTITY_DOMAIN as PHASE1_IDENTITY_DOMAIN,
+    SCHEMA_VERSION as PHASE1_SCHEMA_VERSION,
+    validate_canonical_experiment_identity_v1,
+)
+from src.experiments.cross_lane_identity_join_v1 import (
+    CrossLaneIdentityJoinV1,
+    is_package_n_sha256_canonical_id,
+)
+from src.experiments.experiment_identity_manifest_v1 import (
+    ExperimentIdentityManifestError,
+    PACKAGE_N_IDENTITY_COMPLETENESS,
+    validate_experiment_identity_manifest_v1,
+)
+from src.governance.promotion_loop.i16_remaining_planes_join_attachment_v1 import (
+    I16RemainingPlanesJoinAttachmentError,
+    attach_i16_remaining_planes_join_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import compute_content_sha256
+
+SCHEMA_VERSION: Final[str] = "canonical_experiment_identity_to_package_n_i16_promotion_admission_v1"
+ADMISSION_DOMAIN: Final[str] = (
+    "peak_trade.canonical_experiment_identity_to_package_n_i16_promotion_admission.v1"
+)
+ADMISSION_PRESENT: Final[bool] = True
+ADMISSION_AUTHORITY: Final[str] = "RESEARCH_EVIDENCE_PARENT_ONLY"
+PROMOTION_AUTHORITY: Final[str] = "NONE"
+PROMOTION_APPLY_ALLOWED: Final[bool] = False
+BOUNDED_AUTO_ALLOWED: Final[bool] = False
+REQUIRED_PROMOTION_MODE: Final[str] = "manual_only"
+RUNTIME_AUTHORITY_IMPACT: Final[str] = "NONE"
+SELF_LEARNING_NOT_SELF_AUTHORIZING: Final[bool] = True
+
+STATUS_ADMITTED: Final[str] = "ADMITTED"
+STATUS_REJECTED_MISSING_DIMENSION: Final[str] = "REJECTED_MISSING_DIMENSION"
+STATUS_REJECTED_INCOMPATIBLE_DIMENSION: Final[str] = "REJECTED_INCOMPATIBLE_DIMENSION"
+STATUS_REJECTED_AMBIGUOUS_IDENTITY: Final[str] = "REJECTED_AMBIGUOUS_IDENTITY"
+STATUS_REJECTED_UNSUPPORTED_PROJECTION: Final[str] = "REJECTED_UNSUPPORTED_PROJECTION"
+STATUS_REJECTED_HASH_REINTERPRETATION_REQUIRED: Final[str] = (
+    "REJECTED_HASH_REINTERPRETATION_REQUIRED"
+)
+STATUS_REJECTED_AUTHORITY_BOUNDARY: Final[str] = "REJECTED_AUTHORITY_BOUNDARY"
+STATUS_REJECTED_INCOMPLETE_IDENTITY: Final[str] = "REJECTED_INCOMPLETE_IDENTITY"
+STATUS_REJECTED_INVALID_PACKAGE_N: Final[str] = "REJECTED_INVALID_PACKAGE_N"
+
+NON_PROJECTABLE_PHASE1_DIMENSIONS: Final[tuple[str, ...]] = (
+    "dataset_digest",
+    "feature_pipeline_digest",
+    "fee_model_digest",
+    "slippage_model_digest",
+    "funding_model_digest",
+    "risk_policy_digest",
+    "portfolio_digest",
+    "split_policy_digest",
+    "seed",
+    "git_sha",
+    "working_tree_status",
+    "trading_decision_core_digest",
+    "environment_digest",
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CanonicalIdentityToPackageNI16AdmissionError(ValueError):
+    """Fail-closed malformed admission request error."""
+
+
+@dataclass(frozen=True)
+class CanonicalIdentityToPackageNI16AdmissionRequestV1:
+    phase1_identity: Mapping[str, Any]
+    package_n_manifest: Mapping[str, Any]
+    claimed_package_n_is_phase1_complete: bool = False
+    claimed_recomputed_package_n_id: str | None = None
+    requested_promotion_mode: str = REQUIRED_PROMOTION_MODE
+    requested_apply: bool = False
+
+
+def _freeze(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({str(key): _freeze(item) for key, item in value.items()})
+    if isinstance(value, tuple):
+        return tuple(_freeze(item) for item in value)
+    if isinstance(value, list):
+        return tuple(_freeze(item) for item in value)
+    return value
+
+
+def _plain_mapping(value: Mapping[str, Any]) -> dict[str, Any]:
+    return {str(key): item for key, item in value.items()}
+
+
+def _require_mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise CanonicalIdentityToPackageNI16AdmissionError(f"{label} must be a mapping")
+    return value
+
+
+def _rejected(
+    status: str,
+    reason: str,
+    *,
+    package_n_id: str | None = None,
+    parent_digest: str | None = None,
+    parent_integrity: str | None = None,
+    requested_mode: str = REQUIRED_PROMOTION_MODE,
+) -> Mapping[str, Any]:
+    return _build_result(
+        status=status,
+        rejection_reason=reason,
+        package_n_id=package_n_id,
+        parent_digest=parent_digest,
+        parent_integrity=parent_integrity,
+        i16_assessment_consumable=False,
+        i16_join=None,
+        requested_mode=requested_mode,
+    )
+
+
+def _authority_invariants() -> dict[str, Any]:
+    return {
+        "admission_authority": ADMISSION_AUTHORITY,
+        "bounded_auto_allowed": BOUNDED_AUTO_ALLOWED,
+        "promotion_apply_allowed": PROMOTION_APPLY_ALLOWED,
+        "promotion_authority": PROMOTION_AUTHORITY,
+        "runtime_authority_impact": RUNTIME_AUTHORITY_IMPACT,
+        "self_learning_not_self_authorizing": SELF_LEARNING_NOT_SELF_AUTHORIZING,
+        "live_authorized": False,
+        "testnet_authorized": False,
+        "order_effect": False,
+        "account_mutation_effect": False,
+        "multi_future_auth_effect": False,
+        "funding_auth_effect": False,
+        "i82_full_migration": False,
+        "md5_removal": False,
+        "identity_backfill": False,
+    }
+
+
+def _build_result(
+    *,
+    status: str,
+    rejection_reason: str | None,
+    package_n_id: str | None,
+    parent_digest: str | None,
+    parent_integrity: str | None,
+    i16_assessment_consumable: bool,
+    i16_join: Mapping[str, Any] | None,
+    requested_mode: str,
+) -> Mapping[str, Any]:
+    admitted = status == STATUS_ADMITTED
+    body = {
+        "schema_version": SCHEMA_VERSION,
+        "admission_domain": ADMISSION_DOMAIN,
+        "admission_present": ADMISSION_PRESENT,
+        "status": status,
+        "rejection_reason": rejection_reason,
+        "package_n_experiment_identity_id": package_n_id,
+        "package_n_identity_completeness": PACKAGE_N_IDENTITY_COMPLETENESS,
+        "package_n_experiment_identity_id_mutated": False,
+        "hash_reinterpreted": False,
+        "research_evidence_parent_identity_digest": parent_digest,
+        "research_evidence_parent_integrity_sha256": parent_integrity,
+        "i16_assessment_consumable": i16_assessment_consumable and admitted,
+        "requested_promotion_mode": requested_mode,
+        "required_promotion_mode": REQUIRED_PROMOTION_MODE,
+        "i16_join": None if i16_join is None else dict(i16_join),
+        "authority_invariants": _authority_invariants(),
+    }
+    body["integrity"] = {
+        "content_sha256": compute_content_sha256(
+            {key: value for key, value in body.items() if key != "integrity"}
+        )
+    }
+    return MappingProxyType(_freeze(body))
+
+
+def _package_n_strategy_name(manifest: Mapping[str, Any]) -> str | None:
+    identity_config = manifest.get("identity_config")
+    if not isinstance(identity_config, Mapping):
+        return None
+    raw = identity_config.get("strategy_name")
+    if not isinstance(raw, str) or not raw.strip() or raw != raw.strip():
+        return None
+    return raw
+
+
+def evaluate_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1(
+    request: CanonicalIdentityToPackageNI16AdmissionRequestV1,
+) -> Mapping[str, Any]:
+    """Evaluate admission. Never mutates Package-N hashes or writes config."""
+    phase1 = _require_mapping(request.phase1_identity, "phase1_identity")
+    package_n = _require_mapping(request.package_n_manifest, "package_n_manifest")
+    requested_mode = request.requested_promotion_mode
+    phase1_plain = _plain_mapping(phase1)
+    package_n_plain = _plain_mapping(package_n)
+
+    if request.requested_apply is True:
+        return _rejected(
+            STATUS_REJECTED_AUTHORITY_BOUNDARY,
+            "requested_apply is forbidden; admission is not promotion apply",
+            requested_mode=requested_mode,
+        )
+    if requested_mode != REQUIRED_PROMOTION_MODE:
+        return _rejected(
+            STATUS_REJECTED_AUTHORITY_BOUNDARY,
+            "requested_promotion_mode must be manual_only",
+            requested_mode=requested_mode,
+        )
+    if request.claimed_package_n_is_phase1_complete is True:
+        return _rejected(
+            STATUS_REJECTED_UNSUPPORTED_PROJECTION,
+            "Package N cannot be claimed as Phase-1 COMPLETE; incomplete projection retained",
+            requested_mode=requested_mode,
+        )
+    if request.claimed_recomputed_package_n_id is not None:
+        return _rejected(
+            STATUS_REJECTED_HASH_REINTERPRETATION_REQUIRED,
+            "Package-N experiment_identity_id must not be recomputed or reinterpreted",
+            requested_mode=requested_mode,
+        )
+
+    try:
+        validate_canonical_experiment_identity_v1(phase1_plain)
+    except CanonicalExperimentIdentityError as exc:
+        message = str(exc)
+        status = (
+            STATUS_REJECTED_MISSING_DIMENSION
+            if "must" in message.lower() and "complete" not in message.lower()
+            else STATUS_REJECTED_INCOMPLETE_IDENTITY
+        )
+        if phase1_plain.get("completeness") != COMPLETENESS_COMPLETE:
+            status = STATUS_REJECTED_INCOMPLETE_IDENTITY
+        return _rejected(status, message, requested_mode=requested_mode)
+
+    parent_digest = phase1_plain.get("identity_digest")
+    integrity = phase1_plain.get("integrity")
+    parent_integrity = integrity.get("content_sha256") if isinstance(integrity, Mapping) else None
+    if not isinstance(parent_digest, str) or not parent_digest.strip():
+        return _rejected(
+            STATUS_REJECTED_MISSING_DIMENSION,
+            "phase1 identity_digest missing",
+            requested_mode=requested_mode,
+        )
+    if not isinstance(parent_integrity, str) or not parent_integrity.strip():
+        return _rejected(
+            STATUS_REJECTED_MISSING_DIMENSION,
+            "phase1 integrity.content_sha256 missing",
+            parent_digest=parent_digest,
+            requested_mode=requested_mode,
+        )
+
+    try:
+        validate_experiment_identity_manifest_v1(package_n_plain)
+    except ExperimentIdentityManifestError as exc:
+        return _rejected(
+            STATUS_REJECTED_INVALID_PACKAGE_N,
+            str(exc),
+            parent_digest=parent_digest,
+            parent_integrity=parent_integrity,
+            requested_mode=requested_mode,
+        )
+
+    package_n_id = package_n_plain.get("experiment_identity_id")
+    if not isinstance(package_n_id, str) or not package_n_id.strip():
+        return _rejected(
+            STATUS_REJECTED_MISSING_DIMENSION,
+            "package_n experiment_identity_id missing",
+            parent_digest=parent_digest,
+            parent_integrity=parent_integrity,
+            requested_mode=requested_mode,
+        )
+    if not is_package_n_sha256_canonical_id(package_n_id):
+        return _rejected(
+            STATUS_REJECTED_INVALID_PACKAGE_N,
+            "package_n experiment_identity_id must be Package-N SHA256",
+            package_n_id=package_n_id,
+            parent_digest=parent_digest,
+            parent_integrity=parent_integrity,
+            requested_mode=requested_mode,
+        )
+    if package_n_id == parent_digest:
+        return _rejected(
+            STATUS_REJECTED_AMBIGUOUS_IDENTITY,
+            "Phase-1 identity_digest must remain distinct from Package-N experiment_identity_id",
+            package_n_id=package_n_id,
+            parent_digest=parent_digest,
+            parent_integrity=parent_integrity,
+            requested_mode=requested_mode,
+        )
+
+    strategy_identity = phase1_plain.get("strategy_identity")
+    package_n_strategy = _package_n_strategy_name(package_n_plain)
+    if not isinstance(strategy_identity, str) or not strategy_identity.strip():
+        return _rejected(
+            STATUS_REJECTED_MISSING_DIMENSION,
+            "phase1 strategy_identity missing",
+            package_n_id=package_n_id,
+            parent_digest=parent_digest,
+            parent_integrity=parent_integrity,
+            requested_mode=requested_mode,
+        )
+    if package_n_strategy is None:
+        return _rejected(
+            STATUS_REJECTED_MISSING_DIMENSION,
+            "package_n identity_config.strategy_name missing",
+            package_n_id=package_n_id,
+            parent_digest=parent_digest,
+            parent_integrity=parent_integrity,
+            requested_mode=requested_mode,
+        )
+    if strategy_identity != package_n_strategy:
+        return _rejected(
+            STATUS_REJECTED_INCOMPATIBLE_DIMENSION,
+            "strategy_identity is incompatible with package_n identity_config.strategy_name",
+            package_n_id=package_n_id,
+            parent_digest=parent_digest,
+            parent_integrity=parent_integrity,
+            requested_mode=requested_mode,
+        )
+
+    if phase1_plain.get("schema_version") == package_n_plain.get("schema_version"):
+        return _rejected(
+            STATUS_REJECTED_AMBIGUOUS_IDENTITY,
+            "Phase-1 and Package-N schema_version must remain distinct identity planes",
+            package_n_id=package_n_id,
+            parent_digest=parent_digest,
+            parent_integrity=parent_integrity,
+            requested_mode=requested_mode,
+        )
+    if phase1_plain.get("identity_domain") == package_n_plain.get("identity_domain"):
+        return _rejected(
+            STATUS_REJECTED_AMBIGUOUS_IDENTITY,
+            "Phase-1 and Package-N identity_domain must remain distinct identity planes",
+            package_n_id=package_n_id,
+            parent_digest=parent_digest,
+            parent_integrity=parent_integrity,
+            requested_mode=requested_mode,
+        )
+    if phase1_plain.get("schema_version") != PHASE1_SCHEMA_VERSION:
+        return _rejected(
+            STATUS_REJECTED_INCOMPLETE_IDENTITY,
+            "phase1 schema_version mismatch",
+            package_n_id=package_n_id,
+            parent_digest=parent_digest,
+            parent_integrity=parent_integrity,
+            requested_mode=requested_mode,
+        )
+    if phase1_plain.get("identity_domain") != PHASE1_IDENTITY_DOMAIN:
+        return _rejected(
+            STATUS_REJECTED_INCOMPLETE_IDENTITY,
+            "phase1 identity_domain mismatch",
+            package_n_id=package_n_id,
+            parent_digest=parent_digest,
+            parent_integrity=parent_integrity,
+            requested_mode=requested_mode,
+        )
+
+    try:
+        join = attach_i16_remaining_planes_join_v1(
+            {
+                "experiment_identity_id": package_n_id,
+                "ref_id": package_n_id,
+                "evidence_ref": parent_integrity,
+                "content_sha256": parent_integrity,
+            }
+        )
+    except I16RemainingPlanesJoinAttachmentError as exc:
+        return _rejected(
+            STATUS_REJECTED_INVALID_PACKAGE_N,
+            f"I16 assessment attachment rejected: {exc}",
+            package_n_id=package_n_id,
+            parent_digest=parent_digest,
+            parent_integrity=parent_integrity,
+            requested_mode=requested_mode,
+        )
+    if not isinstance(join, CrossLaneIdentityJoinV1):
+        return _rejected(
+            STATUS_REJECTED_INVALID_PACKAGE_N,
+            "I16 assessment attachment did not return a join record",
+            package_n_id=package_n_id,
+            parent_digest=parent_digest,
+            parent_integrity=parent_integrity,
+            requested_mode=requested_mode,
+        )
+    if join.experiment_identity_id != package_n_id:
+        return _rejected(
+            STATUS_REJECTED_HASH_REINTERPRETATION_REQUIRED,
+            "I16 join mutated Package-N experiment_identity_id",
+            package_n_id=package_n_id,
+            parent_digest=parent_digest,
+            parent_integrity=parent_integrity,
+            requested_mode=requested_mode,
+        )
+
+    result = _build_result(
+        status=STATUS_ADMITTED,
+        rejection_reason=None,
+        package_n_id=package_n_id,
+        parent_digest=parent_digest,
+        parent_integrity=parent_integrity,
+        i16_assessment_consumable=True,
+        i16_join=join.to_canonical_mapping(),
+        requested_mode=requested_mode,
+    )
+    _LOGGER.info(
+        "identity_admission status=%s package_n_id=%s parent_digest=%s apply_allowed=%s",
+        STATUS_ADMITTED,
+        package_n_id,
+        parent_digest,
+        PROMOTION_APPLY_ALLOWED,
+    )
+    return result
+
+
+__all__ = [
+    "ADMISSION_AUTHORITY",
+    "ADMISSION_DOMAIN",
+    "ADMISSION_PRESENT",
+    "BOUNDED_AUTO_ALLOWED",
+    "CanonicalIdentityToPackageNI16AdmissionError",
+    "CanonicalIdentityToPackageNI16AdmissionRequestV1",
+    "NON_PROJECTABLE_PHASE1_DIMENSIONS",
+    "PROMOTION_APPLY_ALLOWED",
+    "PROMOTION_AUTHORITY",
+    "REQUIRED_PROMOTION_MODE",
+    "RUNTIME_AUTHORITY_IMPACT",
+    "SCHEMA_VERSION",
+    "SELF_LEARNING_NOT_SELF_AUTHORIZING",
+    "STATUS_ADMITTED",
+    "STATUS_REJECTED_AMBIGUOUS_IDENTITY",
+    "STATUS_REJECTED_AUTHORITY_BOUNDARY",
+    "STATUS_REJECTED_HASH_REINTERPRETATION_REQUIRED",
+    "STATUS_REJECTED_INCOMPATIBLE_DIMENSION",
+    "STATUS_REJECTED_INCOMPLETE_IDENTITY",
+    "STATUS_REJECTED_INVALID_PACKAGE_N",
+    "STATUS_REJECTED_MISSING_DIMENSION",
+    "STATUS_REJECTED_UNSUPPORTED_PROJECTION",
+    "evaluate_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1",
+]

--- a/tests/experiments/test_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1.py
+++ b/tests/experiments/test_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1.py
@@ -1,0 +1,325 @@
+"""Canonical Experiment Identity to Package-N I16 promotion admission tests."""
+
+from __future__ import annotations
+
+import ast
+import copy
+import hashlib
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+
+import pytest
+
+from src.experiments.canonical_experiment_identity_to_package_n_i16_promotion_admission_v1 import (
+    ADMISSION_AUTHORITY,
+    BOUNDED_AUTO_ALLOWED,
+    CanonicalIdentityToPackageNI16AdmissionError,
+    CanonicalIdentityToPackageNI16AdmissionRequestV1,
+    PROMOTION_APPLY_ALLOWED,
+    PROMOTION_AUTHORITY,
+    REQUIRED_PROMOTION_MODE,
+    STATUS_ADMITTED,
+    STATUS_REJECTED_AMBIGUOUS_IDENTITY,
+    STATUS_REJECTED_AUTHORITY_BOUNDARY,
+    STATUS_REJECTED_HASH_REINTERPRETATION_REQUIRED,
+    STATUS_REJECTED_INCOMPATIBLE_DIMENSION,
+    STATUS_REJECTED_INCOMPLETE_IDENTITY,
+    STATUS_REJECTED_INVALID_PACKAGE_N,
+    STATUS_REJECTED_UNSUPPORTED_PROJECTION,
+    evaluate_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1,
+)
+from src.experiments.canonical_experiment_identity_v1 import (
+    WORKING_TREE_CLEAN,
+    CanonicalExperimentIdentityRequestV1,
+    build_canonical_experiment_identity_v1,
+)
+from src.experiments.base import ExperimentConfig, ParamSweep
+from src.experiments.experiment_identity_manifest_v1 import (
+    PACKAGE_N_IDENTITY_COMPLETENESS,
+    build_manifest,
+)
+from src.governance.promotion_loop.engine import apply_proposals_to_live_overrides
+from src.governance.promotion_loop.models import (
+    DecisionStatus,
+    PromotionCandidate,
+    PromotionDecision,
+    PromotionProposal,
+)
+from src.governance.promotion_loop.policy import AutoApplyBounds, AutoApplyPolicy
+from src.meta.learning_loop.models import ConfigPatch, PatchStatus
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = (
+    REPO_ROOT
+    / "src"
+    / "experiments"
+    / "canonical_experiment_identity_to_package_n_i16_promotion_admission_v1.py"
+)
+_GIT_SHA = "b506929832db11bf7cd5e8aa1c08156b72d82df1"
+_STRATEGY = "ma_crossover"
+
+
+def _digest(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _phase1(**overrides: Any) -> MappingProxyType:
+    payload: dict[str, Any] = {
+        "git_sha": _GIT_SHA,
+        "working_tree_status": WORKING_TREE_CLEAN,
+        "strategy_identity": _STRATEGY,
+        "strategy_params": {"slow": 50, "fast": 10},
+        "dataset_digest": _digest("dataset"),
+        "feature_pipeline_digest": _digest("features"),
+        "fee_model_digest": _digest("fee"),
+        "slippage_model_digest": _digest("slippage"),
+        "funding_model_digest": _digest("funding"),
+        "risk_policy_digest": _digest("risk"),
+        "portfolio_digest": _digest("portfolio"),
+        "split_policy_digest": _digest("split"),
+        "market_context_contract_digest": _digest("market-context"),
+        "bull_bear_logic_digest": _digest("bull-bear"),
+        "state_switch_logic_digest": _digest("state-switch"),
+        "survival_logic_digest": _digest("survival"),
+        "suitability_logic_digest": _digest("suitability"),
+        "double_play_logic_digest": _digest("double-play"),
+        "entry_position_exit_logic_digest": _digest("entry-position-exit"),
+        "seed": 7,
+        "environment": {
+            "python_version": "3.11.15",
+            "python_implementation": "CPython",
+        },
+        "parent_lineage_ref": None,
+        "dirty_paths_digest": None,
+    }
+    payload.update(overrides)
+    return build_canonical_experiment_identity_v1(CanonicalExperimentIdentityRequestV1(**payload))
+
+
+def _package_n(*, strategy_name: str = _STRATEGY) -> dict[str, Any]:
+    return build_manifest(
+        ExperimentConfig(
+            name="MA Optimization",
+            strategy_name=strategy_name,
+            param_sweeps=[ParamSweep("fast", [5, 10])],
+            symbols=["BTC/EUR"],
+            timeframe="1h",
+        )
+    )
+
+
+def _request(**overrides: Any) -> CanonicalIdentityToPackageNI16AdmissionRequestV1:
+    payload: dict[str, Any] = {
+        "phase1_identity": _phase1(),
+        "package_n_manifest": _package_n(),
+    }
+    payload.update(overrides)
+    return CanonicalIdentityToPackageNI16AdmissionRequestV1(**payload)
+
+
+def test_admitted_keeps_package_n_id_and_attaches_research_parent() -> None:
+    package_n = _package_n()
+    phase1 = _phase1()
+    original_id = package_n["experiment_identity_id"]
+    result = evaluate_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1(
+        _request(phase1_identity=phase1, package_n_manifest=package_n)
+    )
+    assert result["status"] == STATUS_ADMITTED
+    assert result["rejection_reason"] is None
+    assert result["package_n_experiment_identity_id"] == original_id
+    assert result["package_n_experiment_identity_id_mutated"] is False
+    assert result["hash_reinterpreted"] is False
+    assert result["research_evidence_parent_identity_digest"] == phase1["identity_digest"]
+    assert (
+        result["research_evidence_parent_integrity_sha256"] == phase1["integrity"]["content_sha256"]
+    )
+    assert result["i16_assessment_consumable"] is True
+    assert result["package_n_identity_completeness"] == PACKAGE_N_IDENTITY_COMPLETENESS
+    join = result["i16_join"]
+    assert join is not None
+    assert join["experiment_identity_id"] == original_id
+    assert join["evidence_ref"] == phase1["integrity"]["content_sha256"]
+    assert result["authority_invariants"]["promotion_apply_allowed"] is False
+    assert result["authority_invariants"]["promotion_authority"] == PROMOTION_AUTHORITY
+    assert PROMOTION_APPLY_ALLOWED is False
+    assert BOUNDED_AUTO_ALLOWED is False
+    assert ADMISSION_AUTHORITY == "RESEARCH_EVIDENCE_PARENT_ONLY"
+
+
+def test_determinism_same_inputs_same_admission() -> None:
+    first = dict(
+        evaluate_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1(_request())
+    )
+    second = dict(
+        evaluate_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1(_request())
+    )
+    assert first == second
+    assert first["integrity"]["content_sha256"] == second["integrity"]["content_sha256"]
+
+
+def test_package_n_hash_not_mutated_when_inputs_copied() -> None:
+    package_n = _package_n()
+    original = copy.deepcopy(package_n)
+    evaluate_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1(
+        _request(package_n_manifest=package_n)
+    )
+    assert package_n == original
+    assert package_n["experiment_identity_id"] == original["experiment_identity_id"]
+
+
+def test_strategy_mismatch_rejected() -> None:
+    result = evaluate_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1(
+        _request(package_n_manifest=_package_n(strategy_name="macd"))
+    )
+    assert result["status"] == STATUS_REJECTED_INCOMPATIBLE_DIMENSION
+    assert result["i16_assessment_consumable"] is False
+    assert result["i16_join"] is None
+
+
+def test_claimed_complete_projection_rejected() -> None:
+    result = evaluate_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1(
+        _request(claimed_package_n_is_phase1_complete=True)
+    )
+    assert result["status"] == STATUS_REJECTED_UNSUPPORTED_PROJECTION
+    assert result["i16_assessment_consumable"] is False
+
+
+def test_recomputed_package_n_id_rejected_even_if_equal() -> None:
+    package_n = _package_n()
+    result = evaluate_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1(
+        _request(
+            package_n_manifest=package_n,
+            claimed_recomputed_package_n_id=package_n["experiment_identity_id"],
+        )
+    )
+    assert result["status"] == STATUS_REJECTED_HASH_REINTERPRETATION_REQUIRED
+    assert result["i16_assessment_consumable"] is False
+
+
+def test_requested_apply_rejected() -> None:
+    result = evaluate_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1(
+        _request(requested_apply=True)
+    )
+    assert result["status"] == STATUS_REJECTED_AUTHORITY_BOUNDARY
+    assert result["i16_assessment_consumable"] is False
+
+
+def test_bounded_auto_mode_rejected() -> None:
+    result = evaluate_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1(
+        _request(requested_promotion_mode="bounded_auto")
+    )
+    assert result["status"] == STATUS_REJECTED_AUTHORITY_BOUNDARY
+    assert result["requested_promotion_mode"] == "bounded_auto"
+    assert result["required_promotion_mode"] == REQUIRED_PROMOTION_MODE
+
+
+def test_incomplete_phase1_rejected() -> None:
+    phase1 = dict(_phase1())
+    phase1["completeness"] = "INCOMPLETE"
+    result = evaluate_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1(
+        _request(phase1_identity=phase1)
+    )
+    assert result["status"] == STATUS_REJECTED_INCOMPLETE_IDENTITY
+    assert result["i16_assessment_consumable"] is False
+
+
+def test_invalid_package_n_rejected() -> None:
+    result = evaluate_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1(
+        _request(package_n_manifest={"experiment_identity_id": "not-a-hash"})
+    )
+    assert result["status"] == STATUS_REJECTED_INVALID_PACKAGE_N
+    assert result["i16_assessment_consumable"] is False
+
+
+def test_malformed_request_raises() -> None:
+    with pytest.raises(CanonicalIdentityToPackageNI16AdmissionError, match="mapping"):
+        evaluate_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1(
+            CanonicalIdentityToPackageNI16AdmissionRequestV1(
+                phase1_identity="not-a-mapping",  # type: ignore[arg-type]
+                package_n_manifest=_package_n(),
+            )
+        )
+
+
+def test_identity_planes_remain_distinct_on_admit() -> None:
+    phase1 = _phase1()
+    package_n = _package_n()
+    result = evaluate_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1(
+        _request(phase1_identity=phase1, package_n_manifest=package_n)
+    )
+    assert result["status"] == STATUS_ADMITTED
+    assert phase1["identity_digest"] != package_n["experiment_identity_id"]
+    assert phase1["schema_version"] != package_n["schema_version"]
+    assert phase1["identity_domain"] != package_n["identity_domain"]
+
+
+def test_frozen_result_is_immutable() -> None:
+    result = evaluate_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1(
+        _request()
+    )
+    assert isinstance(result, MappingProxyType)
+    with pytest.raises(TypeError):
+        result["status"] = "PROMOTED"  # type: ignore[index]
+
+
+def test_module_does_not_import_apply_or_live_paths() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+    forbidden = {
+        "src.core.peak_config",
+        "src.governance.promotion_loop.engine",
+        "src.execution",
+        "scripts.run_learning_apply_cycle",
+        "src.live",
+        "src.trading",
+    }
+    assert imported.isdisjoint(forbidden)
+    assert "apply_proposals_to_live_overrides" not in source
+    assert "bounded_auto" in source
+    assert BOUNDED_AUTO_ALLOWED is False
+
+
+def test_phase0b_apply_firewall_still_fail_closed(tmp_path: Path) -> None:
+    patch = ConfigPatch(
+        id="patch-leverage-admission-regression",
+        target="portfolio.leverage",
+        old_value=1.0,
+        new_value=1.75,
+        status=PatchStatus.APPLIED_OFFLINE,
+    )
+    candidate = PromotionCandidate(
+        patch=patch,
+        eligible_for_live=True,
+        tags=["leverage"],
+    )
+    decision = PromotionDecision(
+        candidate=candidate,
+        status=DecisionStatus.ACCEPTED_FOR_PROPOSAL,
+        reasons=["admission contract must not reopen apply"],
+    )
+    proposal = PromotionProposal(
+        proposal_id="admission_apply_regression",
+        title="fail-closed apply regression",
+        description="bounded_auto must still not write",
+        decisions=[decision],
+        meta={},
+    )
+    live_path = tmp_path / "auto.toml"
+    policy = AutoApplyPolicy(
+        mode="bounded_auto",
+        leverage_bounds=AutoApplyBounds(min_value=1.0, max_value=2.0, max_step=1.0),
+    )
+    written = apply_proposals_to_live_overrides(
+        [proposal],
+        policy=policy,
+        live_override_path=live_path,
+    )
+    assert written is None
+    assert not live_path.exists()


### PR DESCRIPTION
## Summary
- Adds a fail-closed, non-applying admission contract from Canonical Experiment Identity v1 (COMPLETE) onto an existing Package-N `experiment_identity_id` so `manual_only` I16 assessment may consume the research-evidence parent.
- Package-N hashes are never recomputed or reinterpreted. Strategy identity must match exactly. Apply, `bounded_auto`, Champion swap, and completeness-projection claims fail closed.
- Reuses Phase-1 identity validation, Package-N manifest validation, and the existing I16 remaining-plane join surface. Does not start I82 full migration, G14, Feature-Engine activation, Live, Testnet, Funding, or Canary.

## Test plan
- [x] `uv run python -m pytest tests/experiments/test_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1.py tests/governance/promotion_loop/test_apply_proposals_to_live_overrides_fail_closed_v1.py tests/experiments/test_canonical_experiment_identity_v1.py tests/governance/promotion_loop/test_i16_remaining_planes_join_attachment_v1.py -q` (55 passed)
- [x] Selector `PR_BOUNDED_FULL` (`category_central_src_requires_full`) path-equivalent targets plus owner tests (744 passed, 36.57s)
- [x] `ruff format --check` / `ruff check` on the new Python files
- [x] docs token policy and docs reference targets vs `origin/main`
- [ ] GitHub required checks on this PR

MERGE=false. Requires separate `OWNER_MERGE_GO`.


Made with [Cursor](https://cursor.com)