### PR TITLE
research: delegate phase-10 persist to identity observation binding

### DIFF
--- a/docs/ops/specs/CANONICAL_AUTOMATED_OFFLINE_RESEARCH_LOOP_V1.md
+++ b/docs/ops/specs/CANONICAL_AUTOMATED_OFFLINE_RESEARCH_LOOP_V1.md
@@ -93,8 +93,10 @@ Caller-supplied finite observations are required. Missing values fail closed. Ze
 `OFFLINE_EXPERIMENT_EXECUTION` consumes `canonical_identity_bound_offline_observation_binding_v1`
 for caller-supplied `OfflineExperimentObservationsV1`. A Phase-1 `COMPLETE` identity is required.
 Identity digests are reused, not reinterpreted. Missing or incomplete identity, or a malformed
-observation shape, fails closed. Historical experiment memory is not overwritten. Optional persist
-uses the Phase-2 append-only store; divergent duplicate persist remains Phase-2 fail-closed.
+observation shape, fails closed. Historical experiment memory is not overwritten. Optional
+Phase-2 persist is delegated to the consumed `#5943` binding adapter; Phase 10 does not keep a
+parallel experiment-record append path. Divergent duplicate persist remains Phase-2
+`ExperimentRecordConflictError` fail-closed. Identical replay remains Phase-2 idempotent.
 
 ## Comparability and challenger report
 

--- a/src/experiments/canonical_automated_offline_research_loop_v1.py
+++ b/src/experiments/canonical_automated_offline_research_loop_v1.py
@@ -33,7 +33,10 @@ from src.experiments.canonical_experiment_identity_v1 import (
     validate_canonical_experiment_identity_v1,
 )
 from src.experiments.canonical_experiment_memory_store_v1 import CanonicalExperimentMemoryStoreV1
-from src.experiments.canonical_experiment_memory_v1 import derive_experiment_id_v1
+from src.experiments.canonical_experiment_memory_v1 import (
+    ExperimentRecordConflictError,
+    derive_experiment_id_v1,
+)
 from src.experiments.canonical_identity_bound_offline_observation_binding_v1 import (
     BINDING_DOMAIN as OBSERVATION_BINDING_DOMAIN,
     CanonicalIdentityBoundOfflineObservationBindingError,
@@ -41,6 +44,7 @@ from src.experiments.canonical_identity_bound_offline_observation_binding_v1 imp
     OBSERVATION_OWNER_OFFLINE_EXPERIMENT_OBSERVATIONS_V1,
     SCHEMA_VERSION as OBSERVATION_BINDING_SCHEMA_VERSION,
     STATUS_BOUND,
+    STATUS_REJECTED_DIVERGENT_DUPLICATE,
     bind_canonical_identity_bound_offline_observation_v1,
 )
 from src.experiments.canonical_failure_memory_store_v1 import CanonicalFailureMemoryStoreV1
@@ -260,9 +264,7 @@ def run_canonical_automated_offline_research_loop_v1(
         selected=selected,
         created_at=created_at,
     )
-    experiment_persisted = _optional_append(
-        request.experiment_memory_store, experiment_record, "experiment_id"
-    )
+    experiment_persisted = _binding_persist_id(observation_binding)
     robustness_evidence = _run_robustness(
         request=request,
         identity=identity,
@@ -701,13 +703,20 @@ def _bind_experiment_memory(
                 claimed_portfolio_digest=_optional_identity_field(identity, "portfolio_digest"),
                 requested_apply=False,
                 requested_bounded_auto=False,
-                experiment_memory_store=None,
+                experiment_memory_store=request.experiment_memory_store,
             )
         )
     except CanonicalIdentityBoundOfflineObservationBindingError as exc:
         raise AutomatedOfflineResearchLoopValidationError(
             f"offline experiment observation binding failed: {exc}"
         ) from exc
+    if binding.get("status") == STATUS_REJECTED_DIVERGENT_DUPLICATE:
+        raise ExperimentRecordConflictError(
+            str(
+                binding.get("rejection_reason")
+                or "divergent canonical content for existing experiment_id is forbidden"
+            )
+        )
     if binding.get("status") != STATUS_BOUND:
         raise AutomatedOfflineResearchLoopValidationError(
             "offline experiment observation binding rejected: "
@@ -904,6 +913,14 @@ def _optional_identity_field(identity: Mapping[str, Any] | None, field_name: str
     return str(value) if isinstance(value, str) and value else None
 
 
+def _binding_persist_id(binding: Mapping[str, Any]) -> str | None:
+    persist = binding.get("persist")
+    if not isinstance(persist, Mapping):
+        return None
+    value = persist.get("experiment_record_id")
+    return str(value) if isinstance(value, str) and value else None
+
+
 def _observation_binding_evidence(binding: Mapping[str, Any]) -> dict[str, Any]:
     return {
         "binding_domain": binding.get("binding_domain"),
@@ -912,6 +929,7 @@ def _observation_binding_evidence(binding: Mapping[str, Any]) -> dict[str, Any]:
         "identity_digest": binding.get("identity_digest"),
         "identity_reinterpreted": False,
         "observation_owner": binding.get("observation_owner"),
+        "persist": {"experiment_record_id": _binding_persist_id(binding)},
         "promotion_apply_allowed": False,
         "runtime_authority_effect": False,
         "schema_version": binding.get("schema_version"),
@@ -959,6 +977,17 @@ def _require_observation_binding(
         raise AutomatedOfflineResearchLoopValidationError(
             "observation_binding identity_digest does not match Phase-1 identity"
         )
+    persist = value.get("persist")
+    if persist is not None:
+        if not isinstance(persist, Mapping):
+            raise AutomatedOfflineResearchLoopValidationError(
+                "observation_binding persist must be a mapping"
+            )
+        persisted_id = persist.get("experiment_record_id")
+        if persisted_id is not None and str(persisted_id) != experiment_id:
+            raise AutomatedOfflineResearchLoopValidationError(
+                "observation_binding persist experiment_record_id does not match selected_experiment_id"
+            )
 
 
 def _require_identity(value: Any) -> dict[str, Any]:

--- a/tests/experiments/test_canonical_automated_offline_research_loop_v1.py
+++ b/tests/experiments/test_canonical_automated_offline_research_loop_v1.py
@@ -392,6 +392,7 @@ def test_optional_persist_uses_canonical_append_only_stores(tmp_path: Path) -> N
     experiment_id = str(record["selected_experiment_id"])
     assert experiment_store.exists(experiment_id) is True
     assert record["persist"]["experiment_record_id"] == experiment_id
+    assert record["observation_binding"]["persist"]["experiment_record_id"] == experiment_id
     assert (
         record["persist"]["reality_gap_record_id"]
         == record["reality_gap_record"]["reality_gap_record_id"]
@@ -399,6 +400,16 @@ def test_optional_persist_uses_canonical_append_only_stores(tmp_path: Path) -> N
     assert record["persist"]["failure_record_ids"]
     for failure_record_id in record["persist"]["failure_record_ids"]:
         assert failure_store.exists(failure_record_id) is True
+
+
+def test_optional_phase2_persist_is_disabled_without_store(tmp_path: Path) -> None:
+    unused = CanonicalExperimentMemoryStoreV1(tmp_path / "unused")
+    record = run_canonical_automated_offline_research_loop_v1(_request())
+    experiment_id = str(record["selected_experiment_id"])
+    assert record["persist"]["experiment_record_id"] is None
+    assert record["observation_binding"]["persist"]["experiment_record_id"] is None
+    assert unused.store_root.exists() is False
+    assert unused.exists(experiment_id) is False
 
 
 def test_reuses_phase_4_tokens() -> None:
@@ -566,3 +577,96 @@ def test_phase2_divergent_duplicate_persist_remains_fail_closed(tmp_path: Path) 
         )
     stored = store.get(str(first["selected_experiment_id"]))
     assert stored["metrics"]["sharpe"] == 1.25
+
+
+def test_phase2_identical_duplicate_persist_remains_idempotent(tmp_path: Path) -> None:
+    store = CanonicalExperimentMemoryStoreV1(tmp_path / "experiments")
+    first = run_canonical_automated_offline_research_loop_v1(
+        _request(experiment_memory_store=store)
+    )
+    second = run_canonical_automated_offline_research_loop_v1(
+        _request(experiment_memory_store=store)
+    )
+    experiment_id = str(first["selected_experiment_id"])
+    assert second["selected_experiment_id"] == experiment_id
+    assert second["persist"]["experiment_record_id"] == experiment_id
+    assert second["observation_binding"]["status"] == STATUS_BOUND
+    assert len(store.list_metadata()) == 1
+    stored = store.get(experiment_id)
+    assert stored["metrics"]["sharpe"] == 1.25
+
+
+def test_incomplete_identity_does_not_persist(tmp_path: Path) -> None:
+    store = CanonicalExperimentMemoryStoreV1(tmp_path / "experiments")
+    identity = dict(_identity())
+    identity["completeness"] = "INCOMPLETE"
+    with pytest.raises(
+        AutomatedOfflineResearchLoopValidationError, match="REJECTED_INCOMPLETE_IDENTITY"
+    ):
+        _bind_direct(identity=identity, request=_request(experiment_memory_store=store))
+    assert store.list_metadata() == []
+
+
+def test_missing_identity_does_not_persist(tmp_path: Path) -> None:
+    store = CanonicalExperimentMemoryStoreV1(tmp_path / "experiments")
+    with pytest.raises(
+        AutomatedOfflineResearchLoopValidationError, match="REJECTED_MISSING_DIMENSION"
+    ):
+        _bind_direct(identity=None, request=_request(experiment_memory_store=store))
+    assert store.list_metadata() == []
+
+
+def test_malformed_observation_does_not_persist(tmp_path: Path) -> None:
+    store = CanonicalExperimentMemoryStoreV1(tmp_path / "experiments")
+    with pytest.raises(
+        AutomatedOfflineResearchLoopValidationError,
+        match="offline experiment observation binding failed",
+    ):
+        _bind_direct(
+            request=_request(
+                experiment_memory_store=store,
+                experiment_observations=_observations(artifacts="bad"),
+            )
+        )
+    assert store.list_metadata() == []
+
+
+def test_phase10_delegates_optional_persist_to_consumed_binding() -> None:
+    bind_source = inspect.getsource(_bind_experiment_memory)
+    run_source = inspect.getsource(run_canonical_automated_offline_research_loop_v1)
+    assert "experiment_memory_store=request.experiment_memory_store" in bind_source
+    assert "experiment_memory_store=None" not in bind_source
+    assert "_binding_persist_id(observation_binding)" in run_source
+    assert "request.experiment_memory_store, experiment_record" not in run_source
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    bind_fn = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_bind_experiment_memory"
+    )
+    run_fn = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "run_canonical_automated_offline_research_loop_v1"
+    )
+    bind_calls = [
+        node
+        for node in ast.walk(bind_fn)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "bind_canonical_identity_bound_offline_observation_v1"
+    ]
+    assert len(bind_calls) == 1
+    run_optional_appends = [
+        node
+        for node in ast.walk(run_fn)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_optional_append"
+    ]
+    assert len(run_optional_appends) == 1
+    first_arg = run_optional_appends[0].args[0]
+    assert isinstance(first_arg, ast.Attribute)
+    assert first_arg.attr == "reality_gap_store"


### PR DESCRIPTION
## Summary
- Research/offline only: Phase 10 optional Phase-2 persist now goes through the existing PR #5943 identity-bound observation binding adapter consumed in #5944.
- Removes the parallel `_optional_append` experiment-record path. Phase 1 remains identity owner, Phase 2 remains memory/persist/conflict owner, Phase 10 remains orchestrator.
- Divergent duplicates still fail closed as Phase-2 `ExperimentRecordConflictError`. Identical replay remains Phase-2 idempotent. Binding failures do not fall back to a second append.
- No apply, no `bounded_auto`, no runtime/Live/Testnet/order/funding/promotion authority. Cap 11.13.5 remains blocked on OEM fee monetary base.

## Test plan
- [x] Phase-10 owner tests: persist via binding, persist disabled, incomplete/missing identity, malformed observation, identical duplicate, divergent `ExperimentRecordConflictError`, no parallel fallback, source/AST orchestration contract
- [x] PR #5943 binding tests
- [x] Phase-1 / Phase-2 identity and memory regressions
- [x] `ruff format --check` / `ruff check`
- [x] Docs token policy and docs reference targets (`--changed`)
- [x] Canonical selector: `PR_BOUNDED_FULL` (`category_central_src_requires_full`)
- [x] Path-equivalent `PR_BOUNDED_FULL` pytest targets (729 passed, 36.45s)

```text
RESEARCH_OFFLINE_ONLY=true
PHASE10_PERSIST_CONSUMES_PR5943_BINDING=true
PARALLEL_EXPERIMENT_APPEND_REMOVED=true
NEW_RUNNER_ARCHITECTURE=false
PHASE1_IDENTITY_OWNER_UNCHANGED=true
PHASE2_MEMORY_OWNER_UNCHANGED=true
PHASE10_EXECUTION_OWNER_UNCHANGED=true
DIVERGENT_DUPLICATE_SEMANTICS_UNCHANGED=true
PROMOTION_APPLY_EFFECT=false
BOUNDED_AUTO_EFFECT=false
RUNTIME_AUTHORITY_EFFECT=false
LIVE_EFFECT=false
TESTNET_EFFECT=false
ORDER_EFFECT=false
FUNDING_AUTH_EFFECT=false
OWNER_MERGE_GO_REQUIRED=true
```


Made with [Cursor](https://cursor.com)