### PR TITLE
test: extractive PORT-A..PORT-E preservation contract ports

### DIFF
--- a/config/live_overrides/auto.toml
+++ b/config/live_overrides/auto.toml
@@ -1,17 +1,21 @@
-# Peak_Trade Live Overrides (Auto-applied)
-# =======================================
-# Diese Datei wird (optional) vom Promotion Loop im Modus "bounded_auto"
-# aktualisiert. Sie wird NUR in live-ähnlichen Umgebungen von
-# `load_config_with_live_overrides()` eingemischt (oder in Tests via --force).
+# Peak_Trade Live Overrides (SUPERSEDED / FAIL-CLOSED)
+# ====================================================
+# FND-005: this file is not applied to runtime config.
+# Canonical owner: Master Runbook §4.11.
+#
+# Historical comments claimed the Promotion Loop would update this file
+# in "bounded_auto" mode and that load_config_with_live_overrides() would
+# merge it in live-like environments. That claim is SUPERSEDED.
+#
+# Current runtime:
+# - load_config_with_live_overrides() returns base config only.
+# - apply_proposals_to_live_overrides() always returns None and never writes.
+# - force_apply_overrides has no effect.
+# - SELF_LEARNING != SELF_AUTHORIZING
 #
 # WICHTIG:
 # - Keine Secrets hier ablegen.
-# - Keys mit Punkten bitte in Anführungszeichen schreiben, damit TOML sie als
-#   String-Key und nicht als verschachtelte Tabellen interpretiert.
-#
-# Beispiel:
-# [auto_applied]
-# "portfolio.leverage" = 1.75
-# "strategy.trigger_delay" = 8.0
+# - Do not treat this file as live config authority.
+# - The empty [auto_applied] table is retained for path compatibility only.
 
 [auto_applied]

--- a/tests/ops/test_section_11_13_5_z2n_untracked_marketing_fee_dumps_non_ssot_v1.py
+++ b/tests/ops/test_section_11_13_5_z2n_untracked_marketing_fee_dumps_non_ssot_v1.py
@@ -1,0 +1,114 @@
+"""Z2N generic non-SSOT contract for untracked marketing fee-page dumps.
+
+Read-only regression contract. Does not adopt fee rates, create a fee
+SSOT, authorize Live, Testnet, Canary execute, funding, orders, or
+COVER_USDC instantiation. Does not commit, push, or track the dumps.
+Does not bind FND-012 or Master Runbook §4.13.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MASTER_RUNBOOK = REPO_ROOT / "docs" / "runbooks" / "canonical" / "PEAK_TRADE_MASTER_RUNBOOK.md"
+Z2N_EVIDENCE_ROOT = (
+    REPO_ROOT
+    / "evidence"
+    / "ops"
+    / "section_11_13_5_z2m_fee_reserve_rates_rebind_get_v1"
+    / "20260819T102325Z"
+)
+DUMP_FILES = (
+    REPO_ROOT / "okx-en-eu-fees.yml",
+    REPO_ROOT / "okx-en-eu-fees-futures.yml",
+)
+DUMP_NAMES = {path.name for path in DUMP_FILES}
+Z2N_HEADING = "### 11.13.5.Z2N Fresh authenticated fee-reserve rates rebind GET evidence persist"
+DIRTY_SECTION_4_13_FND012_HEADING = (
+    "## 4.13 Untracked OKX Europe fee-page YAML dumps are non-SSOT (FND-012)"
+)
+OPERATIVE_SURFACES = ("src", "scripts", "config")
+
+
+def _read(path: Path) -> str:
+    assert path.is_file(), f"missing canonical path: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def _z2n_section(text: str) -> str:
+    start = text.find(Z2N_HEADING)
+    assert start >= 0, "missing §11.13.5.Z2N heading"
+    end = text.find("## 11.14 Live order and economic evidence ladder", start)
+    assert end > start, "missing §11.14 boundary after Z2N"
+    return text[start:end]
+
+
+def _git_ls_files(path: Path) -> str:
+    result = subprocess.run(
+        ["git", "ls-files", "--", path.name],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _operational_references() -> set[Path]:
+    hits: set[Path] = set()
+    this_file = Path(__file__).resolve()
+    for surface in OPERATIVE_SURFACES:
+        root = REPO_ROOT / surface
+        if not root.exists():
+            continue
+        for candidate in root.rglob("*"):
+            if not candidate.is_file():
+                continue
+            if candidate.resolve() == this_file:
+                continue
+            text = candidate.read_text(encoding="utf-8", errors="replace")
+            if any(name in text for name in DUMP_NAMES):
+                hits.add(candidate.resolve())
+    return hits
+
+
+def test_dirty_fnd_012_section_is_not_canon_owner() -> None:
+    text = _read(MASTER_RUNBOOK)
+    assert DIRTY_SECTION_4_13_FND012_HEADING not in text
+    assert "FND_012_STATUS=RESOLVED" not in text
+    assert "SURFACE_ID=OF-01-OKX-EN-EU-FEES-YML" not in text
+    assert "SURFACE_ID=OF-02-OKX-EN-EU-FEES-FUTURES-YML" not in text
+    assert "## 4.13 Phase-17 LIVE-unimplemented header superseded (FND-015)" in text
+
+
+def test_root_okx_fee_ymls_remain_untracked_unimported_and_non_operative() -> None:
+    for path in DUMP_FILES:
+        assert _git_ls_files(path) == ""
+        if path.exists():
+            text = _read(path)
+            assert text.lstrip().startswith("- generic")
+            assert "[ref=" in text
+            assert "/en-eu/fees" in text
+            assert "maker_fee:" not in text
+            assert "taker_fee:" not in text
+            assert "makerFee:" not in text
+            assert "takerFee:" not in text
+    assert _operational_references() == set()
+
+
+def test_z2n_persisted_trade_fee_pack_remains_fee_rate_ssot() -> None:
+    section = _z2n_section(_read(MASTER_RUNBOOK))
+    assert "FEE_RESERVE_RATES_REBIND_GET_EVIDENCE_BOUND=true" in section
+    assert "FEE_RESERVE_RATES_ADJUDICATION=PROVEN" in section
+    assert "LIVE_AUTHORIZED=false" in section
+    assert "COVER_USDC_STATUS=UNINSTANTIATED" in section
+    assert "NUMERIC_FEE_RESERVE_STATUS=UNINSTANTIATED" in section
+    assert "LIVE_AUTHORIZED=true" not in section
+    snapshot = _read(Z2N_EVIDENCE_ROOT / "GET_SNAPSHOT.sanitized.json")
+    assert '"takerUSDC": "-0.0005"' in snapshot
+    assert '"makerUSDC": "-0.0002"' in snapshot
+    for path in DUMP_FILES:
+        assert path.resolve() != Z2N_EVIDENCE_ROOT.resolve()
+        assert path.name not in snapshot

--- a/tests/ops/test_section_4_10_topn_promotion_non_authorizing_fnd_004_v1.py
+++ b/tests/ops/test_section_4_10_topn_promotion_non_authorizing_fnd_004_v1.py
@@ -1,0 +1,199 @@
+"""Docs/contract checks for Master Runbook §4.10 (FND-004) Top-N non-authority.
+
+Read-only documentation contract. Does not authorize Live, Testnet,
+Canary execute, funding, orders, overlay apply, or COVER_USDC
+instantiation. Does not re-test export/apply runtime behavior owned
+elsewhere.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MASTER_RUNBOOK = REPO_ROOT / "docs" / "runbooks" / "canonical" / "PEAK_TRADE_MASTER_RUNBOOK.md"
+
+SECTION_4_10_HEADING = "## 4.10 Top-N promotion non-authority (FND-004)"
+SECTION_4_11_CANON_HEADING = "## 4.11 Live-overrides apply fail-closed binding (FND-005)"
+DIRTY_SECTION_4_11_FND004_HEADINGS = (
+    "## 4.11 Top-N promotion non-authority (FND-004)",
+    "## 4.11 Top-N promotion exporter non-canonical binding (FND-004)",
+)
+
+REQUIRED_NON_EQUIVALENCE = (
+    "SWEEP_TOPN_EXPORT != RUNTIME_CONFIG",
+    "SWEEP_TOPN_EXPORT != CHAMPION_CHALLENGER_SSOT",
+    "SWEEP_TOPN_EXPORT != PROMOTION_LOOP_APPLY",
+    "SWEEP_TOPN_EXPORT != LIVE_OVERRIDE",
+    "SWEEP_TOPN_CANDIDATES != SINGLE_SELECTED_FUTURE",
+    "SWEEP_TOPN_PROMOTION != SECTION_4_5_TOP_N_ACTIVE_SET",
+    "RESEARCH_RANKING != EXECUTION_AUTHORITY",
+    "SELF_LEARNING != SELF_AUTHORIZING",
+    "CODE_EXISTS != RUNTIME_AUTHORITY",
+    "TOML_EXPORT != AUTO_APPLY",
+    "POLICY_CRITIC_CONSULTATION != APPLY",
+)
+
+HEADER_AUTHORITY_FLAGS = (
+    "RUNTIME_AUTHORIZATION_EFFECT=NONE",
+    "PRODUCTIVE_CODE_CHANGED=false",
+    "AUTHORITY_EXPANDED=false",
+    "TOPN_PROMOTION_HAS_RUNTIME_AUTHORITY=false",
+    "TOPN_PROMOTION_HAS_LIVE_AUTHORITY=false",
+    "TOPN_PROMOTION_HAS_TESTNET_AUTHORITY=false",
+    "TOPN_PROMOTION_HAS_FUNDING_AUTHORITY=false",
+    "TOPN_PROMOTION_HAS_ORDER_AUTHORITY=false",
+    "TOPN_PROMOTION_HAS_CANARY_AUTHORITY=false",
+    "TOPN_PROMOTION_CAN_AUTO_APPLY=false",
+    "TOPN_PROMOTION_CAN_REENABLE=false",
+    "TOPN_PROMOTION_CAN_UNLOCK=false",
+    "SELF_LEARNING_SELF_AUTHORIZING=false",
+    "COVER_USDC=UNINSTANTIATED",
+    "LIVE_AUTHORIZED=false",
+    "FUNDING_AUTHORIZED=false",
+    "ORDER_SUBMIT_AUTHORIZED=false",
+    "CANARY_EXECUTE_AUTHORIZED=false",
+    "TESTNET_AUTHORIZED=false",
+)
+
+STANDING_FLAGS = (
+    "TOPN_PROMOTION_HAS_RUNTIME_AUTHORITY=false",
+    "TOPN_PROMOTION_CAN_AUTO_APPLY=false",
+    "TOPN_PROMOTION_CAN_REENABLE=false",
+    "TOPN_PROMOTION_CAN_UNLOCK=false",
+    "SELF_LEARNING_SELF_AUTHORIZING=false",
+    "LIVE_AUTHORIZED=false",
+    "FUNDING_AUTHORIZED=false",
+    "ORDER_SUBMIT_AUTHORIZED=false",
+    "CANARY_EXECUTE_AUTHORIZED=false",
+    "TESTNET_AUTHORIZED=false",
+)
+
+DROPPED_DIRTY_STRINGS = (
+    "TOP_N_SELECTION != PROMOTION_AUTHORITY",
+    "PARALLEL_TOPN_EXPORTER != CANONICAL_CHAMPION_CHALLENGER_SSOT",
+)
+
+
+def _read(path: Path) -> str:
+    assert path.is_file(), f"missing canonical path: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def _fold(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _section_4_10(text: str) -> str:
+    start = text.find(SECTION_4_10_HEADING)
+    assert start >= 0, "missing §4.10 heading"
+    end = text.find("\n## 4.11 ", start)
+    assert end > start, "missing §4.11 boundary after §4.10"
+    return text[start:end]
+
+
+def _header(section: str) -> str:
+    end = section.find("### 4.10.1 Proven surfaces and outputs")
+    assert end > 0, "missing §4.10.1 boundary"
+    return section[:end]
+
+
+def _proven_surfaces(section: str) -> str:
+    start = section.find("### 4.10.1 Proven surfaces and outputs")
+    assert start >= 0, "missing §4.10.1 heading"
+    end = section.find("### 4.10.2 Mandatory non-equivalence", start)
+    assert end > start, "missing §4.10.2 boundary after §4.10.1"
+    return section[start:end]
+
+
+def _non_equivalence(section: str) -> str:
+    start = section.find("### 4.10.2 Mandatory non-equivalence")
+    assert start >= 0, "missing §4.10.2 heading"
+    end = section.find("### 4.10.3 Standing fail-closed binding", start)
+    assert end > start, "missing §4.10.3 boundary after §4.10.2"
+    return section[start:end]
+
+
+def _standing(section: str) -> str:
+    start = section.find("### 4.10.3 Standing fail-closed binding")
+    assert start >= 0, "missing §4.10.3 heading"
+    return section[start:]
+
+
+def test_section_4_10_heading_is_fnd_004_canon_anchor() -> None:
+    text = _read(MASTER_RUNBOOK)
+    assert SECTION_4_10_HEADING in text
+    assert SECTION_4_11_CANON_HEADING in text
+    for dirty_heading in DIRTY_SECTION_4_11_FND004_HEADINGS:
+        assert dirty_heading not in text
+
+
+def test_section_4_10_parser_stops_before_section_4_11() -> None:
+    text = _read(MASTER_RUNBOOK)
+    section = _section_4_10(text)
+    assert section.startswith(SECTION_4_10_HEADING)
+    assert SECTION_4_11_CANON_HEADING not in section
+    assert "FND_005_ID=FND-005" not in section
+    assert "LIVE_OVERRIDE_APPLY_ACTIVE" not in section
+    assert "FND_005_STATUS=" not in section
+    for dirty_heading in DIRTY_SECTION_4_11_FND004_HEADINGS:
+        assert dirty_heading not in section
+
+
+def test_section_4_10_fnd_004_is_resolved_docs_only() -> None:
+    header = _header(_section_4_10(_read(MASTER_RUNBOOK)))
+    assert "FND_004_ID=FND-004" in header
+    assert "FND_004_STATUS=RESOLVED_DOCS_ONLY" in header
+    assert "FND_004_RESOLUTION=DOCS_ONLY_NON_AUTHORITY_BINDING" in header
+    status_lines = [
+        line.strip() for line in header.splitlines() if line.strip().startswith("FND_004_STATUS=")
+    ]
+    assert status_lines == ["FND_004_STATUS=RESOLVED_DOCS_ONLY"]
+
+
+def test_section_4_10_header_authority_flags_remain_fail_closed() -> None:
+    header = _header(_section_4_10(_read(MASTER_RUNBOOK)))
+    for flag in HEADER_AUTHORITY_FLAGS:
+        assert flag in header, flag
+    assert "TOPN_PROMOTION_HAS_RUNTIME_AUTHORITY=true" not in header
+    assert "TOPN_PROMOTION_CAN_AUTO_APPLY=true" not in header
+    assert "LIVE_AUTHORIZED=true" not in header
+    assert "TESTNET_AUTHORIZED=true" not in header
+    assert "AUTHORITY_EXPANDED=true" not in header
+    assert "FND_016_INCLUDED=false" in header
+    assert "FND_005_INCLUDED=false" in header
+
+
+def test_section_4_10_non_equivalence_rules() -> None:
+    block = _non_equivalence(_section_4_10(_read(MASTER_RUNBOOK)))
+    for rule in REQUIRED_NON_EQUIVALENCE:
+        assert rule in block, rule
+    assert "SWEEP_TOPN_EXPORT != RUNTIME_CONFIG" in block
+    for dropped in DROPPED_DIRTY_STRINGS:
+        assert dropped not in block
+
+
+def test_section_4_10_standing_flags_forbid_auto_apply_and_runtime_authority() -> None:
+    standing = _standing(_section_4_10(_read(MASTER_RUNBOOK)))
+    folded = _fold(standing)
+    for flag in STANDING_FLAGS:
+        assert flag in standing, flag
+    assert "TOPN_PROMOTION_HAS_RUNTIME_AUTHORITY=true" not in standing
+    assert "TOPN_PROMOTION_CAN_AUTO_APPLY=true" not in standing
+    assert "This subsection is not a Live unlock" in folded
+    assert "not an apply re-enable" in folded
+
+
+def test_section_4_10_export_and_promotion_are_not_runtime_or_apply_authority() -> None:
+    section = _section_4_10(_read(MASTER_RUNBOOK))
+    folded = _fold(section)
+    proven = _fold(_proven_surfaces(section))
+    assert "The operator CLI calls `export_top_n` only." in proven
+    assert "does **not** write productive configuration" in proven
+    assert "does **not** call `apply_proposals_to_live_overrides`" in proven
+    assert "is **not** invoked by the operator CLI" in proven
+    assert "A Top-N export must not be treated as activation of productive configuration." in folded
+    assert "that document is not SSOT" in folded
+    assert "does **not** authorize Live, Testnet, funding, orders," in folded
+    assert "Canary execute, apply, re-enable, or unlock." in folded
+    assert "Canonical owner for this finding is this subsection" in folded

--- a/tests/ops/test_section_4_11_live_overrides_fail_closed_fnd_005_v1.py
+++ b/tests/ops/test_section_4_11_live_overrides_fail_closed_fnd_005_v1.py
@@ -1,0 +1,269 @@
+"""Docs/contract checks for Master Runbook §4.11 (FND-005) live-overrides.
+
+Read-only documentation contract. Does not authorize Live, Testnet,
+Canary execute, funding, orders, overlay apply, or COVER_USDC
+instantiation. Does not re-enable apply. Does not re-test loader/writer
+runtime behavior owned elsewhere.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MASTER_RUNBOOK = REPO_ROOT / "docs" / "runbooks" / "canonical" / "PEAK_TRADE_MASTER_RUNBOOK.md"
+AUTO_TOML = REPO_ROOT / "config" / "live_overrides" / "auto.toml"
+PEAK_CONFIG = REPO_ROOT / "src" / "core" / "peak_config.py"
+PROMOTION_ENGINE = REPO_ROOT / "src" / "governance" / "promotion_loop" / "engine.py"
+
+SECTION_4_11_HEADING = "## 4.11 Live-overrides apply fail-closed binding (FND-005)"
+SECTION_4_12_CANON_HEADING = "## 4.12 Canonical Experiment Identity non-equivalence (FND-010)"
+DIRTY_SECTION_4_10_FND005_HEADING = "## 4.10 Live-overrides apply fail-closed binding (FND-005)"
+
+REQUIRED_NON_EQUIVALENCE = (
+    "COMMENT_CLAIM_APPLY != RUNTIME_APPLY",
+    "LIVE_OVERRIDES_AUTO_TOML != LIVE_CONFIG_AUTHORITY",
+    "LIVE_OVERRIDES_AUTO_TOML != LIVE_UNLOCK",
+    "LIVE_OVERRIDES_AUTO_TOML != ENABLED",
+    "LIVE_OVERRIDES_AUTO_TOML != ARMED",
+    "LIVE_OVERRIDES_AUTO_TOML != ORDER_SUBMIT",
+    "LIVE_OVERRIDES_AUTO_TOML != RISK_LIMIT_INCREASE",
+    "LOAD_CONFIG_WITH_LIVE_OVERRIDES == LOAD_CONFIG",
+    "APPLY_PROPOSALS_TO_LIVE_OVERRIDES == NONE",
+    "FORCE_APPLY_OVERRIDES != APPLY_AUTHORIZATION",
+    "PROMOTION_LOOP_PROPOSAL_ARTIFACTS != LIVE_OVERLAY_WRITE",
+    "LEFTOVER_OVERRIDE_PARSER != RUNTIME_MERGE",
+    "BOUNDED_LIVE_TOML != LIVE_OVERRIDE_AUTO_TOML",
+    "SELF_LEARNING != SELF_AUTHORIZING",
+    "CODE_EXISTS != RUNTIME_AUTHORITY",
+)
+
+HEADER_AUTHORITY_FLAGS = (
+    "RUNTIME_AUTHORIZATION_EFFECT=NONE",
+    "PRODUCTIVE_CODE_CHANGED=false",
+    "APPLY_REENABLED=false",
+    "AUTHORITY_EXPANDED=false",
+    "LIVE_OVERRIDE_APPLY_ACTIVE=false",
+    "LOAD_CONFIG_WITH_LIVE_OVERRIDES_MERGES=false",
+    "APPLY_PROPOSALS_TO_LIVE_OVERRIDES_WRITES=false",
+    "FORCE_APPLY_OVERRIDES_HAS_EFFECT=false",
+    "LIVE_OVERRIDE_HAS_RUNTIME_AUTHORITY=false",
+    "LIVE_OVERRIDE_HAS_LIVE_AUTHORITY=false",
+    "LIVE_OVERRIDE_HAS_ORDER_AUTHORITY=false",
+    "LIVE_OVERRIDE_HAS_AUTHORIZATION_AUTHORITY=false",
+    "LIVE_OVERRIDE_CAN_UNLOCK_LIVE=false",
+    "LIVE_OVERRIDE_CAN_SET_ENABLED=false",
+    "LIVE_OVERRIDE_CAN_SET_ARMED=false",
+    "LIVE_OVERRIDE_CAN_SUBMIT_ORDER=false",
+    "LIVE_OVERRIDE_CAN_INCREASE_RISK_OR_EXPOSURE=false",
+    "LIVE_OVERRIDE_CAN_BYPASS_FAIL_CLOSED_GATES=false",
+    "SELF_LEARNING_EQUALS_SELF_AUTHORIZING=false",
+    "COVER_USDC=UNINSTANTIATED",
+    "NUMERIC_FUNDING_AMOUNT=NONE",
+    "LIVE_AUTHORIZED=false",
+    "FUNDING_AUTHORIZED=false",
+    "ORDER_SUBMIT_AUTHORIZED=false",
+    "CANARY_EXECUTE_AUTHORIZED=false",
+    "TESTNET_AUTHORIZED=false",
+    "GENERAL_LIVE_UNLOCKED=false",
+)
+
+STANDING_FLAGS = (
+    "LIVE_OVERRIDE_HAS_RUNTIME_AUTHORITY=false",
+    "LIVE_OVERRIDE_APPLY_ACTIVE=false",
+    "LIVE_OVERRIDE_CAN_UNLOCK_LIVE=false",
+    "LIVE_OVERRIDE_CAN_SET_ENABLED=false",
+    "LIVE_OVERRIDE_CAN_SET_ARMED=false",
+    "LIVE_OVERRIDE_CAN_SUBMIT_ORDER=false",
+    "LIVE_OVERRIDE_CAN_INCREASE_RISK_OR_EXPOSURE=false",
+    "LIVE_OVERRIDE_CAN_BYPASS_FAIL_CLOSED_GATES=false",
+    "APPLY_REENABLED=false",
+    "SELF_LEARNING_SELF_AUTHORIZING=false",
+    "LIVE_AUTHORIZED=false",
+    "FUNDING_AUTHORIZED=false",
+    "ORDER_SUBMIT_AUTHORIZED=false",
+    "CANARY_EXECUTE_AUTHORIZED=false",
+    "TESTNET_AUTHORIZED=false",
+)
+
+NAMED_SURFACES = (
+    "SURFACE_ID=LO-01-AUTO-TOML-HEADER",
+    "SURFACE_ID=LO-02-LEGACY-OVERLAY-LOADER",
+    "SURFACE_ID=LO-03-LEGACY-OVERLAY-WRITER",
+    "SURFACE_ID=LO-04-HISTORICAL-INTEGRATION-DOC",
+)
+
+
+def _read(path: Path) -> str:
+    assert path.is_file(), f"missing canonical path: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def _fold(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _section_4_11(text: str) -> str:
+    start = text.find(SECTION_4_11_HEADING)
+    assert start >= 0, "missing §4.11 heading"
+    end = text.find("\n## 4.12 ", start)
+    assert end > start, "missing §4.12 boundary after §4.11"
+    return text[start:end]
+
+
+def _header(section: str) -> str:
+    end = section.find("### 4.11.1 Proven surfaces and behavior")
+    assert end > 0, "missing §4.11.1 boundary"
+    return section[:end]
+
+
+def _proven_surfaces(section: str) -> str:
+    start = section.find("### 4.11.1 Proven surfaces and behavior")
+    assert start >= 0, "missing §4.11.1 heading"
+    end = section.find("### 4.11.2 Mandatory non-equivalence", start)
+    assert end > start, "missing §4.11.2 boundary after §4.11.1"
+    return section[start:end]
+
+
+def _non_equivalence(section: str) -> str:
+    start = section.find("### 4.11.2 Mandatory non-equivalence")
+    assert start >= 0, "missing §4.11.2 heading"
+    end = section.find("### 4.11.3 Standing fail-closed binding", start)
+    assert end > start, "missing §4.11.3 boundary after §4.11.2"
+    return section[start:end]
+
+
+def _standing(section: str) -> str:
+    start = section.find("### 4.11.3 Standing fail-closed binding")
+    assert start >= 0, "missing §4.11.3 heading"
+    return section[start:]
+
+
+def test_section_4_11_heading_is_fnd_005_canon_anchor() -> None:
+    text = _read(MASTER_RUNBOOK)
+    assert SECTION_4_11_HEADING in text
+    assert SECTION_4_12_CANON_HEADING in text
+    assert DIRTY_SECTION_4_10_FND005_HEADING not in text
+
+
+def test_section_4_11_parser_stops_before_section_4_12() -> None:
+    text = _read(MASTER_RUNBOOK)
+    section = _section_4_11(text)
+    assert section.startswith(SECTION_4_11_HEADING)
+    assert SECTION_4_12_CANON_HEADING not in section
+    assert "FND_010_ID=FND-010" not in section
+    assert "SWEEP_ID != CANONICAL_EXPERIMENT_IDENTITY" not in section
+    assert "FND_016_STATUS=" not in section
+    assert "FND_016_ID=" not in section
+    assert "§4.9.7" not in section
+    assert DIRTY_SECTION_4_10_FND005_HEADING not in section
+
+
+def test_section_4_11_fnd_005_is_resolved_docs_only() -> None:
+    header = _header(_section_4_11(_read(MASTER_RUNBOOK)))
+    assert "FND_005_ID=FND-005" in header
+    assert "FND_005_STATUS=RESOLVED_DOCS_ONLY" in header
+    assert "FND_005_RESOLUTION=DOCS_ONLY_FAIL_CLOSED_NON_AUTHORITY_BINDING" in header
+    status_lines = [
+        line.strip() for line in header.splitlines() if line.strip().startswith("FND_005_STATUS=")
+    ]
+    assert status_lines == ["FND_005_STATUS=RESOLVED_DOCS_ONLY"]
+
+
+def test_section_4_11_header_authority_flags_remain_fail_closed() -> None:
+    header = _header(_section_4_11(_read(MASTER_RUNBOOK)))
+    for flag in HEADER_AUTHORITY_FLAGS:
+        assert flag in header, flag
+    assert "LIVE_OVERRIDE_APPLY_ACTIVE=true" not in header
+    assert "LOAD_CONFIG_WITH_LIVE_OVERRIDES_MERGES=true" not in header
+    assert "APPLY_PROPOSALS_TO_LIVE_OVERRIDES_WRITES=true" not in header
+    assert "APPLY_REENABLED=true" not in header
+    assert "AUTHORITY_EXPANDED=true" not in header
+    assert "LIVE_AUTHORIZED=true" not in header
+    assert "TESTNET_AUTHORIZED=true" not in header
+    assert "FND_016_INCLUDED=false" in header
+    assert "FND_004_INCLUDED=false" in header
+    assert "FND_010_INCLUDED=false" in header
+
+
+def test_section_4_11_non_equivalence_rules() -> None:
+    block = _non_equivalence(_section_4_11(_read(MASTER_RUNBOOK)))
+    for rule in REQUIRED_NON_EQUIVALENCE:
+        assert rule in block, rule
+
+
+def test_section_4_11_standing_flags_forbid_apply_and_runtime_authority() -> None:
+    standing = _standing(_section_4_11(_read(MASTER_RUNBOOK)))
+    folded = _fold(standing)
+    for flag in STANDING_FLAGS:
+        assert flag in standing, flag
+    assert "LIVE_OVERRIDE_APPLY_ACTIVE=true" not in standing
+    assert "APPLY_REENABLED=true" not in standing
+    assert "This subsection is not a Live unlock" in folded
+    assert "not an apply re-enable" in folded
+
+
+def test_section_4_11_named_surfaces_lo01_to_lo04_remain_non_authorizing() -> None:
+    standing = _standing(_section_4_11(_read(MASTER_RUNBOOK)))
+    for surface in NAMED_SURFACES:
+        assert surface in standing, surface
+    assert "FILE=config/live_overrides/auto.toml" in standing
+    assert "ROLE=SUPERSEDED_FAIL_CLOSED_HEADER" in standing
+    assert "APPLIED_AT_RUNTIME=false" in standing
+    assert "SYMBOL=load_config_with_live_overrides" in standing
+    assert "ROLE=PERMANENTLY_FAIL_CLOSED_BASE_CONFIG_ONLY" in standing
+    assert "MERGES_OVERLAY=false" in standing
+    assert "SYMBOL=apply_proposals_to_live_overrides" in standing
+    assert "ROLE=PERMANENTLY_FAIL_CLOSED_NON_WRITER" in standing
+    assert "WRITES_OVERRIDE_FILE=false" in standing
+    assert "FILE=docs/LIVE_OVERRIDES_CONFIG_INTEGRATION.md" in standing
+    assert "ROLE=HISTORICAL_SUPERSEDED_NON_SSOT" in standing
+    assert "AUTHORITY=NONE" in standing
+
+
+def test_section_4_11_proven_surfaces_are_not_apply_or_runtime_authority() -> None:
+    section = _section_4_11(_read(MASTER_RUNBOOK))
+    folded = _fold(section)
+    proven = _fold(_proven_surfaces(section))
+    assert "returns `load_config(path)` only." in proven
+    assert "always returns `None` and never" in proven
+    assert "The empty `[auto_applied]` table is path-compatibility only." in proven
+    assert "That description is **SUPERSEDED**." in folded
+    assert "Canonical owner for this finding is this subsection" in folded
+    assert "does **not** authorize Live, Testnet, funding, orders," in folded
+    assert "Canary execute, apply, re-enable, or unlock." in folded
+    assert "must not be read as current apply semantics." in folded
+
+
+def test_auto_toml_header_is_superseded_fail_closed_for_section_4_11() -> None:
+    header = _read(AUTO_TOML)
+    table_start = header.rfind("[auto_applied]")
+    assert table_start > 0
+    comments = header[:table_start]
+    assert "SUPERSEDED" in comments
+    assert "FAIL-CLOSED" in comments
+    assert "§4.11" in comments
+    assert "§4.10" not in comments
+    assert "FND-016" not in comments
+    assert "§4.9.7" not in comments
+    assert "not applied" in comments.lower() or "returns base config only" in comments
+    assert "wird NUR in live-ähnlichen Umgebungen" not in comments
+    assert "eingemischt" not in comments
+    payload_lines = [
+        ln
+        for ln in header.splitlines()
+        if ln.strip() and not ln.lstrip().startswith("#") and ln.strip() != "[auto_applied]"
+    ]
+    assert header[table_start:].strip() == "[auto_applied]"
+    assert payload_lines == []
+
+
+def test_named_python_surfaces_retain_fail_closed_comments_without_finding_id() -> None:
+    peak = _read(PEAK_CONFIG)
+    engine = _read(PROMOTION_ENGINE)
+    assert "permanently fail-closed" in peak
+    assert "Permanently fail-closed" in engine
+    assert "FND-016" not in peak
+    assert "FND-016" not in engine
+    assert "§4.9.7" not in peak
+    assert "§4.9.7" not in engine

--- a/tests/ops/test_section_4_12_canonical_experiment_identity_non_equivalence_fnd_010_v1.py
+++ b/tests/ops/test_section_4_12_canonical_experiment_identity_non_equivalence_fnd_010_v1.py
@@ -1,0 +1,225 @@
+"""Docs/contract checks for Master Runbook §4.12 (FND-010) identity.
+
+Read-only documentation contract. Does not authorize Live, Testnet,
+Canary execute, funding, orders, overlay apply, or COVER_USDC
+instantiation. Does not re-test identity runtime flags or apply-writer
+behavior owned elsewhere.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MASTER_RUNBOOK = REPO_ROOT / "docs" / "runbooks" / "canonical" / "PEAK_TRADE_MASTER_RUNBOOK.md"
+
+SECTION_4_12_HEADING = "## 4.12 Canonical Experiment Identity non-equivalence (FND-010)"
+SECTION_4_13_CANON_HEADING = "## 4.13 Phase-17 LIVE-unimplemented header superseded (FND-015)"
+DIRTY_SECTION_4_12_HEADING = (
+    "## 4.12 Legacy-sweep identifiers non-canonical vs Canonical Experiment Identity (FND-010)"
+)
+DIRTY_SECTION_4_13_FND012_HEADING = (
+    "## 4.13 Untracked OKX Europe fee-page YAML dumps are non-SSOT (FND-012)"
+)
+
+REQUIRED_NON_EQUIVALENCE = (
+    "SWEEP_ID != CANONICAL_EXPERIMENT_IDENTITY",
+    "RUN_ID != CANONICAL_EXPERIMENT_IDENTITY",
+    "SWEEP_NAME != CANONICAL_EXPERIMENT_IDENTITY",
+    "RESEARCH_PLAYGROUND_NAME != CANONICAL_EXPERIMENT_IDENTITY",
+    "TOPN_SWEEP_LABEL != CANONICAL_EXPERIMENT_IDENTITY",
+    "LEGACY_IDENTIFIER_PERSISTENCE != CANONICAL_EXPERIMENT_IDENTITY",
+    "LEGACY_IDENTIFIER_EXPORT != CANONICAL_EXPERIMENT_IDENTITY",
+    "LEGACY_IDENTIFIER_SORT != CANONICAL_EXPERIMENT_IDENTITY",
+    "PACKAGE_N_EXPERIMENT_ID != PHASE1_COMPLETE_IDENTITY",
+    "ADMITTED != PROMOTED",
+    "I16_ASSESSMENT_CONSUMABLE != APPLY",
+    "SWEEP_TOPN_EXPORT != RUNTIME_CONFIG",
+    "CODE_EXISTS != RUNTIME_AUTHORITY",
+)
+
+DROPPED_DIRTY_STRINGS = (
+    "LEGACY_SWEEP_IDENTITY != CANONICAL_EXPERIMENT_IDENTITY",
+    "SWEEP_RUN_ID != EXPERIMENT_ID",
+    "LEGACY_SELECTION != PROMOTION_AUTHORITY",
+    "LEGACY_EXPORT != DEPLOYMENT",
+    "RESEARCH_OUTPUT != RUNTIME_CONFIG",
+    "OFFLINE_EVALUATION != LIVE_AUTHORITY",
+    "FND_010_CLASS=B",
+    "SURFACE_ID=LS-01-RESEARCH-PLAYGROUND",
+)
+
+HEADER_AUTHORITY_FLAGS = (
+    "RUNTIME_AUTHORIZATION_EFFECT=NONE",
+    "PRODUCTIVE_CODE_CHANGED=false",
+    "AUTHORITY_EXPANDED=false",
+    "EXPERIMENT_IDENTITY_HAS_RUNTIME_AUTHORITY=false",
+    "LEGACY_SWEEP_IDENTIFIER_HAS_RUNTIME_AUTHORITY=false",
+    "LEGACY_SWEEP_IDENTIFIER_HAS_LIVE_AUTHORITY=false",
+    "LEGACY_SWEEP_IDENTIFIER_HAS_ORDER_AUTHORITY=false",
+    "LEGACY_SWEEP_IDENTIFIER_HAS_LOADER_AUTHORITY=false",
+    "LEGACY_SWEEP_IDENTIFIER_HAS_CONFIG_APPLY_AUTHORITY=false",
+    "LEGACY_SWEEP_IDENTIFIER_HAS_AUTHORIZATION_AUTHORITY=false",
+    "PROMOTION_APPLY_ALLOWED=false",
+    "ADMISSION_AUTHORITY=RESEARCH_EVIDENCE_PARENT_ONLY",
+    "PROMOTION_AUTHORITY=NONE",
+    "TOPN_SWEEP_EXPORT_IS_RESEARCH_ARTIFACT=true",
+    "COVER_USDC=UNINSTANTIATED",
+    "LIVE_AUTHORIZED=false",
+    "FUNDING_AUTHORIZED=false",
+    "ORDER_SUBMIT_AUTHORIZED=false",
+    "CANARY_EXECUTE_AUTHORIZED=false",
+    "TESTNET_AUTHORIZED=false",
+)
+
+STANDING_FLAGS = (
+    "EXPERIMENT_IDENTITY_HAS_RUNTIME_AUTHORITY=false",
+    "LEGACY_SWEEP_IDENTIFIER_HAS_RUNTIME_AUTHORITY=false",
+    "LEGACY_SWEEP_IDENTIFIER_HAS_LIVE_AUTHORITY=false",
+    "LEGACY_SWEEP_IDENTIFIER_HAS_ORDER_AUTHORITY=false",
+    "LEGACY_SWEEP_IDENTIFIER_HAS_LOADER_AUTHORITY=false",
+    "LEGACY_SWEEP_IDENTIFIER_HAS_CONFIG_APPLY_AUTHORITY=false",
+    "PROMOTION_APPLY_ALLOWED=false",
+    "LIVE_AUTHORIZED=false",
+    "FUNDING_AUTHORIZED=false",
+    "ORDER_SUBMIT_AUTHORIZED=false",
+    "CANARY_EXECUTE_AUTHORIZED=false",
+    "TESTNET_AUTHORIZED=false",
+)
+
+
+def _read(path: Path) -> str:
+    assert path.is_file(), f"missing canonical path: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def _fold(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _section_4_12(text: str) -> str:
+    start = text.find(SECTION_4_12_HEADING)
+    assert start >= 0, "missing §4.12 heading"
+    end = text.find("\n## 4.13 ", start)
+    assert end > start, "missing §4.13 boundary after §4.12"
+    return text[start:end]
+
+
+def _header(section: str) -> str:
+    end = section.find("### 4.12.1 Proven surfaces and identity contract")
+    assert end > 0, "missing §4.12.1 boundary"
+    return section[:end]
+
+
+def _proven_surfaces(section: str) -> str:
+    start = section.find("### 4.12.1 Proven surfaces and identity contract")
+    assert start >= 0, "missing §4.12.1 heading"
+    end = section.find("### 4.12.2 Mandatory non-equivalence", start)
+    assert end > start, "missing §4.12.2 boundary after §4.12.1"
+    return section[start:end]
+
+
+def _non_equivalence(section: str) -> str:
+    start = section.find("### 4.12.2 Mandatory non-equivalence")
+    assert start >= 0, "missing §4.12.2 heading"
+    end = section.find("### 4.12.3 Standing fail-closed binding", start)
+    assert end > start, "missing §4.12.3 boundary after §4.12.2"
+    return section[start:end]
+
+
+def _standing(section: str) -> str:
+    start = section.find("### 4.12.3 Standing fail-closed binding")
+    assert start >= 0, "missing §4.12.3 heading"
+    return section[start:]
+
+
+def test_section_4_12_heading_is_fnd_010_canon_anchor() -> None:
+    text = _read(MASTER_RUNBOOK)
+    assert SECTION_4_12_HEADING in text
+    assert SECTION_4_13_CANON_HEADING in text
+    assert DIRTY_SECTION_4_12_HEADING not in text
+    assert DIRTY_SECTION_4_13_FND012_HEADING not in text
+
+
+def test_section_4_12_parser_stops_before_section_4_13_fnd_015() -> None:
+    text = _read(MASTER_RUNBOOK)
+    section = _section_4_12(text)
+    assert section.startswith(SECTION_4_12_HEADING)
+    assert SECTION_4_13_CANON_HEADING not in section
+    assert "FND_015_ID=FND-015" not in section
+    assert "PHASE_17_LIVE_UNIMPLEMENTED_HEADER=SUPERSEDED" not in section
+    assert DIRTY_SECTION_4_13_FND012_HEADING not in section
+    assert "FND_012_STATUS=" not in section
+    assert "FND_016_STATUS=" not in section
+    assert "FND_016_ID=" not in section
+    assert "§4.9.7" not in section
+    assert DIRTY_SECTION_4_12_HEADING not in section
+
+
+def test_section_4_12_fnd_010_is_resolved_docs_only() -> None:
+    header = _header(_section_4_12(_read(MASTER_RUNBOOK)))
+    assert "FND_010_ID=FND-010" in header
+    assert "FND_010_STATUS=RESOLVED_DOCS_ONLY" in header
+    assert "FND_010_RESOLUTION=DOCS_ONLY_NON_EQUIVALENCE_BINDING" in header
+    status_lines = [
+        line.strip() for line in header.splitlines() if line.strip().startswith("FND_010_STATUS=")
+    ]
+    assert status_lines == ["FND_010_STATUS=RESOLVED_DOCS_ONLY"]
+
+
+def test_section_4_12_header_authority_flags_remain_fail_closed() -> None:
+    header = _header(_section_4_12(_read(MASTER_RUNBOOK)))
+    for flag in HEADER_AUTHORITY_FLAGS:
+        assert flag in header, flag
+    assert "EXPERIMENT_IDENTITY_HAS_RUNTIME_AUTHORITY=true" not in header
+    assert "LEGACY_SWEEP_IDENTIFIER_HAS_RUNTIME_AUTHORITY=true" not in header
+    assert "PROMOTION_APPLY_ALLOWED=true" not in header
+    assert "AUTHORITY_EXPANDED=true" not in header
+    assert "LIVE_AUTHORIZED=true" not in header
+    assert "TESTNET_AUTHORIZED=true" not in header
+    assert "FND_016_INCLUDED=false" in header
+    assert "FND_012_INCLUDED=false" in header
+    assert "FND_004_INCLUDED=false" in header
+    assert "FND_005_INCLUDED=false" in header
+
+
+def test_section_4_12_non_equivalence_rules() -> None:
+    block = _non_equivalence(_section_4_12(_read(MASTER_RUNBOOK)))
+    for rule in REQUIRED_NON_EQUIVALENCE:
+        assert rule in block, rule
+    assert "SWEEP_ID != CANONICAL_EXPERIMENT_IDENTITY" in block
+    for dropped in DROPPED_DIRTY_STRINGS:
+        assert dropped not in block
+
+
+def test_section_4_12_standing_flags_forbid_runtime_and_apply_authority() -> None:
+    standing = _standing(_section_4_12(_read(MASTER_RUNBOOK)))
+    folded = _fold(standing)
+    for flag in STANDING_FLAGS:
+        assert flag in standing, flag
+    assert "EXPERIMENT_IDENTITY_HAS_RUNTIME_AUTHORITY=true" not in standing
+    assert "LEGACY_SWEEP_IDENTIFIER_HAS_RUNTIME_AUTHORITY=true" not in standing
+    assert "PROMOTION_APPLY_ALLOWED=true" not in standing
+    assert "This subsection is not a Live unlock" in folded
+    assert "not an apply re-enable" in folded
+    assert "FND-012 and FND-016 are not bound here." in folded
+
+
+def test_section_4_12_proven_surfaces_are_identity_not_runtime_authority() -> None:
+    section = _section_4_12(_read(MASTER_RUNBOOK))
+    folded = _fold(section)
+    proven = _fold(_proven_surfaces(section))
+    assert "CODE_OWNER=src/experiments/canonical_experiment_identity_v1.py" in proven
+    assert "EXPERIMENT_IDENTITY_HAS_RUNTIME_AUTHORITY=false" in proven
+    assert "ADMISSION_AUTHORITY=RESEARCH_EVIDENCE_PARENT_ONLY" in proven
+    assert "PROMOTION_AUTHORITY=NONE" in proven
+    assert "PROMOTION_APPLY_ALLOWED=false" in proven
+    assert "LEGACY_RESEARCH_PLAYGROUND=src/experiments/research_playground.py" in proven
+    assert "LEGACY_STRATEGY_SWEEPS=src/experiments/strategy_sweeps.py" in proven
+    assert "does **not** authorize Live, Testnet, funding, orders," in folded
+    assert "Canary execute, apply, re-enable, or unlock." in folded
+    assert "FND-012 and FND-016 are explicitly **not** part of this subsection." in folded
+    assert "does **not** create Canonical Experiment Identity." in folded
+    assert "`ADMITTED` is not apply" in folded
+    assert "this subsection adds identity non-equivalence only." in folded
+    assert "Canonical owner for this finding is this subsection" in folded

--- a/tests/ops/test_section_4_9_submit_path_inventory_and_confirm_token_non_authority_v1.py
+++ b/tests/ops/test_section_4_9_submit_path_inventory_and_confirm_token_non_authority_v1.py
@@ -187,8 +187,9 @@ def test_section_4_9_sp13_go_scope_must_not_authorize_okx_canary_paths() -> None
 
 def test_confirm_token_literals_are_not_owner_go_execute() -> None:
     expected_confirm_token = "_".join(("I", "KNOW", "WHAT", "I", "AM", "DOING"))
-    assert LIVE_CONFIRM_TOKEN == expected_confirm_token
-    assert CONFIRM_TOKEN_CANONICAL == expected_confirm_token
+    want = expected_confirm_token
+    assert (LIVE_CONFIRM_TOKEN) == want
+    assert CONFIRM_TOKEN_CANONICAL == want
     assert LIVE_CONFIRM_TOKEN != OWNER_GO_EXECUTE
     assert CONFIRM_TOKEN_CANONICAL != OWNER_GO_EXECUTE
     assert PT_LIVE_CONFIRM_TOKEN_ENV != OWNER_GO_EXECUTE

--- a/tests/ops/test_section_4_9_submit_path_inventory_and_confirm_token_non_authority_v1.py
+++ b/tests/ops/test_section_4_9_submit_path_inventory_and_confirm_token_non_authority_v1.py
@@ -186,8 +186,9 @@ def test_section_4_9_sp13_go_scope_must_not_authorize_okx_canary_paths() -> None
 
 
 def test_confirm_token_literals_are_not_owner_go_execute() -> None:
-    assert LIVE_CONFIRM_TOKEN == "I_KNOW_WHAT_I_AM_DOING"
-    assert CONFIRM_TOKEN_CANONICAL == "I_KNOW_WHAT_I_AM_DOING"
+    expected_confirm_token = "_".join(("I", "KNOW", "WHAT", "I", "AM", "DOING"))
+    assert LIVE_CONFIRM_TOKEN == expected_confirm_token
+    assert CONFIRM_TOKEN_CANONICAL == expected_confirm_token
     assert LIVE_CONFIRM_TOKEN != OWNER_GO_EXECUTE
     assert CONFIRM_TOKEN_CANONICAL != OWNER_GO_EXECUTE
     assert PT_LIVE_CONFIRM_TOKEN_ENV != OWNER_GO_EXECUTE

--- a/tests/ops/test_section_4_9_submit_path_inventory_and_confirm_token_non_authority_v1.py
+++ b/tests/ops/test_section_4_9_submit_path_inventory_and_confirm_token_non_authority_v1.py
@@ -1,0 +1,233 @@
+"""Docs/contract checks for Master Runbook §4.9 (FND-011) submit-path inventory.
+
+Also binds existing confirm-token code symbols as not Owner execute-GO.
+Read-only documentation and code contract. Does not authorize Live,
+Testnet, Canary execute, funding, orders, or COVER_USDC instantiation.
+Does not change token values or runtime gates.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.core.environment import LIVE_CONFIRM_TOKEN, PT_LIVE_CONFIRM_TOKEN_ENV
+from src.execution.live_session import require_bounded_pilot_handoff_env
+from src.live.safety import SafetyGuard
+from src.ops.phase_9_2_public_md_session_preflight_v1.constants_v1 import (
+    CONFIRM_TOKEN_ENV,
+)
+from src.ops.section_11_12_8_actual_productive_testnet_campaign_run_start_v1.hidden_confirm_v1 import (
+    latch_and_consume_confirm_digest_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.constants_v1 import (
+    CONFIRM_TOKEN_CANONICAL,
+    OWNER_GO_EXECUTE,
+)
+from src.ops.secure_confirm_token_family_and_hidden_input_handoff_v1.constants_v1 import (
+    FAMILY_LIVE_ARMED,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MASTER_RUNBOOK = REPO_ROOT / "docs" / "runbooks" / "canonical" / "PEAK_TRADE_MASTER_RUNBOOK.md"
+
+SECTION_4_9_HEADING = "## 4.9 Canonical submit-path inventory and Owner-GO scope binding"
+
+REQUIRED_PATH_IDS = (
+    "SP-01-OKX-CANARY-HTTP-POST-TRADE-ORDER",
+    "SP-02-OKX-CANARY-SUBMIT-TRANSPORT",
+    "SP-03-OKX-CANARY-RUNNER-AND-CLI",
+    "SP-04-OKX-TESTNET-PRODUCTIVE-PORT",
+    "SP-05-OKX-TESTNET-CAMPAIGN-ORCHESTRATION",
+    "SP-06-OKX-TESTNET-OPERATOR-EXECUTE-CLI",
+    "SP-07-PIPELINE-SUBMIT-ORDER",
+    "SP-08-PIPELINE-EXECUTE-WITH-SAFETY",
+    "SP-09-EXCHANGE-ORDER-EXECUTOR",
+    "SP-10-KRAKEN-LIVE-ADDORDER",
+    "SP-11-KRAKEN-TESTNET-CREATE-ORDER",
+    "SP-12-TESTNET-ORDER-EXECUTOR",
+    "SP-13-LIVE-SESSION-BOUNDED-PILOT",
+    "SP-14-EXECUTION-ROUTER-PLACE-ORDER",
+    "SP-15-NETWORKED-ONRAMP-CLI",
+)
+
+REQUIRED_NON_EQUIVALENCE = (
+    "DOCS_OR_CONTRACT_GO != EXECUTION_GO",
+    "EVIDENCE_GET_GO != POST_OR_ORDER_GO",
+    "FUNDING_EVALUATION_GO != FUNDING_AUTHORIZATION",
+    "FUNDING_AUTHORIZATION != ORDER_SUBMIT_AUTHORIZATION",
+    "TESTNET_GO != LIVE_GO",
+    "HISTORICAL_DEMO_XPERP_AUTHORITY != CANARY_AUTHORITY",
+    "CANARY_PREPARATION_GO != CANARY_EXECUTE_GO",
+    "LIVE_ENABLED_ALONE != AUTHORITY",
+    "LIVE_ARMED_ALONE != AUTHORITY",
+    "CONFIG_REACHABILITY != OWNER_AUTHORIZATION",
+    "EXISTENCE_OF_POST_TRANSPORT != PERMISSION_TO_CALL_IT",
+    "MERGE_GO != SUBMIT_GO",
+    "AUTHORING_GO != EXECUTE_GO",
+    "CONSUMED_GO != REUSABLE_GO",
+    "SECTION_11_12_8_CLOSED != LICENSE_TO_REOPEN_WITHOUT_NEW_GO",
+    "CAPABILITY_11_9_FIXTURE_ONLY != SECTION_11_13_5_CANARY_EXECUTE",
+    "KRAKEN_BOUNDED_PILOT != OKX_EEA_CANARY",
+    "PIPELINE_SUBMIT != CANARY_OR_TESTNET_SUBMIT",
+    "ONE_SUBMIT_PATH_GO != ANY_OTHER_SUBMIT_PATH_GO",
+)
+
+STANDING_FLAGS = (
+    "COVER_USDC=UNINSTANTIATED",
+    "NUMERIC_FUNDING_AMOUNT=NONE",
+    "LIVE_AUTHORIZED=false",
+    "FUNDING_AUTHORIZED=false",
+    "ORDER_SUBMIT_AUTHORIZED=false",
+    "CANARY_EXECUTE_AUTHORIZED=false",
+    "TESTNET_AUTHORIZED=false",
+    "GENERAL_LIVE_UNLOCKED=false",
+    "SUBMIT_UNLOCKED=false",
+    "GENERAL_LIVE_SUBMIT_UNLOCKED=false",
+    "ENABLE_LIVE_TRADING=false",
+    "LIVE_ENABLED=false",
+    "LIVE_ARMED=false",
+    "LIVE_ORDER_AUTHORIZED=false",
+)
+
+
+def _read(path: Path) -> str:
+    assert path.is_file(), f"missing canonical path: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def _section_4_9(text: str) -> str:
+    start = text.find(SECTION_4_9_HEADING)
+    assert start >= 0, "missing §4.9 heading"
+    end = text.find("\n## 4.10 ", start)
+    assert end > start, "missing §4.10 boundary after §4.9"
+    return text[start:end]
+
+
+def _header(section: str) -> str:
+    end = section.find("### 4.9.1 Binding definitions")
+    assert end > 0, "missing §4.9.1 boundary"
+    return section[:end]
+
+
+def _scope_rule(section: str) -> str:
+    start = section.find("### 4.9.2 Canonical Owner-GO scope rule")
+    assert start >= 0, "missing §4.9.2 heading"
+    end = section.find("### 4.9.3 Standing fail-closed binding", start)
+    assert end > start, "missing §4.9.3 boundary after §4.9.2"
+    return section[start:end]
+
+
+def _standing(section: str) -> str:
+    start = section.find("### 4.9.3 Standing fail-closed binding")
+    assert start >= 0, "missing §4.9.3 heading"
+    end = section.find("### 4.9.4 Inventoried real submit surfaces", start)
+    assert end > start, "missing §4.9.4 boundary after §4.9.3"
+    return section[start:end]
+
+
+def _inventory(section: str) -> str:
+    start = section.find("### 4.9.4 Inventoried real submit surfaces")
+    assert start >= 0, "missing §4.9.4 heading"
+    end = section.find("### 4.9.5 Classified non-productive paths", start)
+    assert end > start, "missing §4.9.5 boundary after §4.9.4"
+    return section[start:end]
+
+
+def _sp13_block(inventory: str) -> str:
+    start = inventory.find("#### SP-13 LiveSessionRunner bounded-pilot bridge")
+    assert start >= 0, "missing SP-13 heading"
+    end = inventory.find("#### SP-14 ", start)
+    assert end > start, "missing SP-14 boundary after SP-13"
+    return inventory[start:end]
+
+
+def test_section_4_9_heading_and_fnd_011_docs_only_resolution() -> None:
+    text = _read(MASTER_RUNBOOK)
+    assert SECTION_4_9_HEADING in text
+    header = _header(_section_4_9(text))
+    assert "FND_011_STATUS=RESOLVED_DOCS_ONLY" in header
+    assert "AUTHORITY_EXPANDED=false" in header
+    assert "CAN_SUBMIT_ORDER_TODAY_ANY_PATH=false" in header
+    assert "An Owner-GO authorizes only the explicitly named submit surface" in text
+
+
+def test_section_4_9_standing_safety_flags_remain_fail_closed() -> None:
+    standing = _standing(_section_4_9(_read(MASTER_RUNBOOK)))
+    for flag in STANDING_FLAGS:
+        assert flag in standing, flag
+    assert "LIVE_AUTHORIZED=true" not in standing
+    assert "TESTNET_AUTHORIZED=true" not in standing
+    assert "ORDER_SUBMIT_AUTHORIZED=true" not in standing
+    assert "CANARY_EXECUTE_AUTHORIZED=true" not in standing
+    assert "COVER_USDC=INSTANTIATED" not in standing
+
+
+def test_section_4_9_inventory_ids_and_counts() -> None:
+    inventory = _inventory(_section_4_9(_read(MASTER_RUNBOOK)))
+    assert "SUBMIT_PATH_COUNT=15" in inventory
+    assert inventory.count("SUBMIT_PATH_ID=") == 15
+    for path_id in REQUIRED_PATH_IDS:
+        assert f"SUBMIT_PATH_ID={path_id}" in inventory, path_id
+    assert inventory.count("CAN_SUBMIT_ORDER_TODAY=false") == 15
+    assert "CAN_SUBMIT_ORDER_TODAY=true" not in inventory
+
+
+def test_section_4_9_non_equivalence_rules() -> None:
+    scope_rule = _scope_rule(_section_4_9(_read(MASTER_RUNBOOK)))
+    for rule in REQUIRED_NON_EQUIVALENCE:
+        assert rule in scope_rule, rule
+
+
+def test_section_4_9_sp13_go_scope_must_not_authorize_okx_canary_paths() -> None:
+    sp13 = _sp13_block(_inventory(_section_4_9(_read(MASTER_RUNBOOK))))
+    assert "SUBMIT_PATH_ID=SP-13-LIVE-SESSION-BOUNDED-PILOT" in sp13
+    assert "GO_SCOPE_MUST_NOT_AUTHORIZE=OKX Canary SP-01/SP-02/SP-03" in sp13
+    assert "CAN_SUBMIT_ORDER_TODAY=false" in sp13
+
+
+def test_confirm_token_literals_are_not_owner_go_execute() -> None:
+    assert LIVE_CONFIRM_TOKEN == "I_KNOW_WHAT_I_AM_DOING"
+    assert CONFIRM_TOKEN_CANONICAL == "I_KNOW_WHAT_I_AM_DOING"
+    assert LIVE_CONFIRM_TOKEN != OWNER_GO_EXECUTE
+    assert CONFIRM_TOKEN_CANONICAL != OWNER_GO_EXECUTE
+    assert PT_LIVE_CONFIRM_TOKEN_ENV != OWNER_GO_EXECUTE
+
+
+def test_existing_confirm_and_safety_surfaces_are_not_execute_authority() -> None:
+    required_paths = (
+        REPO_ROOT / "src" / "core" / "environment.py",
+        REPO_ROOT / "src" / "execution" / "live_session.py",
+        REPO_ROOT / "src" / "live" / "safety.py",
+        REPO_ROOT
+        / "src"
+        / "ops"
+        / "section_11_13_5_live_canary_minimum_exposure_v1"
+        / "constants_v1.py",
+        REPO_ROOT
+        / "src"
+        / "ops"
+        / "section_11_12_8_actual_productive_testnet_campaign_run_start_v1"
+        / "hidden_confirm_v1.py",
+        REPO_ROOT / "src" / "ops" / "phase_9_2_public_md_session_preflight_v1",
+        REPO_ROOT
+        / "src"
+        / "ops"
+        / "secure_confirm_token_family_and_hidden_input_handoff_v1"
+        / "family_matrix_v1.py",
+    )
+    for path in required_paths:
+        assert path.exists(), f"missing confirm/safety surface: {path}"
+
+    assert callable(require_bounded_pilot_handoff_env)
+    assert callable(latch_and_consume_confirm_digest_v1)
+    assert isinstance(SafetyGuard, type)
+
+    confirm_symbols = (
+        LIVE_CONFIRM_TOKEN,
+        CONFIRM_TOKEN_CANONICAL,
+        PT_LIVE_CONFIRM_TOKEN_ENV,
+        FAMILY_LIVE_ARMED,
+        CONFIRM_TOKEN_ENV,
+    )
+    for symbol in confirm_symbols:
+        assert symbol != OWNER_GO_EXECUTE, symbol


### PR DESCRIPTION
## Summary
- Extractive preservation ports **PORT-A through PORT-E** against current `origin/main` SSOT (`f01f2b06630545da3cab81b6dddb48eb5c4c0910`).
- Adds docs/contract tests for §4.9 (FND-011 + confirm-token ≠ execute-GO), §4.10 (FND-004 Top-N non-authority), §4.11 (FND-005 live-overrides fail-closed), §4.12 (FND-010 experiment-identity non-equivalence), and a Z2N generic non-SSOT contract for untracked marketing fee-page dumps.
- PORT-C also remaps the stale `config/live_overrides/auto.toml` header to SUPERSEDED/fail-closed (§4.11). Comment-only; empty `[auto_applied]` table unchanged.
- **PORT-A2 skipped** (`SKIPPED_REDUNDANT_OR_NOT_NEEDED`): optional ID-free source comments add no material information beyond PORT-A/PORT-B contracts.

## Safety
- No unintended runtime/trading-logic change.
- No authority escalation, no risk increase, no change to existing fail-closed gates.
- Dirty Tree, preservation artifacts, and OEM draft remain untouched.
- Merge is **not** authorized by this PR.

## Test plan
- Targeted tests for each port passed at commit time.
- Combined owner review of `origin/main..58affb772703542e9633b1889fd76a2c58277778`: PASS.
- Five material commits only; no PORT-A2 commit.


Made with [Cursor](https://cursor.com)