### PR TITLE
ci: skip rclone setup on pull requests

### DIFF
--- a/.github/workflows/ci-export-pack-download-verify.yml
+++ b/.github/workflows/ci-export-pack-download-verify.yml
@@ -68,11 +68,13 @@ jobs:
           python-version: "3.11"
 
       - name: Install rclone
+        if: github.event_name == 'workflow_dispatch'
         run: |
           sudo apt-get update
           sudo apt-get install -y rclone
 
       - name: Materialize rclone config (read-only)
+        if: github.event_name == 'workflow_dispatch'
         env:
           PT_RCLONE_CONF_B64: ${{ secrets.PT_RCLONE_CONF_B64 }}
         run: |


### PR DESCRIPTION
## Summary
- Root cause: `CI / Export Pack Download + Verify` ran `Install rclone` on `pull_request`. `sudo apt-get update` stalled against `azure.archive.ubuntu.com` and run `32210893259` hit the 25m job timeout (`cancelled`). Seed/Resolve/Download/Verify were already `workflow_dispatch`-only, so rclone was unused on the PR path.
- Fix: add the existing event gate `if: github.event_name == 'workflow_dispatch'` to `Install rclone` and `Materialize rclone config (read-only)` only.
- Scope: exactly one workflow file, two gating lines. No timeout change, no job-`if` change, no Guardrails/Verify/secrets change, no other workflows, no runtime/trading change. Does not modify or merge PR #5956.

## Test plan
- [x] YAML `safe_load`
- [x] PR event: Install + Materialize skipped; Checkout/Guardrails/Validate/Setup Python still run; no `apt-get`/rclone binary on PR path
- [x] `workflow_dispatch`: Install + Materialize still run, bodies unchanged
- [x] `python3 -m pytest -q tests/ci/test_ci_export_pack_download_verify_workflow_contract_v0.py` (7 passed)
- [ ] GitHub PR checks confirm export-pack job no longer stalls on apt/rclone


Made with [Cursor](https://cursor.com)