### PR TITLE
ci: split operator-verify install tooling to bound apt stall

### DIFF
--- a/.github/workflows/ci-operator-verify-registry.yml
+++ b/.github/workflows/ci-operator-verify-registry.yml
@@ -10,6 +10,11 @@ permissions:
 jobs:
   operator-verify:
     runs-on: ubuntu-latest
+    # Observed successful Attempt 2 (run 32299845303) finished in ~5.5 minutes
+    # including slow apt (Azure mirror Ign + archive.ubuntu.com fallback).
+    # Bound the job well below the GitHub 360-minute default so a future
+    # apt/pip stall cannot remain in_progress indefinitely.
+    timeout-minutes: 15
     permissions:
       actions: read
       contents: read
@@ -23,13 +28,31 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Install tooling
+      - name: Install Python tooling
         run: |
           python -V
-          pip -V
-          pip install -U pip
-          pip install ruff
-          sudo apt-get update -qq && sudo apt-get install -y ripgrep
+          python -m pip -V
+          python -m pip install -U pip
+          python -m pip install ruff==0.15.22
+
+      - name: Ensure ripgrep
+        # Attempt 2: apt-get update + install took ~5m10s after pip/ruff
+        # succeeded in ~5s. 10 minutes is ~2x that observed apt success path
+        # and still fail-closed versus the previous unbounded stall.
+        timeout-minutes: 10
+        run: |
+          set -euo pipefail
+          if command -v rg >/dev/null 2>&1; then
+            echo "rg already present; skipping apt"
+            command -v rg
+            rg --version
+            exit 0
+          fi
+          echo "rg not found; installing ripgrep via apt"
+          sudo apt-get update
+          sudo apt-get install -y ripgrep
+          command -v rg
+          rg --version
 
       - name: Ruff check (fast)
         run: |


### PR DESCRIPTION
## Summary
- Split the non-required `CI / Operator Verify (Registry)` compound `Install tooling` step so pip/ruff cannot hide behind a silent `apt-get update -qq`.
- Skip apt entirely when `rg` is already present; otherwise run a visible `Ensure ripgrep` step with `timeout-minutes: 10`.
- Pin `ruff==0.15.22` to the existing Lint Gate CI binding and set job `timeout-minutes: 15` (observed successful Attempt 2 was ~5.5 minutes including Azure-mirror fallback).

## Risk
- `operator-verify` is **not** a required status check.
- Verifier script, registry invariants, required-check policy, trading/runtime/config are unchanged.
- No `continue-on-error`, no retry loop, no workflow_dispatch of this job from this PR beyond the normal PR event.

## Test plan
- [x] YAML `safe_load` of `.github/workflows/ci-operator-verify-registry.yml`
- [x] Invariants: split steps, `command -v rg`, no `-qq`, pinned ruff, job/apt timeouts
- [x] `tests/ops/test_verify_registry_pointer_artifacts_smoke.py::test_workflow_allows_expired_only_on_pull_request`
- [x] CI selector `NO_OP` (`docs_workflow_or_static_contract_only`) for this file
- [ ] GitHub PR run of `CI / Operator Verify (Registry)` on this head (automatic; do not dispatch extra)


Made with [Cursor](https://cursor.com)