### PR TITLE
research: consume identity-bound observation binding in phase 10

### DIFF
--- a/docs/ops/specs/CANONICAL_AUTOMATED_OFFLINE_RESEARCH_LOOP_V1.md
+++ b/docs/ops/specs/CANONICAL_AUTOMATED_OFFLINE_RESEARCH_LOOP_V1.md
@@ -24,11 +24,13 @@ Reuse, do not replace:
 ```text
 Phase 1  src.experiments.canonical_experiment_identity_v1     REUSE identity
 Phase 2  src.experiments.canonical_experiment_memory_v1       REUSE experiment_id and memory
+Phase 2  src.experiments.canonical_experiment_memory_store_v1 REUSE append-only persist
 Phase 3  src.experiments.canonical_failure_memory_v1          REUSE fingerprint, records, persist
 Phase 4  src.experiments.canonical_robustness_suite_v1        REUSE robustness evidence
 Phase 5  src.experiments.canonical_comparison_ssot_v1         REUSE comparability
 Phase 6  src.experiments.canonical_champion_challenger_v1     REUSE challenger report
 Phase 7  src.experiments.canonical_reality_gap_store_v1       REUSE gap report
+Binding  src.experiments.canonical_identity_bound_offline_observation_binding_v1  REUSE observation binding
 ```
 
 ```text
@@ -61,10 +63,16 @@ RESEARCH_METADATA_AGGREGATION
 Silent step omission is forbidden. Every step is represented in evidence.
 
 ```text
-OFFLINE_EXPERIMENT_EXECUTION = bind Phase-2 memory from caller-supplied observations
+OFFLINE_EXPERIMENT_EXECUTION = consume canonical identity-bound observation binding
+OFFLINE_EXPERIMENT_EXECUTION = bind Phase-2 memory from caller-supplied OfflineExperimentObservationsV1
+OFFLINE_EXPERIMENT_EXECUTION != invent identity
 OFFLINE_EXPERIMENT_EXECUTION != run productive trading engine
 OFFLINE_EXPERIMENT_EXECUTION != write config
 ```
+
+Phase 10 remains the offline-execution owner. Phase 1 remains the identity owner.
+Phase 2 remains the immutable-memory owner. The #5943 binding contract is the
+adapter consumed by `OFFLINE_EXPERIMENT_EXECUTION`; it is not a second runner.
 
 ## Hypothesis selection
 
@@ -82,7 +90,11 @@ Duplicate `hypothesis_fingerprint` values from Phase 3 Failure Memory are assess
 
 Caller-supplied finite observations are required. Missing values fail closed. Zero is never inferred for missing fee, slippage, funding, or robustness observations.
 
-`OFFLINE_EXPERIMENT_EXECUTION` binds a COMPLETE Phase-2 experiment-memory record. Historical experiment memory is not overwritten. Optional persist uses the Phase-2 append-only store.
+`OFFLINE_EXPERIMENT_EXECUTION` consumes `canonical_identity_bound_offline_observation_binding_v1`
+for caller-supplied `OfflineExperimentObservationsV1`. A Phase-1 `COMPLETE` identity is required.
+Identity digests are reused, not reinterpreted. Missing or incomplete identity, or a malformed
+observation shape, fails closed. Historical experiment memory is not overwritten. Optional persist
+uses the Phase-2 append-only store; divergent duplicate persist remains Phase-2 fail-closed.
 
 ## Comparability and challenger report
 

--- a/src/experiments/canonical_automated_offline_research_loop_v1.py
+++ b/src/experiments/canonical_automated_offline_research_loop_v1.py
@@ -33,10 +33,15 @@ from src.experiments.canonical_experiment_identity_v1 import (
     validate_canonical_experiment_identity_v1,
 )
 from src.experiments.canonical_experiment_memory_store_v1 import CanonicalExperimentMemoryStoreV1
-from src.experiments.canonical_experiment_memory_v1 import (
-    CanonicalExperimentMemoryRecordRequestV1,
-    build_canonical_experiment_memory_record_v1,
-    derive_experiment_id_v1,
+from src.experiments.canonical_experiment_memory_v1 import derive_experiment_id_v1
+from src.experiments.canonical_identity_bound_offline_observation_binding_v1 import (
+    BINDING_DOMAIN as OBSERVATION_BINDING_DOMAIN,
+    CanonicalIdentityBoundOfflineObservationBindingError,
+    CanonicalIdentityBoundOfflineObservationBindingRequestV1,
+    OBSERVATION_OWNER_OFFLINE_EXPERIMENT_OBSERVATIONS_V1,
+    SCHEMA_VERSION as OBSERVATION_BINDING_SCHEMA_VERSION,
+    STATUS_BOUND,
+    bind_canonical_identity_bound_offline_observation_v1,
 )
 from src.experiments.canonical_failure_memory_store_v1 import CanonicalFailureMemoryStoreV1
 from src.experiments.canonical_failure_memory_v1 import (
@@ -247,7 +252,7 @@ def run_canonical_automated_offline_research_loop_v1(
             "duplicate hypothesis requires explicit retest_reason"
         )
 
-    experiment_record = _bind_experiment_memory(
+    experiment_record, observation_binding = _bind_experiment_memory(
         request=request,
         identity=identity,
         experiment_id=experiment_id,
@@ -403,6 +408,7 @@ def run_canonical_automated_offline_research_loop_v1(
         "digest_algorithm": DIGEST_ALGORITHM,
         "duplicate_assessment": _plain_mapping(duplicate_assessment),
         "experiment_record": _plain_mapping(experiment_record),
+        "observation_binding": _observation_binding_evidence(observation_binding),
         "failure_records": [_plain_mapping(item) for item in failure_records],
         "hypothesis_preparation": {
             "experiment_id": experiment_id,
@@ -614,6 +620,11 @@ def validate_canonical_automated_offline_research_loop_v1(record: Mapping[str, A
         )
     identity = payload.get("experiment_record", {}).get("experiment_identity")
     _require_identity(identity)
+    _require_observation_binding(
+        payload.get("observation_binding"),
+        identity=identity,
+        experiment_id=str(payload.get("selected_experiment_id")),
+    )
     challenger_state = payload.get("challenger_report", {}).get("champion_state", {})
     if challenger_state.get("swapped") is True or challenger_state.get("mutated") is True:
         raise AutomatedOfflineResearchLoopValidationError("champion state mutation is forbidden")
@@ -659,36 +670,69 @@ def _prepare_identity(selected: ResearchHypothesisCandidateV1) -> Mapping[str, A
 def _bind_experiment_memory(
     *,
     request: CanonicalAutomatedOfflineResearchLoopRequestV1,
-    identity: Mapping[str, Any],
+    identity: Mapping[str, Any] | None,
     experiment_id: str,
     fingerprint: str,
     selected: ResearchHypothesisCandidateV1,
     created_at: str,
-) -> Mapping[str, Any]:
-    observations = request.experiment_observations
-    return build_canonical_experiment_memory_record_v1(
-        CanonicalExperimentMemoryRecordRequestV1(
-            experiment_identity=identity,
-            hypothesis_id=selected.hypothesis_id,
-            hypothesis_fingerprint=fingerprint,
-            parent_experiment=request.parent_experiment,
-            strategy_family=selected.strategy_family,
-            candidate_role=request.candidate_role,
-            dataset_ref=_bound_ref(str(identity["dataset_digest"])),
-            cost_model_ref=_bound_ref(str(identity["cost_model_digest"])),
-            risk_policy_ref=_bound_ref(str(identity["risk_policy_digest"])),
-            portfolio_ref=_bound_ref(str(identity["portfolio_digest"])),
-            metrics=observations.metrics,
-            robustness_results=observations.robustness_results,
-            regime_results=observations.regime_results,
-            comparison_status=COMPARISON_STATUS_NOT_COMPARED,
-            disposition=request.disposition,
-            rejection_reason=request.rejection_reason,
-            created_at=created_at,
-            artifacts=observations.artifacts,
-            experiment_id=experiment_id,
+) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
+    try:
+        binding = bind_canonical_identity_bound_offline_observation_v1(
+            CanonicalIdentityBoundOfflineObservationBindingRequestV1(
+                phase1_identity=identity,
+                observation_owner=OBSERVATION_OWNER_OFFLINE_EXPERIMENT_OBSERVATIONS_V1,
+                observations=request.experiment_observations,
+                claimed_identity_digest=_optional_identity_field(identity, "identity_digest"),
+                claimed_experiment_id=experiment_id,
+                claimed_parent_lineage_ref=(
+                    None if identity is None else _parent_lineage_ref(identity)
+                ),
+                hypothesis_id=selected.hypothesis_id,
+                hypothesis_fingerprint=fingerprint,
+                strategy_family=selected.strategy_family,
+                created_at=created_at,
+                parent_experiment=request.parent_experiment,
+                candidate_role=request.candidate_role,
+                disposition=request.disposition,
+                rejection_reason=request.rejection_reason,
+                claimed_dataset_digest=_optional_identity_field(identity, "dataset_digest"),
+                claimed_cost_model_digest=_optional_identity_field(identity, "cost_model_digest"),
+                claimed_risk_policy_digest=_optional_identity_field(identity, "risk_policy_digest"),
+                claimed_portfolio_digest=_optional_identity_field(identity, "portfolio_digest"),
+                requested_apply=False,
+                requested_bounded_auto=False,
+                experiment_memory_store=None,
+            )
         )
-    )
+    except CanonicalIdentityBoundOfflineObservationBindingError as exc:
+        raise AutomatedOfflineResearchLoopValidationError(
+            f"offline experiment observation binding failed: {exc}"
+        ) from exc
+    if binding.get("status") != STATUS_BOUND:
+        raise AutomatedOfflineResearchLoopValidationError(
+            "offline experiment observation binding rejected: "
+            f"{binding.get('status')}: {binding.get('rejection_reason')}"
+        )
+    record = binding.get("experiment_record")
+    if not isinstance(record, Mapping):
+        raise AutomatedOfflineResearchLoopValidationError(
+            "offline experiment observation binding did not return a Phase-2 record"
+        )
+    bound_id = str(record.get("experiment_id") or "")
+    if bound_id != experiment_id:
+        raise AutomatedOfflineResearchLoopValidationError(
+            "bound experiment_id does not match the Phase-1 identity digest binding"
+        )
+    bound_identity = record.get("experiment_identity")
+    if not isinstance(bound_identity, Mapping):
+        raise AutomatedOfflineResearchLoopValidationError(
+            "bound experiment_record is missing experiment_identity"
+        )
+    source_digest = _optional_identity_field(identity, "identity_digest")
+    bound_digest = str(bound_identity.get("identity_digest") or "")
+    if source_digest is None or bound_digest != source_digest:
+        raise AutomatedOfflineResearchLoopValidationError("bound identity_digest was reinterpreted")
+    return record, binding
 
 
 def _run_robustness(
@@ -851,6 +895,70 @@ def _parent_lineage_ref(identity: Mapping[str, Any]) -> str | None:
         value = parent_lineage.get("parent_lineage_ref")
         return value if isinstance(value, str) else None
     return None
+
+
+def _optional_identity_field(identity: Mapping[str, Any] | None, field_name: str) -> str | None:
+    if not isinstance(identity, Mapping):
+        return None
+    value = identity.get(field_name)
+    return str(value) if isinstance(value, str) and value else None
+
+
+def _observation_binding_evidence(binding: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "binding_domain": binding.get("binding_domain"),
+        "bounded_auto_allowed": False,
+        "experiment_id": binding.get("experiment_id"),
+        "identity_digest": binding.get("identity_digest"),
+        "identity_reinterpreted": False,
+        "observation_owner": binding.get("observation_owner"),
+        "promotion_apply_allowed": False,
+        "runtime_authority_effect": False,
+        "schema_version": binding.get("schema_version"),
+        "status": binding.get("status"),
+    }
+
+
+def _require_observation_binding(
+    value: Any,
+    *,
+    identity: Mapping[str, Any],
+    experiment_id: str,
+) -> None:
+    if not isinstance(value, Mapping):
+        raise AutomatedOfflineResearchLoopValidationError("observation_binding is required")
+    if value.get("schema_version") != OBSERVATION_BINDING_SCHEMA_VERSION:
+        raise AutomatedOfflineResearchLoopValidationError(
+            "observation_binding schema_version mismatch"
+        )
+    if value.get("binding_domain") != OBSERVATION_BINDING_DOMAIN:
+        raise AutomatedOfflineResearchLoopValidationError("observation_binding domain mismatch")
+    if value.get("status") != STATUS_BOUND:
+        raise AutomatedOfflineResearchLoopValidationError(
+            "observation_binding status must be BOUND"
+        )
+    if value.get("observation_owner") != OBSERVATION_OWNER_OFFLINE_EXPERIMENT_OBSERVATIONS_V1:
+        raise AutomatedOfflineResearchLoopValidationError("observation_binding owner mismatch")
+    if value.get("identity_reinterpreted") is not False:
+        raise AutomatedOfflineResearchLoopValidationError("identity reinterpretation is forbidden")
+    if value.get("promotion_apply_allowed") is not False:
+        raise AutomatedOfflineResearchLoopValidationError("observation_binding cannot allow apply")
+    if value.get("bounded_auto_allowed") is not False:
+        raise AutomatedOfflineResearchLoopValidationError(
+            "observation_binding cannot allow bounded_auto"
+        )
+    if value.get("runtime_authority_effect") is not False:
+        raise AutomatedOfflineResearchLoopValidationError(
+            "observation_binding runtime_authority_effect must be false"
+        )
+    if str(value.get("experiment_id") or "") != experiment_id:
+        raise AutomatedOfflineResearchLoopValidationError(
+            "observation_binding experiment_id does not match selected_experiment_id"
+        )
+    if str(value.get("identity_digest") or "") != str(identity.get("identity_digest") or ""):
+        raise AutomatedOfflineResearchLoopValidationError(
+            "observation_binding identity_digest does not match Phase-1 identity"
+        )
 
 
 def _require_identity(value: Any) -> dict[str, Any]:

--- a/tests/experiments/test_canonical_automated_offline_research_loop_v1.py
+++ b/tests/experiments/test_canonical_automated_offline_research_loop_v1.py
@@ -30,6 +30,7 @@ from src.experiments.canonical_automated_offline_research_loop_v1 import (
     canonical_record_payload_v1,
     run_canonical_automated_offline_research_loop_v1,
     validate_canonical_automated_offline_research_loop_v1,
+    _bind_experiment_memory,
 )
 from src.experiments.canonical_comparison_ssot_v1 import ComparisonCandidateV1
 from src.experiments.canonical_experiment_identity_v1 import (
@@ -38,7 +39,14 @@ from src.experiments.canonical_experiment_identity_v1 import (
     build_canonical_experiment_identity_v1,
 )
 from src.experiments.canonical_experiment_memory_store_v1 import CanonicalExperimentMemoryStoreV1
-from src.experiments.canonical_experiment_memory_v1 import derive_experiment_id_v1
+from src.experiments.canonical_experiment_memory_v1 import (
+    ExperimentRecordConflictError,
+    derive_experiment_id_v1,
+)
+from src.experiments.canonical_identity_bound_offline_observation_binding_v1 import (
+    OBSERVATION_OWNER_OFFLINE_EXPERIMENT_OBSERVATIONS_V1,
+    STATUS_BOUND,
+)
 from src.experiments.canonical_failure_memory_store_v1 import CanonicalFailureMemoryStoreV1
 from src.experiments.canonical_reality_gap_store_persist_v1 import CanonicalRealityGapStoreV1
 from src.experiments.canonical_reality_gap_store_v1 import (
@@ -288,6 +296,19 @@ def test_complete_loop_reuses_phase_owners_and_is_deterministic() -> None:
     assert first["robustness_evidence"]["aggregate_status"] == "PASS"
     assert first["reality_gap_record"]["overall_disposition"] == "WITHIN_THRESHOLD"
     assert first["failure_records"] == []
+    binding = first["observation_binding"]
+    assert binding["status"] == STATUS_BOUND
+    assert binding["observation_owner"] == OBSERVATION_OWNER_OFFLINE_EXPERIMENT_OBSERVATIONS_V1
+    assert binding["identity_digest"] == selected_identity["identity_digest"]
+    assert binding["experiment_id"] == first["selected_experiment_id"]
+    assert binding["identity_reinterpreted"] is False
+    assert binding["promotion_apply_allowed"] is False
+    assert binding["bounded_auto_allowed"] is False
+    assert binding["runtime_authority_effect"] is False
+    assert (
+        first["experiment_record"]["experiment_identity"]["identity_digest"]
+        == selected_identity["identity_digest"]
+    )
     validate_canonical_automated_offline_research_loop_v1(first)
     assert canonical_record_payload_v1(first) == canonical_record_payload_v1(second)
     assert deterministic_json_dumps(canonical_record_payload_v1(first)) == deterministic_json_dumps(
@@ -419,6 +440,8 @@ def test_no_runtime_live_config_promotion_or_authority_paths() -> None:
         "src.meta.learning_loop.autonomous_non_live_orchestration_plan_v1",
     }
     assert forbidden_imports.isdisjoint(imported)
+    assert "src.experiments.canonical_identity_bound_offline_observation_binding_v1" in imported
+    assert "bind_canonical_identity_bound_offline_observation_v1" in source
     for token in (
         "config/live_overrides",
         "config/auto/",
@@ -457,3 +480,89 @@ def test_no_runtime_live_config_promotion_or_authority_paths() -> None:
     assert "apply_proposals_to_live_overrides" not in inspect.getsource(
         run_canonical_automated_offline_research_loop_v1
     )
+
+
+def _bind_direct(**overrides: Any) -> tuple[Mapping[str, Any], Mapping[str, Any]]:
+    identity = overrides.pop("identity", _identity())
+    selected = overrides.pop("selected", _hypothesis())
+    request = overrides.pop("request", _request())
+    if identity is None:
+        experiment_id = overrides.pop("experiment_id", _digest("missing-experiment"))
+    else:
+        experiment_id = overrides.pop(
+            "experiment_id", derive_experiment_id_v1(str(identity["identity_digest"]))
+        )
+    fingerprint = overrides.pop("fingerprint", _digest("hypothesis"))
+    return _bind_experiment_memory(
+        request=request,
+        identity=identity,
+        experiment_id=experiment_id,
+        fingerprint=fingerprint,
+        selected=selected,
+        created_at=_CREATED_AT,
+        **overrides,
+    )
+
+
+def test_offline_execution_consumes_identity_binding_for_complete_observation() -> None:
+    identity = _identity()
+    record, binding = _bind_direct(identity=identity)
+    assert binding["status"] == STATUS_BOUND
+    assert record["experiment_id"] == derive_experiment_id_v1(str(identity["identity_digest"]))
+    assert record["experiment_identity"]["identity_digest"] == identity["identity_digest"]
+    assert binding["identity_digest"] == identity["identity_digest"]
+    assert binding["identity_reinterpreted"] is False
+
+
+def test_incomplete_identity_is_rejected_by_consumed_binding() -> None:
+    identity = dict(_identity())
+    identity["completeness"] = "INCOMPLETE"
+    with pytest.raises(
+        AutomatedOfflineResearchLoopValidationError, match="REJECTED_INCOMPLETE_IDENTITY"
+    ):
+        _bind_direct(identity=identity)
+
+
+def test_missing_identity_is_rejected_by_consumed_binding() -> None:
+    with pytest.raises(
+        AutomatedOfflineResearchLoopValidationError, match="REJECTED_MISSING_DIMENSION"
+    ):
+        _bind_direct(identity=None)
+
+
+def test_malformed_observation_is_rejected_by_consumed_binding() -> None:
+    with pytest.raises(
+        AutomatedOfflineResearchLoopValidationError,
+        match="offline experiment observation binding failed",
+    ):
+        _bind_direct(request=_request(experiment_observations=_observations(artifacts="bad")))
+
+
+def test_identity_digest_is_passed_through_unchanged() -> None:
+    identity = _identity()
+    record, binding = _bind_direct(identity=identity)
+    assert record["experiment_identity"]["identity_digest"] == identity["identity_digest"]
+    assert binding["identity_digest"] == identity["identity_digest"]
+    assert binding["experiment_id"] == record["experiment_id"]
+    loop = run_canonical_automated_offline_research_loop_v1(_request())
+    assert loop["observation_binding"]["identity_digest"] == identity["identity_digest"]
+    assert loop["selected_experiment_id"] == record["experiment_id"]
+
+
+def test_phase2_divergent_duplicate_persist_remains_fail_closed(tmp_path: Path) -> None:
+    store = CanonicalExperimentMemoryStoreV1(tmp_path / "experiments")
+    first = run_canonical_automated_offline_research_loop_v1(
+        _request(experiment_memory_store=store)
+    )
+    assert store.exists(str(first["selected_experiment_id"])) is True
+    with pytest.raises(ExperimentRecordConflictError, match="divergent"):
+        run_canonical_automated_offline_research_loop_v1(
+            _request(
+                experiment_memory_store=store,
+                experiment_observations=_observations(
+                    metrics={"sharpe": 0.01, "max_drawdown": -0.9}
+                ),
+            )
+        )
+    stored = store.get(str(first["selected_experiment_id"]))
+    assert stored["metrics"]["sharpe"] == 1.25


### PR DESCRIPTION
## Summary
- Research/offline only: Phase 10 `OFFLINE_EXPERIMENT_EXECUTION` now consumes the PR #5943 identity-bound observation binding contract instead of building Phase-2 memory inline.
- Phase 1 remains identity owner, Phase 2 remains memory/persist owner, Phase 10 remains the offline-execution orchestrator. No new runner architecture.
- Incomplete/missing identity and malformed observations fail closed. Identity digests are reused, not reinterpreted. Divergent duplicate persist remains Phase-2 `ExperimentRecordConflictError`.
- No apply, no `bounded_auto`, no runtime/Live/Testnet/order/funding/promotion authority.

## Test plan
- [x] Phase-10 owner tests including binding consumption, incomplete/missing identity, malformed observation, identity passthrough, divergent duplicate persist
- [x] PR #5943 binding tests
- [x] Phase-1 / Phase-2 / PR #5942 admission regressions
- [x] `ruff format --check` / `ruff check`
- [x] Docs token policy and docs reference targets (`--changed`)
- [x] Canonical selector: `PR_BOUNDED_FULL` (`category_central_src_requires_full`)
- [x] Path-equivalent `PR_BOUNDED_FULL` pytest targets (729 passed, 36.82s)

```text
RESEARCH_OFFLINE_ONLY=true
PHASE10_CONSUMES_PR5943_BINDING=true
NEW_RUNNER_ARCHITECTURE=false
PHASE1_IDENTITY_OWNER_UNCHANGED=true
PHASE2_MEMORY_OWNER_UNCHANGED=true
PHASE10_EXECUTION_OWNER_UNCHANGED=true
PROMOTION_APPLY_EFFECT=false
BOUNDED_AUTO_EFFECT=false
RUNTIME_AUTHORITY_EFFECT=false
LIVE_EFFECT=false
TESTNET_EFFECT=false
ORDER_EFFECT=false
FUNDING_AUTH_EFFECT=false
OWNER_MERGE_GO_REQUIRED=true
```


Made with [Cursor](https://cursor.com)