### PR TITLE
research: bind offline observations to complete experiment identity

### DIFF
--- a/docs/ops/specs/CANONICAL_IDENTITY_BOUND_OFFLINE_OBSERVATION_BINDING_V1.md
+++ b/docs/ops/specs/CANONICAL_IDENTITY_BOUND_OFFLINE_OBSERVATION_BINDING_V1.md
@@ -1,0 +1,143 @@
+# Canonical Identity-Bound Offline Observation Binding v1
+
+Contract for Peak_Trade identity-bound offline observation binding from existing
+backtest/research observation owners. This is not Self-Learning Phase 13.
+
+```text
+SCHEMA_VERSION=canonical_identity_bound_offline_observation_binding_v1
+BINDING_DOMAIN=peak_trade.canonical_identity_bound_offline_observation_binding.v1
+BINDING_PRESENT=true
+BINDING_AUTHORITY=RESEARCH_EVIDENCE_ONLY
+PROMOTION_AUTHORITY=NONE
+PROMOTION_APPLY_ALLOWED=false
+BOUNDED_AUTO_ALLOWED=false
+NEW_RUNNER_ARCHITECTURE=false
+PACKAGE_N_HASH_REINTERPRETATION_FORBIDDEN=true
+SELF_LEARNING_SELF_AUTHORIZING_SEPARATION=true
+SELF_LEARNING_NOT_SELF_AUTHORIZING=true
+```
+
+Owner:
+
+- `src&#47;experiments&#47;canonical_identity_bound_offline_observation_binding_v1.py` — bind only
+
+Reuse, do not replace:
+
+```text
+Phase 1  src.experiments.canonical_experiment_identity_v1              REUSE COMPLETE identity
+Phase 2  src.experiments.canonical_experiment_identity_v1              REUSE identity_digest
+Phase 2  src.experiments.canonical_experiment_memory_v1                REUSE experiment_id and memory
+Phase 2  src.experiments.canonical_experiment_memory_store_v1          REUSE append-only persist
+Phase 10 OfflineExperimentObservationsV1                               REUSE caller-supplied observation shape
+```
+
+```text
+src.experiments.canonical_automated_offline_research_loop_v1           NOT_APPLICABLE as executor
+src.experiments.canonical_experiment_identity_to_package_n_i16_promotion_admission_v1  NOT_APPLICABLE
+src.experiments.experiment_identity_manifest_v1                        NOT_APPLICABLE as COMPLETE identity
+src.experiments.tracking.run_summary                                   NOT_APPLICABLE as COMPLETE identity
+src.experiments.live_session_registry                                  NOT_APPLICABLE as COMPLETE identity
+src.governance.promotion_loop.engine                                   NOT_APPLICABLE as apply&#47;authority
+src.live.live_gates                                                    NOT_APPLICABLE
+```
+
+This layer does not invent identity, does not rewrite Phase-1 digests, does not
+create a second experiment-memory truth, and does not run a research loop. It
+binds observations from the existing Phase-10 caller-supplied observation owner
+onto an already COMPLETE Phase-1 identity and persists through the existing
+Phase-2 immutable memory owner.
+
+## Shape
+
+```text
+PHASE_1_COMPLETE_VALIDATION
+OBSERVATION_OWNER_GUARD
+CLAIMED_IDENTITY_DIGEST_BIND
+CLAIMED_EXPERIMENT_ID_BIND
+LINEAGE_DIGEST_BIND
+IDENTITY_BOUND_OBSERVATION
+PHASE_2_IMMUTABLE_MEMORY_RECORD
+OPTIONAL_APPEND_ONLY_PERSIST
+AUTHORITY_BOUNDARY
+```
+
+```text
+existing OfflineExperimentObservationsV1 owner
+        ↓
+Phase-1 COMPLETE canonical experiment identity required
+        ↓
+identity-bound observation
+        ↓
+Phase-2 immutable experiment memory record
+```
+
+Allowed observation owner:
+
+```text
+OFFLINE_EXPERIMENT_OBSERVATIONS_V1
+```
+
+That token is the Phase-10 caller-supplied observation interface already consumed
+by Phase-2 memory (`metrics`, `robustness_results`, `regime_results`, `artifacts`).
+Unknown owners and historical incomplete surfaces fail closed.
+
+## Fail closed
+
+Any of the following yields a typed `REJECTED_*` result, never `BOUND`:
+
+```text
+missing Phase-1 identity
+non-COMPLETE Phase-1 identity
+identity digest mismatch
+experiment_id mismatch
+lineage &#47; digest mismatch
+observation bound to a non-allowed owner
+divergent duplicate persist (Phase-2 conflict)
+requested apply
+requested bounded_auto
+legacy &#47; Package-N claimed as Phase-1 COMPLETE
+identity or experiment_id reinterpretation required
+```
+
+Identity IDs and digests are never reconstructed or silently replaced. Package N
+remains an incomplete historical projection. Completeness of a bound observation
+does not make Package N or `RunSummary` COMPLETE.
+
+Divergent duplicate persist reuses Phase-2 `ExperimentRecordConflictError`
+semantics: same `experiment_id` plus divergent canonical content is fail-closed.
+Identical canonical replay remains idempotent.
+
+## Authority
+
+```text
+PROMOTION_AUTHORITY=NONE
+PROMOTION_APPLY_ALLOWED=false
+BOUNDED_AUTO_ALLOWED=false
+BOUND != PROMOTED
+BOUND != LIVE
+BOUND != PHASE_10_RUNTIME
+```
+
+`BOUND` means only that a Phase-1 COMPLETE identity and an allowed observation
+owner produced a Phase-2 memory record. It does not write live overrides, arm,
+fund, submit orders, swap a Champion, authorize canary, or grant Phase 10
+runtime authority.
+
+## Non-effects
+
+```text
+LIVE_AUTHORIZED=false
+TESTNET_AUTHORIZED=false
+ORDER_EFFECT=false
+ACCOUNT_MUTATION_EFFECT=false
+MULTI_FUTURE_AUTH_EFFECT=false
+FUNDING_AUTH_EFFECT=false
+PROMOTION_APPLY_EFFECT=false
+BOUNDED_AUTO_EFFECT=false
+RUNTIME_AUTHORITY_EFFECT=false
+NEW_RUNNER_ARCHITECTURE=false
+I82_FULL_MIGRATION=false
+MD5_REMOVAL=false
+IDENTITY_BACKFILL=false
+G14_PRODUCTIVE_AUTHORITY=false
+```

--- a/src/experiments/canonical_identity_bound_offline_observation_binding_v1.py
+++ b/src/experiments/canonical_identity_bound_offline_observation_binding_v1.py
@@ -1,0 +1,519 @@
+"""Identity-bound offline observation binding from existing observation owners.
+
+Binds Phase-10 caller-supplied observations to a Phase-1 COMPLETE identity and
+writes a Phase-2 immutable experiment-memory record. Does not invent identity,
+run a research loop, apply promotions, or grant runtime authority.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Final, Mapping
+
+from src.experiments.canonical_experiment_identity_v1 import (
+    COMPLETENESS_COMPLETE,
+    CanonicalExperimentIdentityError,
+    validate_canonical_experiment_identity_v1,
+)
+from src.experiments.canonical_experiment_memory_store_v1 import CanonicalExperimentMemoryStoreV1
+from src.experiments.canonical_experiment_memory_v1 import (
+    CanonicalExperimentMemoryRecordRequestV1,
+    ExperimentMemoryValidationError,
+    ExperimentRecordConflictError,
+    REF_KIND_IDENTITY_DIGEST_BOUND,
+    build_canonical_experiment_memory_record_v1,
+    derive_experiment_id_v1,
+)
+from src.meta.learning_loop.contract_safety_v1 import compute_content_sha256, is_valid_sha256_hex
+
+SCHEMA_VERSION: Final[str] = "canonical_identity_bound_offline_observation_binding_v1"
+BINDING_DOMAIN: Final[str] = "peak_trade.canonical_identity_bound_offline_observation_binding.v1"
+BINDING_PRESENT: Final[bool] = True
+BINDING_AUTHORITY: Final[str] = "RESEARCH_EVIDENCE_ONLY"
+PROMOTION_AUTHORITY: Final[str] = "NONE"
+PROMOTION_APPLY_ALLOWED: Final[bool] = False
+BOUNDED_AUTO_ALLOWED: Final[bool] = False
+NEW_RUNNER_ARCHITECTURE: Final[bool] = False
+RUNTIME_AUTHORITY_IMPACT: Final[str] = "NONE"
+SELF_LEARNING_NOT_SELF_AUTHORIZING: Final[bool] = True
+
+OBSERVATION_OWNER_OFFLINE_EXPERIMENT_OBSERVATIONS_V1: Final[str] = (
+    "OFFLINE_EXPERIMENT_OBSERVATIONS_V1"
+)
+ALLOWED_OBSERVATION_OWNERS: Final[frozenset[str]] = frozenset(
+    {OBSERVATION_OWNER_OFFLINE_EXPERIMENT_OBSERVATIONS_V1}
+)
+DISPOSITION_RESEARCH_ONLY: Final[str] = "RESEARCH_ONLY"
+COMPARISON_STATUS_NOT_COMPARED: Final[str] = "NOT_COMPARED"
+CANDIDATE_ROLE_RESEARCH: Final[str] = "RESEARCH"
+
+STATUS_BOUND: Final[str] = "BOUND"
+STATUS_REJECTED_MISSING_DIMENSION: Final[str] = "REJECTED_MISSING_DIMENSION"
+STATUS_REJECTED_INCOMPATIBLE_DIMENSION: Final[str] = "REJECTED_INCOMPATIBLE_DIMENSION"
+STATUS_REJECTED_INCOMPLETE_IDENTITY: Final[str] = "REJECTED_INCOMPLETE_IDENTITY"
+STATUS_REJECTED_IDENTITY_MISMATCH: Final[str] = "REJECTED_IDENTITY_MISMATCH"
+STATUS_REJECTED_EXPERIMENT_ID_MISMATCH: Final[str] = "REJECTED_EXPERIMENT_ID_MISMATCH"
+STATUS_REJECTED_LINEAGE_DIGEST_MISMATCH: Final[str] = "REJECTED_LINEAGE_DIGEST_MISMATCH"
+STATUS_REJECTED_WRONG_OBSERVATION_OWNER: Final[str] = "REJECTED_WRONG_OBSERVATION_OWNER"
+STATUS_REJECTED_DIVERGENT_DUPLICATE: Final[str] = "REJECTED_DIVERGENT_DUPLICATE"
+STATUS_REJECTED_UNSUPPORTED_PROJECTION: Final[str] = "REJECTED_UNSUPPORTED_PROJECTION"
+STATUS_REJECTED_HASH_REINTERPRETATION_REQUIRED: Final[str] = (
+    "REJECTED_HASH_REINTERPRETATION_REQUIRED"
+)
+STATUS_REJECTED_AUTHORITY_BOUNDARY: Final[str] = "REJECTED_AUTHORITY_BOUNDARY"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CanonicalIdentityBoundOfflineObservationBindingError(ValueError):
+    """Fail-closed malformed observation-binding request error."""
+
+
+@dataclass(frozen=True)
+class CanonicalIdentityBoundOfflineObservationBindingRequestV1:
+    phase1_identity: Mapping[str, Any] | None
+    observation_owner: str
+    observations: Any
+    claimed_identity_digest: str | None
+    claimed_experiment_id: str | None
+    claimed_parent_lineage_ref: str | None
+    hypothesis_id: str
+    hypothesis_fingerprint: str
+    strategy_family: str
+    created_at: str
+    parent_experiment: str | None = None
+    candidate_role: str = CANDIDATE_ROLE_RESEARCH
+    disposition: str = DISPOSITION_RESEARCH_ONLY
+    rejection_reason: str | None = None
+    claimed_dataset_digest: str | None = None
+    claimed_cost_model_digest: str | None = None
+    claimed_risk_policy_digest: str | None = None
+    claimed_portfolio_digest: str | None = None
+    claimed_legacy_is_phase1_complete: bool = False
+    claimed_recomputed_identity_digest: str | None = None
+    claimed_recomputed_experiment_id: str | None = None
+    requested_apply: bool = False
+    requested_bounded_auto: bool = False
+    experiment_memory_store: CanonicalExperimentMemoryStoreV1 | None = None
+
+
+def _freeze(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({str(key): _freeze(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return [_freeze(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_freeze(item) for item in value)
+    return value
+
+
+def _plain_mapping(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _plain_mapping(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_plain_mapping(item) for item in value]
+    if isinstance(value, tuple):
+        return [_plain_mapping(item) for item in value]
+    return value
+
+
+def _authority_invariants() -> dict[str, Any]:
+    return {
+        "binding_authority": BINDING_AUTHORITY,
+        "bounded_auto_allowed": BOUNDED_AUTO_ALLOWED,
+        "bounded_auto_effect": False,
+        "promotion_apply_allowed": PROMOTION_APPLY_ALLOWED,
+        "promotion_apply_effect": False,
+        "promotion_authority": PROMOTION_AUTHORITY,
+        "runtime_authority_impact": RUNTIME_AUTHORITY_IMPACT,
+        "runtime_authority_effect": False,
+        "new_runner_architecture": NEW_RUNNER_ARCHITECTURE,
+        "self_learning_not_self_authorizing": SELF_LEARNING_NOT_SELF_AUTHORIZING,
+        "live_authorized": False,
+        "testnet_authorized": False,
+        "order_effect": False,
+        "account_mutation_effect": False,
+        "multi_future_auth_effect": False,
+        "funding_auth_effect": False,
+        "i82_full_migration": False,
+        "md5_removal": False,
+        "identity_backfill": False,
+    }
+
+
+def _build_result(
+    *,
+    status: str,
+    rejection_reason: str | None,
+    observation_owner: str,
+    identity_digest: str | None,
+    experiment_id: str | None,
+    parent_lineage_ref: str | None,
+    identity_bound_observation: Mapping[str, Any] | None,
+    experiment_record: Mapping[str, Any] | None,
+    persisted_experiment_id: str | None,
+) -> Mapping[str, Any]:
+    bound = status == STATUS_BOUND
+    body = {
+        "schema_version": SCHEMA_VERSION,
+        "binding_domain": BINDING_DOMAIN,
+        "binding_present": BINDING_PRESENT,
+        "status": status,
+        "rejection_reason": rejection_reason,
+        "observation_owner": observation_owner,
+        "allowed_observation_owners": sorted(ALLOWED_OBSERVATION_OWNERS),
+        "identity_digest": identity_digest,
+        "experiment_id": experiment_id,
+        "parent_lineage_ref": parent_lineage_ref,
+        "identity_bound_observation": (
+            None if identity_bound_observation is None else dict(identity_bound_observation)
+        ),
+        "experiment_record": (
+            None if experiment_record is None else _plain_mapping(experiment_record)
+        ),
+        "persist": {"experiment_record_id": persisted_experiment_id},
+        "identity_reinterpreted": False,
+        "experiment_id_reinterpreted": False,
+        "package_n_experiment_identity_id_mutated": False,
+        "hash_reinterpreted": False,
+        "phase10_runtime_authority": False,
+        "authority_invariants": _authority_invariants(),
+        "bound": bound,
+    }
+    body["integrity"] = {
+        "content_sha256": compute_content_sha256(
+            {key: value for key, value in body.items() if key != "integrity"}
+        )
+    }
+    return MappingProxyType(_freeze(body))
+
+
+def _rejected(
+    status: str,
+    reason: str,
+    *,
+    observation_owner: str = "",
+    identity_digest: str | None = None,
+    experiment_id: str | None = None,
+    parent_lineage_ref: str | None = None,
+) -> Mapping[str, Any]:
+    return _build_result(
+        status=status,
+        rejection_reason=reason,
+        observation_owner=observation_owner,
+        identity_digest=identity_digest,
+        experiment_id=experiment_id,
+        parent_lineage_ref=parent_lineage_ref,
+        identity_bound_observation=None,
+        experiment_record=None,
+        persisted_experiment_id=None,
+    )
+
+
+def _parent_lineage_ref(identity: Mapping[str, Any]) -> str | None:
+    parent_lineage = identity.get("parent_lineage")
+    if not isinstance(parent_lineage, Mapping):
+        return None
+    value = parent_lineage.get("parent_lineage_ref")
+    return value if isinstance(value, str) else None
+
+
+def _observation_mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        payload = _plain_mapping(value)
+    else:
+        required = ("metrics", "robustness_results", "regime_results", "artifacts")
+        if not all(hasattr(value, field) for field in required):
+            raise CanonicalIdentityBoundOfflineObservationBindingError(
+                "observations must be OfflineExperimentObservationsV1 or a mapping"
+            )
+        payload = {
+            "metrics": getattr(value, "metrics"),
+            "robustness_results": getattr(value, "robustness_results"),
+            "regime_results": getattr(value, "regime_results"),
+            "artifacts": getattr(value, "artifacts"),
+        }
+    for field_name in ("metrics", "robustness_results", "regime_results"):
+        if not isinstance(payload.get(field_name), Mapping):
+            raise CanonicalIdentityBoundOfflineObservationBindingError(
+                f"observations.{field_name} must be a mapping"
+            )
+    artifacts = payload.get("artifacts")
+    if not isinstance(artifacts, (list, tuple)):
+        raise CanonicalIdentityBoundOfflineObservationBindingError(
+            "observations.artifacts must be a sequence"
+        )
+    return {
+        "metrics": dict(payload["metrics"]),
+        "robustness_results": dict(payload["robustness_results"]),
+        "regime_results": dict(payload["regime_results"]),
+        "artifacts": list(artifacts),
+    }
+
+
+def _bound_ref(digest: str) -> dict[str, str]:
+    return {"digest": digest, "kind": REF_KIND_IDENTITY_DIGEST_BOUND}
+
+
+def _optional_sha256_claim(field_name: str, value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not is_valid_sha256_hex(value):
+        raise CanonicalIdentityBoundOfflineObservationBindingError(
+            f"{field_name} must be a sha256 hex digest"
+        )
+    return value
+
+
+def bind_canonical_identity_bound_offline_observation_v1(
+    request: CanonicalIdentityBoundOfflineObservationBindingRequestV1,
+) -> Mapping[str, Any]:
+    """Bind allowed observations to Phase-1 COMPLETE identity and Phase-2 memory."""
+    owner = request.observation_owner
+    if request.requested_apply is True:
+        return _rejected(
+            STATUS_REJECTED_AUTHORITY_BOUNDARY,
+            "requested_apply is forbidden; binding is not promotion apply",
+            observation_owner=owner,
+        )
+    if request.requested_bounded_auto is True:
+        return _rejected(
+            STATUS_REJECTED_AUTHORITY_BOUNDARY,
+            "requested_bounded_auto is forbidden; binding has no bounded_auto capability",
+            observation_owner=owner,
+        )
+    if request.claimed_legacy_is_phase1_complete is True:
+        return _rejected(
+            STATUS_REJECTED_UNSUPPORTED_PROJECTION,
+            "legacy or Package-N records cannot be claimed as Phase-1 COMPLETE",
+            observation_owner=owner,
+        )
+    if request.claimed_recomputed_identity_digest is not None:
+        return _rejected(
+            STATUS_REJECTED_HASH_REINTERPRETATION_REQUIRED,
+            "Phase-1 identity_digest must not be recomputed or reinterpreted",
+            observation_owner=owner,
+        )
+    if request.claimed_recomputed_experiment_id is not None:
+        return _rejected(
+            STATUS_REJECTED_HASH_REINTERPRETATION_REQUIRED,
+            "Phase-2 experiment_id must not be recomputed or reinterpreted",
+            observation_owner=owner,
+        )
+    if owner not in ALLOWED_OBSERVATION_OWNERS:
+        return _rejected(
+            STATUS_REJECTED_WRONG_OBSERVATION_OWNER,
+            "observation_owner is not the existing Phase-10 observation owner",
+            observation_owner=owner,
+        )
+    if request.phase1_identity is None:
+        return _rejected(
+            STATUS_REJECTED_MISSING_DIMENSION,
+            "phase1_identity is required",
+            observation_owner=owner,
+        )
+    if not isinstance(request.phase1_identity, Mapping):
+        raise CanonicalIdentityBoundOfflineObservationBindingError(
+            "phase1_identity must be a mapping"
+        )
+
+    phase1_plain = _plain_mapping(request.phase1_identity)
+    try:
+        validate_canonical_experiment_identity_v1(phase1_plain)
+    except CanonicalExperimentIdentityError as exc:
+        status = STATUS_REJECTED_INCOMPLETE_IDENTITY
+        if phase1_plain.get("completeness") == COMPLETENESS_COMPLETE and "must" in str(exc).lower():
+            status = STATUS_REJECTED_MISSING_DIMENSION
+        if phase1_plain.get("completeness") != COMPLETENESS_COMPLETE:
+            status = STATUS_REJECTED_INCOMPLETE_IDENTITY
+        return _rejected(status, str(exc), observation_owner=owner)
+
+    identity_digest = phase1_plain.get("identity_digest")
+    if not isinstance(identity_digest, str) or not is_valid_sha256_hex(identity_digest):
+        return _rejected(
+            STATUS_REJECTED_MISSING_DIMENSION,
+            "phase1 identity_digest missing",
+            observation_owner=owner,
+        )
+    experiment_id = derive_experiment_id_v1(identity_digest)
+    parent_lineage_ref = _parent_lineage_ref(phase1_plain)
+
+    if request.claimed_identity_digest is None:
+        return _rejected(
+            STATUS_REJECTED_MISSING_DIMENSION,
+            "claimed_identity_digest is required",
+            observation_owner=owner,
+            identity_digest=identity_digest,
+            experiment_id=experiment_id,
+            parent_lineage_ref=parent_lineage_ref,
+        )
+    if request.claimed_identity_digest != identity_digest:
+        return _rejected(
+            STATUS_REJECTED_IDENTITY_MISMATCH,
+            "claimed_identity_digest does not match Phase-1 identity_digest",
+            observation_owner=owner,
+            identity_digest=identity_digest,
+            experiment_id=experiment_id,
+            parent_lineage_ref=parent_lineage_ref,
+        )
+    if request.claimed_experiment_id is None:
+        return _rejected(
+            STATUS_REJECTED_MISSING_DIMENSION,
+            "claimed_experiment_id is required",
+            observation_owner=owner,
+            identity_digest=identity_digest,
+            experiment_id=experiment_id,
+            parent_lineage_ref=parent_lineage_ref,
+        )
+    if request.claimed_experiment_id != experiment_id:
+        return _rejected(
+            STATUS_REJECTED_EXPERIMENT_ID_MISMATCH,
+            "claimed_experiment_id is not bound to the Phase-1 identity digest",
+            observation_owner=owner,
+            identity_digest=identity_digest,
+            experiment_id=experiment_id,
+            parent_lineage_ref=parent_lineage_ref,
+        )
+    if request.claimed_parent_lineage_ref != parent_lineage_ref:
+        return _rejected(
+            STATUS_REJECTED_LINEAGE_DIGEST_MISMATCH,
+            "claimed_parent_lineage_ref does not match Phase-1 parent_lineage_ref",
+            observation_owner=owner,
+            identity_digest=identity_digest,
+            experiment_id=experiment_id,
+            parent_lineage_ref=parent_lineage_ref,
+        )
+
+    digest_claims = (
+        ("claimed_dataset_digest", "dataset_digest"),
+        ("claimed_cost_model_digest", "cost_model_digest"),
+        ("claimed_risk_policy_digest", "risk_policy_digest"),
+        ("claimed_portfolio_digest", "portfolio_digest"),
+    )
+    for claim_field, identity_field in digest_claims:
+        claimed = _optional_sha256_claim(claim_field, getattr(request, claim_field))
+        if claimed is None:
+            continue
+        expected = phase1_plain.get(identity_field)
+        if claimed != expected:
+            return _rejected(
+                STATUS_REJECTED_LINEAGE_DIGEST_MISMATCH,
+                f"{claim_field} does not match Phase-1 {identity_field}",
+                observation_owner=owner,
+                identity_digest=identity_digest,
+                experiment_id=experiment_id,
+                parent_lineage_ref=parent_lineage_ref,
+            )
+
+    observations = _observation_mapping(request.observations)
+    identity_bound_observation = {
+        "artifacts": observations["artifacts"],
+        "experiment_id": experiment_id,
+        "identity_digest": identity_digest,
+        "metrics": observations["metrics"],
+        "observation_owner": owner,
+        "parent_lineage_ref": parent_lineage_ref,
+        "regime_results": observations["regime_results"],
+        "robustness_results": observations["robustness_results"],
+    }
+    try:
+        experiment_record = build_canonical_experiment_memory_record_v1(
+            CanonicalExperimentMemoryRecordRequestV1(
+                experiment_identity=phase1_plain,
+                hypothesis_id=request.hypothesis_id,
+                hypothesis_fingerprint=request.hypothesis_fingerprint,
+                parent_experiment=request.parent_experiment,
+                strategy_family=request.strategy_family,
+                candidate_role=request.candidate_role,
+                dataset_ref=_bound_ref(str(phase1_plain["dataset_digest"])),
+                cost_model_ref=_bound_ref(str(phase1_plain["cost_model_digest"])),
+                risk_policy_ref=_bound_ref(str(phase1_plain["risk_policy_digest"])),
+                portfolio_ref=_bound_ref(str(phase1_plain["portfolio_digest"])),
+                metrics=observations["metrics"],
+                robustness_results=observations["robustness_results"],
+                regime_results=observations["regime_results"],
+                comparison_status=COMPARISON_STATUS_NOT_COMPARED,
+                disposition=request.disposition,
+                rejection_reason=request.rejection_reason,
+                created_at=request.created_at,
+                artifacts=observations["artifacts"],
+                experiment_id=experiment_id,
+            )
+        )
+    except ExperimentMemoryValidationError as exc:
+        return _rejected(
+            STATUS_REJECTED_INCOMPATIBLE_DIMENSION,
+            str(exc),
+            observation_owner=owner,
+            identity_digest=identity_digest,
+            experiment_id=experiment_id,
+            parent_lineage_ref=parent_lineage_ref,
+        )
+
+    persisted_id: str | None = None
+    if request.experiment_memory_store is not None:
+        try:
+            stored = request.experiment_memory_store.append(experiment_record)
+        except ExperimentRecordConflictError as exc:
+            return _rejected(
+                STATUS_REJECTED_DIVERGENT_DUPLICATE,
+                str(exc),
+                observation_owner=owner,
+                identity_digest=identity_digest,
+                experiment_id=experiment_id,
+                parent_lineage_ref=parent_lineage_ref,
+            )
+        persisted_id = str(stored["experiment_id"])
+
+    result = _build_result(
+        status=STATUS_BOUND,
+        rejection_reason=None,
+        observation_owner=owner,
+        identity_digest=identity_digest,
+        experiment_id=experiment_id,
+        parent_lineage_ref=parent_lineage_ref,
+        identity_bound_observation=identity_bound_observation,
+        experiment_record=experiment_record,
+        persisted_experiment_id=persisted_id,
+    )
+    _LOGGER.info(
+        "identity_bound_offline_observation status=%s experiment_id=%s owner=%s apply=%s",
+        STATUS_BOUND,
+        experiment_id,
+        owner,
+        PROMOTION_APPLY_ALLOWED,
+    )
+    return result
+
+
+__all__ = [
+    "ALLOWED_OBSERVATION_OWNERS",
+    "BINDING_AUTHORITY",
+    "BINDING_DOMAIN",
+    "BINDING_PRESENT",
+    "BOUNDED_AUTO_ALLOWED",
+    "CanonicalIdentityBoundOfflineObservationBindingError",
+    "CanonicalIdentityBoundOfflineObservationBindingRequestV1",
+    "NEW_RUNNER_ARCHITECTURE",
+    "OBSERVATION_OWNER_OFFLINE_EXPERIMENT_OBSERVATIONS_V1",
+    "PROMOTION_APPLY_ALLOWED",
+    "PROMOTION_AUTHORITY",
+    "RUNTIME_AUTHORITY_IMPACT",
+    "SCHEMA_VERSION",
+    "SELF_LEARNING_NOT_SELF_AUTHORIZING",
+    "STATUS_BOUND",
+    "STATUS_REJECTED_AUTHORITY_BOUNDARY",
+    "STATUS_REJECTED_DIVERGENT_DUPLICATE",
+    "STATUS_REJECTED_EXPERIMENT_ID_MISMATCH",
+    "STATUS_REJECTED_HASH_REINTERPRETATION_REQUIRED",
+    "STATUS_REJECTED_IDENTITY_MISMATCH",
+    "STATUS_REJECTED_INCOMPATIBLE_DIMENSION",
+    "STATUS_REJECTED_INCOMPLETE_IDENTITY",
+    "STATUS_REJECTED_LINEAGE_DIGEST_MISMATCH",
+    "STATUS_REJECTED_MISSING_DIMENSION",
+    "STATUS_REJECTED_UNSUPPORTED_PROJECTION",
+    "STATUS_REJECTED_WRONG_OBSERVATION_OWNER",
+    "bind_canonical_identity_bound_offline_observation_v1",
+]

--- a/tests/experiments/test_canonical_identity_bound_offline_observation_binding_v1.py
+++ b/tests/experiments/test_canonical_identity_bound_offline_observation_binding_v1.py
@@ -1,0 +1,442 @@
+"""Identity-bound offline observation binding contract tests."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+
+import pytest
+
+from src.experiments.canonical_automated_offline_research_loop_v1 import (
+    OfflineExperimentObservationsV1,
+    RESEARCH_LOOP_HAS_RUNTIME_AUTHORITY,
+)
+from src.experiments.canonical_experiment_identity_to_package_n_i16_promotion_admission_v1 import (
+    STATUS_ADMITTED,
+    CanonicalIdentityToPackageNI16AdmissionRequestV1,
+    evaluate_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1,
+)
+from src.experiments.canonical_experiment_identity_v1 import (
+    WORKING_TREE_CLEAN,
+    CanonicalExperimentIdentityRequestV1,
+    build_canonical_experiment_identity_v1,
+    validate_canonical_experiment_identity_v1,
+)
+from src.experiments.canonical_experiment_memory_store_v1 import CanonicalExperimentMemoryStoreV1
+from src.experiments.canonical_experiment_memory_v1 import (
+    EXPERIMENT_MEMORY_HAS_RUNTIME_AUTHORITY,
+    derive_experiment_id_v1,
+    validate_canonical_experiment_memory_record_v1,
+)
+from src.experiments.canonical_identity_bound_offline_observation_binding_v1 import (
+    BOUNDED_AUTO_ALLOWED,
+    CanonicalIdentityBoundOfflineObservationBindingError,
+    CanonicalIdentityBoundOfflineObservationBindingRequestV1,
+    NEW_RUNNER_ARCHITECTURE,
+    OBSERVATION_OWNER_OFFLINE_EXPERIMENT_OBSERVATIONS_V1,
+    PROMOTION_APPLY_ALLOWED,
+    PROMOTION_AUTHORITY,
+    STATUS_BOUND,
+    STATUS_REJECTED_AUTHORITY_BOUNDARY,
+    STATUS_REJECTED_DIVERGENT_DUPLICATE,
+    STATUS_REJECTED_EXPERIMENT_ID_MISMATCH,
+    STATUS_REJECTED_HASH_REINTERPRETATION_REQUIRED,
+    STATUS_REJECTED_IDENTITY_MISMATCH,
+    STATUS_REJECTED_INCOMPLETE_IDENTITY,
+    STATUS_REJECTED_LINEAGE_DIGEST_MISMATCH,
+    STATUS_REJECTED_MISSING_DIMENSION,
+    STATUS_REJECTED_UNSUPPORTED_PROJECTION,
+    STATUS_REJECTED_WRONG_OBSERVATION_OWNER,
+    bind_canonical_identity_bound_offline_observation_v1,
+)
+from src.experiments.base import ExperimentConfig, ParamSweep
+from src.experiments.experiment_identity_manifest_v1 import build_manifest
+from src.governance.promotion_loop.engine import apply_proposals_to_live_overrides
+from src.governance.promotion_loop.models import (
+    DecisionStatus,
+    PromotionCandidate,
+    PromotionDecision,
+    PromotionProposal,
+)
+from src.governance.promotion_loop.policy import AutoApplyBounds, AutoApplyPolicy
+from src.meta.learning_loop.models import ConfigPatch, PatchStatus
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = (
+    REPO_ROOT / "src" / "experiments" / "canonical_identity_bound_offline_observation_binding_v1.py"
+)
+_GIT_SHA = "57c8c7d83aff0892ffedea54257321e841389c2a"
+_STRATEGY = "ma_crossover.v1"
+_CREATED_AT = "2026-08-18T17:00:00Z"
+
+
+def _digest(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _phase1(**overrides: Any) -> MappingProxyType:
+    payload: dict[str, Any] = {
+        "git_sha": _GIT_SHA,
+        "working_tree_status": WORKING_TREE_CLEAN,
+        "strategy_identity": _STRATEGY,
+        "strategy_params": {"slow": 50, "fast": 10},
+        "dataset_digest": _digest("dataset"),
+        "feature_pipeline_digest": _digest("features"),
+        "fee_model_digest": _digest("fee"),
+        "slippage_model_digest": _digest("slippage"),
+        "funding_model_digest": _digest("funding"),
+        "risk_policy_digest": _digest("risk"),
+        "portfolio_digest": _digest("portfolio"),
+        "split_policy_digest": _digest("split"),
+        "market_context_contract_digest": _digest("market-context"),
+        "bull_bear_logic_digest": _digest("bull-bear"),
+        "state_switch_logic_digest": _digest("state-switch"),
+        "survival_logic_digest": _digest("survival"),
+        "suitability_logic_digest": _digest("suitability"),
+        "double_play_logic_digest": _digest("double-play"),
+        "entry_position_exit_logic_digest": _digest("entry-position-exit"),
+        "seed": 7,
+        "environment": {
+            "python_version": "3.11.15",
+            "python_implementation": "CPython",
+        },
+        "parent_lineage_ref": None,
+        "dirty_paths_digest": None,
+    }
+    payload.update(overrides)
+    return build_canonical_experiment_identity_v1(CanonicalExperimentIdentityRequestV1(**payload))
+
+
+def _observations(**overrides: Any) -> OfflineExperimentObservationsV1:
+    payload: dict[str, Any] = {
+        "metrics": {"sharpe": 1.25, "max_drawdown": -0.12},
+        "robustness_results": {"walk_forward": {"passed": True, "folds": 4}},
+        "regime_results": {"high_vol": {"sharpe": 0.4}},
+        "artifacts": [
+            {
+                "kind": "REPO_RELATIVE",
+                "ref": "docs/ops/specs/CANONICAL_EXPERIMENT_IDENTITY_V1.md",
+                "digest": _digest("artifact"),
+                "media_type": "text/markdown",
+            }
+        ],
+        "robustness_observations": {"sample_size": 32},
+    }
+    payload.update(overrides)
+    return OfflineExperimentObservationsV1(**payload)
+
+
+def _request(**overrides: Any) -> CanonicalIdentityBoundOfflineObservationBindingRequestV1:
+    identity = overrides.pop("phase1_identity", _phase1())
+    experiment_id = (
+        derive_experiment_id_v1(str(identity["identity_digest"]))
+        if isinstance(identity, dict) or hasattr(identity, "__getitem__")
+        else None
+    )
+    payload: dict[str, Any] = {
+        "phase1_identity": identity,
+        "observation_owner": OBSERVATION_OWNER_OFFLINE_EXPERIMENT_OBSERVATIONS_V1,
+        "observations": _observations(),
+        "claimed_identity_digest": (None if identity is None else str(identity["identity_digest"])),
+        "claimed_experiment_id": experiment_id,
+        "claimed_parent_lineage_ref": (
+            None
+            if identity is None
+            else identity.get("parent_lineage", {}).get("parent_lineage_ref")
+        ),
+        "hypothesis_id": "hyp.ma-crossover.v1",
+        "hypothesis_fingerprint": _digest("hypothesis"),
+        "strategy_family": "ma_crossover",
+        "created_at": _CREATED_AT,
+    }
+    payload.update(overrides)
+    return CanonicalIdentityBoundOfflineObservationBindingRequestV1(**payload)
+
+
+def test_happy_path_binds_complete_identity_to_phase2_memory() -> None:
+    identity = _phase1()
+    result = bind_canonical_identity_bound_offline_observation_v1(
+        _request(phase1_identity=identity)
+    )
+    assert result["status"] == STATUS_BOUND
+    assert result["bound"] is True
+    assert result["rejection_reason"] is None
+    assert result["observation_owner"] == OBSERVATION_OWNER_OFFLINE_EXPERIMENT_OBSERVATIONS_V1
+    assert result["identity_digest"] == identity["identity_digest"]
+    assert result["experiment_id"] == derive_experiment_id_v1(str(identity["identity_digest"]))
+    observation = result["identity_bound_observation"]
+    assert observation is not None
+    assert observation["identity_digest"] == identity["identity_digest"]
+    assert observation["experiment_id"] == result["experiment_id"]
+    record = result["experiment_record"]
+    assert record is not None
+    validate_canonical_experiment_memory_record_v1(record)
+    assert record["experiment_identity"]["identity_digest"] == identity["identity_digest"]
+    assert result["authority_invariants"]["promotion_apply_allowed"] is False
+    assert result["authority_invariants"]["bounded_auto_allowed"] is False
+    assert result["authority_invariants"]["runtime_authority_effect"] is False
+    assert result["phase10_runtime_authority"] is False
+    assert NEW_RUNNER_ARCHITECTURE is False
+    assert PROMOTION_APPLY_ALLOWED is False
+    assert BOUNDED_AUTO_ALLOWED is False
+    assert PROMOTION_AUTHORITY == "NONE"
+
+
+def test_incomplete_identity_rejected() -> None:
+    phase1 = dict(_phase1())
+    phase1["completeness"] = "INCOMPLETE"
+    result = bind_canonical_identity_bound_offline_observation_v1(_request(phase1_identity=phase1))
+    assert result["status"] == STATUS_REJECTED_INCOMPLETE_IDENTITY
+    assert result["bound"] is False
+    assert result["experiment_record"] is None
+
+
+def test_missing_identity_rejected() -> None:
+    result = bind_canonical_identity_bound_offline_observation_v1(
+        _request(
+            phase1_identity=None,
+            claimed_identity_digest=_digest("missing"),
+            claimed_experiment_id=_digest("missing-id"),
+        )
+    )
+    assert result["status"] == STATUS_REJECTED_MISSING_DIMENSION
+    assert result["bound"] is False
+
+
+def test_identity_mismatch_rejected() -> None:
+    result = bind_canonical_identity_bound_offline_observation_v1(
+        _request(claimed_identity_digest=_digest("other-identity"))
+    )
+    assert result["status"] == STATUS_REJECTED_IDENTITY_MISMATCH
+    assert result["bound"] is False
+
+
+def test_experiment_id_mismatch_rejected() -> None:
+    result = bind_canonical_identity_bound_offline_observation_v1(
+        _request(claimed_experiment_id=_digest("unrelated-experiment"))
+    )
+    assert result["status"] == STATUS_REJECTED_EXPERIMENT_ID_MISMATCH
+    assert result["bound"] is False
+
+
+def test_lineage_mismatch_rejected() -> None:
+    result = bind_canonical_identity_bound_offline_observation_v1(
+        _request(claimed_parent_lineage_ref="parent.other")
+    )
+    assert result["status"] == STATUS_REJECTED_LINEAGE_DIGEST_MISMATCH
+    assert result["bound"] is False
+
+
+def test_digest_mismatch_rejected() -> None:
+    result = bind_canonical_identity_bound_offline_observation_v1(
+        _request(claimed_dataset_digest=_digest("other-dataset"))
+    )
+    assert result["status"] == STATUS_REJECTED_LINEAGE_DIGEST_MISMATCH
+    assert result["bound"] is False
+
+
+def test_observation_bound_to_wrong_owner_rejected() -> None:
+    for owner in (
+        "RUN_SUMMARY",
+        "PACKAGE_N_EXPERIMENT_IDENTITY_MANIFEST",
+        "LIVE_SESSION_REGISTRY",
+        "ECONOMIC_VIABILITY_EVIDENCE_V1",
+    ):
+        result = bind_canonical_identity_bound_offline_observation_v1(
+            _request(observation_owner=owner)
+        )
+        assert result["status"] == STATUS_REJECTED_WRONG_OBSERVATION_OWNER
+        assert result["bound"] is False
+        assert result["experiment_record"] is None
+
+
+def test_divergent_duplicate_remains_fail_closed(tmp_path: Path) -> None:
+    store = CanonicalExperimentMemoryStoreV1(tmp_path / "memory")
+    identity = _phase1()
+    first = bind_canonical_identity_bound_offline_observation_v1(
+        _request(phase1_identity=identity, experiment_memory_store=store)
+    )
+    assert first["status"] == STATUS_BOUND
+    identical = bind_canonical_identity_bound_offline_observation_v1(
+        _request(phase1_identity=identity, experiment_memory_store=store)
+    )
+    assert identical["status"] == STATUS_BOUND
+    assert identical["persist"]["experiment_record_id"] == first["experiment_id"]
+    divergent = bind_canonical_identity_bound_offline_observation_v1(
+        _request(
+            phase1_identity=identity,
+            observations=_observations(metrics={"sharpe": 0.1, "max_drawdown": -0.5}),
+            experiment_memory_store=store,
+        )
+    )
+    assert divergent["status"] == STATUS_REJECTED_DIVERGENT_DUPLICATE
+    assert divergent["bound"] is False
+    stored = store.get(str(first["experiment_id"]))
+    assert stored["metrics"]["sharpe"] == 1.25
+
+
+def test_determinism_same_inputs_same_binding() -> None:
+    first = dict(bind_canonical_identity_bound_offline_observation_v1(_request()))
+    second = dict(bind_canonical_identity_bound_offline_observation_v1(_request()))
+    assert first == second
+    assert first["integrity"]["content_sha256"] == second["integrity"]["content_sha256"]
+
+
+def test_no_apply_or_bounded_auto_capability() -> None:
+    apply_result = bind_canonical_identity_bound_offline_observation_v1(
+        _request(requested_apply=True)
+    )
+    assert apply_result["status"] == STATUS_REJECTED_AUTHORITY_BOUNDARY
+    auto_result = bind_canonical_identity_bound_offline_observation_v1(
+        _request(requested_bounded_auto=True)
+    )
+    assert auto_result["status"] == STATUS_REJECTED_AUTHORITY_BOUNDARY
+    assert PROMOTION_APPLY_ALLOWED is False
+    assert BOUNDED_AUTO_ALLOWED is False
+
+
+def test_legacy_complete_claim_and_hash_reinterpretation_rejected() -> None:
+    legacy = bind_canonical_identity_bound_offline_observation_v1(
+        _request(claimed_legacy_is_phase1_complete=True)
+    )
+    assert legacy["status"] == STATUS_REJECTED_UNSUPPORTED_PROJECTION
+    identity = _phase1()
+    reinterpreted = bind_canonical_identity_bound_offline_observation_v1(
+        _request(
+            phase1_identity=identity,
+            claimed_recomputed_identity_digest=str(identity["identity_digest"]),
+        )
+    )
+    assert reinterpreted["status"] == STATUS_REJECTED_HASH_REINTERPRETATION_REQUIRED
+    experiment_id = derive_experiment_id_v1(str(identity["identity_digest"]))
+    recomputed_id = bind_canonical_identity_bound_offline_observation_v1(
+        _request(
+            phase1_identity=identity,
+            claimed_recomputed_experiment_id=experiment_id,
+        )
+    )
+    assert recomputed_id["status"] == STATUS_REJECTED_HASH_REINTERPRETATION_REQUIRED
+
+
+def test_identity_not_mutated_when_inputs_copied() -> None:
+    identity = _phase1()
+    digest = identity["identity_digest"]
+    integrity = identity["integrity"]["content_sha256"]
+    bind_canonical_identity_bound_offline_observation_v1(_request(phase1_identity=identity))
+    assert identity["identity_digest"] == digest
+    assert identity["integrity"]["content_sha256"] == integrity
+
+
+def test_malformed_observations_raise() -> None:
+    with pytest.raises(CanonicalIdentityBoundOfflineObservationBindingError, match="observations"):
+        bind_canonical_identity_bound_offline_observation_v1(
+            _request(observations="not-observations")
+        )
+
+
+def test_frozen_result_is_immutable() -> None:
+    result = bind_canonical_identity_bound_offline_observation_v1(_request())
+    assert isinstance(result, MappingProxyType)
+    with pytest.raises(TypeError):
+        result["status"] = "PROMOTED"  # type: ignore[index]
+
+
+def test_no_runtime_authority_and_existing_contracts_remain_compatible() -> None:
+    identity = _phase1()
+    validate_canonical_experiment_identity_v1(identity)
+    result = bind_canonical_identity_bound_offline_observation_v1(
+        _request(phase1_identity=identity)
+    )
+    assert result["status"] == STATUS_BOUND
+    validate_canonical_experiment_memory_record_v1(result["experiment_record"])
+    assert RESEARCH_LOOP_HAS_RUNTIME_AUTHORITY is False
+    assert EXPERIMENT_MEMORY_HAS_RUNTIME_AUTHORITY is False
+    package_n = build_manifest(
+        ExperimentConfig(
+            name="MA Optimization",
+            strategy_name="ma_crossover.v1",
+            param_sweeps=[ParamSweep("fast", [5, 10])],
+            symbols=["BTC/EUR"],
+            timeframe="1h",
+        )
+    )
+    admission = evaluate_canonical_experiment_identity_to_package_n_i16_promotion_admission_v1(
+        CanonicalIdentityToPackageNI16AdmissionRequestV1(
+            phase1_identity=identity,
+            package_n_manifest=package_n,
+        )
+    )
+    assert admission["status"] == STATUS_ADMITTED
+    assert admission["package_n_experiment_identity_id"] == package_n["experiment_identity_id"]
+    assert result["experiment_id"] != package_n["experiment_identity_id"]
+    assert result["identity_reinterpreted"] is False
+    assert result["package_n_experiment_identity_id_mutated"] is False
+
+
+def test_module_does_not_import_apply_or_live_paths() -> None:
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.add(node.module)
+    forbidden = {
+        "src.core.peak_config",
+        "src.governance.promotion_loop.engine",
+        "src.execution",
+        "scripts.run_learning_apply_cycle",
+        "src.live",
+        "src.trading",
+        "src.experiments.canonical_automated_offline_research_loop_v1",
+        "src.experiments.experiment_identity_manifest_v1",
+        "src.experiments.canonical_experiment_identity_to_package_n_i16_promotion_admission_v1",
+    }
+    assert imported.isdisjoint(forbidden)
+    assert "apply_proposals_to_live_overrides" not in source
+    assert "run_canonical_automated_offline_research_loop_v1" not in source
+    assert BOUNDED_AUTO_ALLOWED is False
+    assert NEW_RUNNER_ARCHITECTURE is False
+
+
+def test_phase0b_apply_firewall_still_fail_closed(tmp_path: Path) -> None:
+    patch = ConfigPatch(
+        id="patch-leverage-observation-binding-regression",
+        target="portfolio.leverage",
+        old_value=1.0,
+        new_value=1.75,
+        status=PatchStatus.APPLIED_OFFLINE,
+    )
+    candidate = PromotionCandidate(
+        patch=patch,
+        eligible_for_live=True,
+        tags=["leverage"],
+    )
+    decision = PromotionDecision(
+        candidate=candidate,
+        status=DecisionStatus.ACCEPTED_FOR_PROPOSAL,
+        reasons=["observation binding must not reopen apply"],
+    )
+    proposal = PromotionProposal(
+        proposal_id="observation_binding_apply_regression",
+        title="fail-closed apply regression",
+        description="bounded_auto must still not write",
+        decisions=[decision],
+        meta={},
+    )
+    live_path = tmp_path / "auto.toml"
+    policy = AutoApplyPolicy(
+        mode="bounded_auto",
+        leverage_bounds=AutoApplyBounds(min_value=1.0, max_value=2.0, max_step=1.0),
+    )
+    written = apply_proposals_to_live_overrides(
+        [proposal],
+        policy=policy,
+        live_override_path=live_path,
+    )
+    assert written is None
+    assert not live_path.exists()


### PR DESCRIPTION
## Summary
- Research/offline only: bind existing Phase-10 caller-supplied observations (`OFFLINE_EXPERIMENT_OBSERVATIONS_V1`) to a Phase-1 `COMPLETE` canonical experiment identity, then persist through existing Phase-2 immutable experiment memory.
- Reuses Phase-1 identity validation, Phase-2 `experiment_id` / append-only store, and the existing observation shape. No second identity, no second memory truth, no new runner architecture.
- Fail-closed on incomplete/missing identity, identity/`experiment_id`/lineage/digest mismatch, wrong observation owner, divergent duplicate persist, apply, `bounded_auto`, and any claim that a legacy/Package-N record is Phase-1 `COMPLETE`.
- Does **not** extend or bypass PR #5942 admission. Does **not** grant Phase-10 runtime authority. Does **not** apply promotions, start Live/Testnet/Canary, fund, submit orders, or mutate accounts.

## Test plan
- [x] Focused owner tests: `tests/experiments/test_canonical_identity_bound_offline_observation_binding_v1.py`
- [x] Phase-1 / Phase-2 / Phase-10 / PR #5942 regression owners
- [x] `ruff format --check` / `ruff check`
- [x] Docs token policy (changed markdown)
- [x] Docs reference targets (`--changed`)
- [x] Canonical selector on the exact diff: `PR_BOUNDED_FULL` (`category_central_src_requires_full`)
- [x] Path-equivalent `PR_BOUNDED_FULL` pytest targets (729 passed)

```text
RESEARCH_OFFLINE_ONLY=true
IDENTITY_BOUND_OBSERVATION_BINDING=true
EXISTING_OWNERS_REUSED=true
PHASE_1_COMPLETE_REQUIRED=true
PHASE_2_IMMUTABLE_MEMORY_REUSED=true
NEW_RUNNER_ARCHITECTURE=false
PROMOTION_APPLY_EFFECT=false
BOUNDED_AUTO_EFFECT=false
RUNTIME_AUTHORITY_EFFECT=false
LIVE_EFFECT=false
TESTNET_EFFECT=false
FUNDING_AUTH_EFFECT=false
CANARY_EFFECT=false
ORDER_EFFECT=false
OWNER_MERGE_GO_REQUIRED=true
```


Made with [Cursor](https://cursor.com)