### PR TITLE
Establish deterministic Peak_Trade Python runtime contract

### DIFF
--- a/.cursor/rules/peak-trade-python-runtime.mdc
+++ b/.cursor/rules/peak-trade-python-runtime.mdc
@@ -1,0 +1,28 @@
+---
+description: Peak_Trade deterministic Python runtime contract for Cursor and agents
+alwaysApply: true
+---
+
+# Peak_Trade Python Runtime Contract
+
+Canonical launcher: `scripts/pt`
+Canonical interpreter: `.venv/bin/python`
+Version floor: `pyproject.toml` `requires-python = ">=3.10"`
+Docs: `docs/runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md`
+
+## Hard rules
+
+- Never execute Peak_Trade Python using PATH `python` or PATH `python3`.
+- Never infer the interpreter from terminal state, pyenv, or IDE selection.
+- Never rely on prior `source .venv/bin/activate`.
+- Never use `PYTHONPATH` or `sys.path` mutation as a runtime workaround.
+- Never silently switch interpreter, create a venv, or install/upgrade packages.
+- Use `./scripts/pt ...` (or `make` targets that delegate to it).
+- If runtime validation fails: HARD STOP and report the contract diagnostic.
+- Direct `python3 src/...py` is unsupported for package code.
+
+```text
+./scripts/pt runtime-check
+./scripts/pt -m pytest -q
+./scripts/pt -c "import trading"
+```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,6 +307,8 @@ jobs:
             echo "docs_or_static_contract_only=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # CI_PROVISIONED_INTERPRETER: `python` after setup-python is the
+      # documented runtime-contract exception. Local PATH python3 remains prohibited.
       - name: Set up Python 3.11
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:

--- a/.github/workflows/lint_gate.yml
+++ b/.github/workflows/lint_gate.yml
@@ -180,7 +180,7 @@ jobs:
           echo "applicable=false" >> $GITHUB_OUTPUT
 
       - name: Set up Python
-        if: ${{ steps.reuse_norm.outputs.reuse != 'true' && steps.detect.outputs.applicable == 'true' }}
+        if: ${{ steps.reuse_norm.outputs.reuse != 'true' }}
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.11'
@@ -250,7 +250,16 @@ jobs:
 
       - name: Governance AI matrix consistency gate
         if: ${{ steps.reuse_norm.outputs.reuse != 'true' }}
+        env:
+          PT_RUNTIME_MODE: provisioned
+          PT_SKIP_TRADING_PREFLIGHT: "1"
         run: |
+          set -euo pipefail
+          if [ -z "${pythonLocation:-}" ] || [ ! -x "${pythonLocation}/bin/python" ]; then
+            echo "PT_RUNTIME_FAIL: setup-python pythonLocation unbound" >&2
+            exit 8
+          fi
+          export PT_PROVISIONED_PYTHON="${pythonLocation}/bin/python"
           bash scripts/governance/ai_matrix_consistency_gate.sh
 
       - name: Gate Success (Not Applicable)

--- a/.github/workflows/paper_session_audit_evidence.yml
+++ b/.github/workflows/paper_session_audit_evidence.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/paper_session_telemetry_summary.yml
+++ b/.github/workflows/paper_session_telemetry_summary.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
 
     env:
       PEAK_TRADE_LIVE_ENABLED: "false"

--- a/.github/workflows/paper_tests_audit_evidence.yml
+++ b/.github/workflows/paper_tests_audit_evidence.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/policy_critic.yml
+++ b/.github/workflows/policy_critic.yml
@@ -202,7 +202,7 @@ jobs:
         if: steps.mode.outputs.format_only_ok != 'true'
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: '3.9'
+          python-version: '3.11'
 
       - name: Install dependencies
         if: steps.mode.outputs.format_only_ok != 'true'

--- a/.github/workflows/shadow_paper_smoke.yml
+++ b/.github/workflows/shadow_paper_smoke.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/test-health-automation.yml
+++ b/.github/workflows/test-health-automation.yml
@@ -477,7 +477,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11']
     steps:
       - name: Checkout
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,9 @@ CANONICAL_MAP_OF_TRUTH_PATH=docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md
 READ_BEFORE_MUTATION=true
 RUNTIME_AUTHORIZATION_EFFECT=NONE
 NO_PARALLEL_SEMANTIC_MODEL=true
+CANONICAL_PYTHON_LAUNCHER=scripts/pt
+CANONICAL_PYTHON_INTERPRETER=.venv/bin/python
+REQUIRES_PYTHON=>=3.10
 ```
 
 - Vor jeder Mutation: `docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md` vollständig lesen.
@@ -15,3 +18,4 @@ NO_PARALLEL_SEMANTIC_MODEL=true
 - Git nur im echten lokalen Repository über das lokale Terminal; Cursor-Sandbox-Git ist verboten.
 - Untracked Evidence unverändert erhalten.
 - Lokale CI-Dedup&#47;Reuse-Orchestrierung (Master Runbook §15.3): `docs&#47;ops&#47;specs&#47;GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1.md` — kein redundantes Suite-Re-Run nur für Evidence&#47;Verifier&#47;Pre-PR bei identischem gebundenem PASS.
+- Python-Ausführung: nur `scripts/pt` bzw. `make` targets, die darauf delegieren. Nie PATH `python`/`python3`, nie `source .venv/bin/activate` als Korrektheitsmechanismus, nie `PYTHONPATH` als Runtime-Workaround. Vertrag: `docs/runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md`. Bei Validation-Fail: HARD STOP.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,4 +18,4 @@ REQUIRES_PYTHON=>=3.10
 - Git nur im echten lokalen Repository über das lokale Terminal; Cursor-Sandbox-Git ist verboten.
 - Untracked Evidence unverändert erhalten.
 - Lokale CI-Dedup&#47;Reuse-Orchestrierung (Master Runbook §15.3): `docs&#47;ops&#47;specs&#47;GOVERNANCE_VERIFICATION_MINIMUM_LOCAL_CI_DEDUP_V1.md` — kein redundantes Suite-Re-Run nur für Evidence&#47;Verifier&#47;Pre-PR bei identischem gebundenem PASS.
-- Python-Ausführung: nur `scripts/pt` bzw. `make` targets, die darauf delegieren. Nie PATH `python`/`python3`, nie `source .venv/bin/activate` als Korrektheitsmechanismus, nie `PYTHONPATH` als Runtime-Workaround. Vertrag: `docs/runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md`. Bei Validation-Fail: HARD STOP.
+- Python-Ausführung: nur `scripts/pt` bzw. `make` targets, die darauf delegieren. Nie PATH `python`/`python3`, nie `source .venv&#47;bin&#47;activate` als Korrektheitsmechanismus, nie `PYTHONPATH` als Runtime-Workaround. Vertrag: `docs/runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md`. Bei Validation-Fail: HARD STOP.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 .PHONY: clean clean-all audit audit-tools gc report-smoke report-smoke-open ops-validate-pr-reports drift-report
 
+REPO_ROOT := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+PT := $(REPO_ROOT)/scripts/pt
+
+
 # ============================================================================
 # Cleanup Targets
 # ============================================================================
@@ -105,7 +109,7 @@ mlflow-reset:
 
 mlflow-smoke:
 	@echo "Using MLFLOW_TRACKING_URI=http://localhost:$${MLFLOW_PORT:-5001}"
-	@MLFLOW_TRACKING_URI="http://localhost:$${MLFLOW_PORT:-5001}" python3 -c 'import mlflow; mlflow.set_experiment("peak_trade_local_docker"); r = mlflow.start_run(run_name="make_mlflow_smoke"); mlflow.log_param("ui_port", 5001); mlflow.log_metric("ok", 1.0); mlflow.end_run(); print("✅ logged run to", mlflow.get_tracking_uri())'
+	@MLFLOW_TRACKING_URI="http://localhost:$${MLFLOW_PORT:-5001}" $(PT) -c 'import mlflow; mlflow.set_experiment("peak_trade_local_docker"); r = mlflow.start_run(run_name="make_mlflow_smoke"); mlflow.log_param("ui_port", 5001); mlflow.log_metric("ok", 1.0); mlflow.end_run(); print("✅ logged run to", mlflow.get_tracking_uri())'
 
 # ============================================================================
 # Merge-Log PR Workflow
@@ -160,7 +164,7 @@ ops-validate-pr-reports:
 
 # Non-blocking global docs/reference drift visibility report
 drift-report:
-	python3 scripts/ops/reference_drift_report_v1.py
+	$(PT) scripts/ops/reference_drift_report_v1.py
 
 # ============================================================================
 # Governance Gate (AI matrix vs registry)
@@ -171,88 +175,97 @@ governance-gate:
 	@bash scripts/governance/ai_matrix_consistency_gate.sh
 
 governance-validate:
-	@python3 src/governance/validate_ai_matrix_vs_registry.py --level P2
+	@$(PT) src/governance/validate_ai_matrix_vs_registry.py --level P2
 
 test:
-	@python3 -m pytest -q
+	@$(PT) -m pytest -q
 
 lint:
-	@python3 -m ruff check .
+	@$(PT) -m ruff check .
 
 l3-docker:
 	@bash scripts/docker/run_l3_no_net.sh
-	@OUT_DIR=out/l3 CACHE_DIR=$${CACHE_DIR:-.cache/l3} IMAGE=$${IMAGE:-peaktrade-l3:latest} python3 scripts/ops/augment_run_manifest.py
+	@OUT_DIR=out/l3 CACHE_DIR=$${CACHE_DIR:-.cache/l3} IMAGE=$${IMAGE:-peaktrade-l3:latest} $(PT) scripts/ops/augment_run_manifest.py
 
 
 research-new-listings-smoke:
-	@python3 -m src.research.new_listings --help
-	@python3 -m src.research.new_listings run --help
+	@$(PT) -m src.research.new_listings --help
+	@$(PT) -m src.research.new_listings run --help
 
 research-new-listings-run-smoke:
-	@python3 -m src.research.new_listings run --help
+	@$(PT) -m src.research.new_listings run --help
 
 ai-policy-audit-smoke:
-	@PYTHONPATH=. python3 src/ops/p50/ai_model_policy_cli_v1.py --help
+	@$(PT) src/ops/p50/ai_model_policy_cli_v1.py --help
 
 ai-switch-layer-smoke:
-	@python3 scripts/ai/switch_layer_smoke.py
+	@$(PT) scripts/ai/switch_layer_smoke.py
 
 wave2-ai-entrypoints-smoke:
-	@PYTHONPATH=. python3 src/ops/p50/ai_model_policy_cli_v1.py --help
-	@python3 scripts/ai/switch_layer_smoke.py
+	@$(PT) src/ops/p50/ai_model_policy_cli_v1.py --help
+	@$(PT) scripts/ai/switch_layer_smoke.py
 
 ai-policy-audit-deterministic-smoke:
-	@PYTHONPATH=. python3 scripts/ai/policy_audit_smoke.py
+	@$(PT) scripts/ai/policy_audit_smoke.py
 
 ai-switch-layer-deterministic-smoke:
-	@PYTHONPATH=. python3 scripts/ai/switch_layer_smoke.py
+	@$(PT) scripts/ai/switch_layer_smoke.py
 
 wave2-ai-deterministic-smoke:
-	@PYTHONPATH=. python3 scripts/ai/policy_audit_smoke.py
-	@PYTHONPATH=. python3 scripts/ai/switch_layer_smoke.py
+	@$(PT) scripts/ai/policy_audit_smoke.py
+	@$(PT) scripts/ai/switch_layer_smoke.py
 
 
 wave3-model-registry-loader-smoke:
-	PYTHONPATH=. python3 scripts/wave3/model_registry_loader_smoke.py
+	$(PT) scripts/wave3/model_registry_loader_smoke.py
 
 wave3-metrics-server-smoke:
-	PYTHONPATH=. python3 scripts/wave3/metrics_server_smoke.py
+	$(PT) scripts/wave3/metrics_server_smoke.py
 
 wave3-api-manager-smoke:
-	PYTHONPATH=. python3 scripts/wave3/api_manager_smoke.py
+	$(PT) scripts/wave3/api_manager_smoke.py
 
 wave3-orch-obs-service-smoke:
-	PYTHONPATH=. python3 scripts/wave3/model_registry_loader_smoke.py
-	PYTHONPATH=. python3 scripts/wave3/metrics_server_smoke.py
-	PYTHONPATH=. python3 scripts/wave3/api_manager_smoke.py
+	$(PT) scripts/wave3/model_registry_loader_smoke.py
+	$(PT) scripts/wave3/metrics_server_smoke.py
+	$(PT) scripts/wave3/api_manager_smoke.py
 
 
 wave3-deterministic-smokes:
-	PYTHONPATH=. python3 scripts/wave3/model_registry_loader_smoke.py
-	PYTHONPATH=. python3 scripts/wave3/metrics_server_smoke.py
-	PYTHONPATH=. python3 scripts/wave3/api_manager_smoke.py
+	$(PT) scripts/wave3/model_registry_loader_smoke.py
+	$(PT) scripts/wave3/metrics_server_smoke.py
+	$(PT) scripts/wave3/api_manager_smoke.py
 
 
 wave4-aggregate-smoke-summary:
-	PYTHONPATH=. python3 scripts/ai/policy_audit_smoke.py
-	PYTHONPATH=. python3 scripts/ai/switch_layer_smoke.py
-	PYTHONPATH=. python3 scripts/wave3/model_registry_loader_smoke.py
-	PYTHONPATH=. python3 scripts/wave3/metrics_server_smoke.py
-	PYTHONPATH=. python3 scripts/wave3/api_manager_smoke.py
-	PYTHONPATH=. python3 scripts/wave5/new_listings_to_ai_bridge.py
-	PYTHONPATH=. python3 scripts/wave4/aggregate_smoke_contracts.py
+	$(PT) scripts/ai/policy_audit_smoke.py
+	$(PT) scripts/ai/switch_layer_smoke.py
+	$(PT) scripts/wave3/model_registry_loader_smoke.py
+	$(PT) scripts/wave3/metrics_server_smoke.py
+	$(PT) scripts/wave3/api_manager_smoke.py
+	$(PT) scripts/wave5/new_listings_to_ai_bridge.py
+	$(PT) scripts/wave4/aggregate_smoke_contracts.py
 
 
 wave5-new-listings-ai-bridge:
-	PYTHONPATH=. python3 scripts/wave5/new_listings_to_ai_bridge.py
+	$(PT) scripts/wave5/new_listings_to_ai_bridge.py
 
 
 wave6-evidence-registry-hook:
 	$(MAKE) wave4-aggregate-smoke-summary
-	PYTHONPATH=. python3 scripts/wave6/write_evidence_registry_hook.py
+	$(PT) scripts/wave6/write_evidence_registry_hook.py
 
 workflow-officer-audit:
-	python3 src/ops/workflow_officer.py --mode audit --profile docs_only_pr
+	$(PT) src/ops/workflow_officer.py --mode audit --profile docs_only_pr
 
 workflow-officer-preflight:
-	python3 src/ops/workflow_officer.py --mode preflight --profile ops_local_env
+	$(PT) src/ops/workflow_officer.py --mode preflight --profile ops_local_env
+
+
+# ============================================================================
+# Deterministic Python runtime contract
+# ============================================================================
+
+.PHONY: runtime-check
+runtime-check:
+	$(PT) runtime-check

--- a/README.md
+++ b/README.md
@@ -9,20 +9,25 @@ Peak_Trade ist ein modulares, research-getriebenes Trading-Framework mit konsequ
 ### 🚀 Quick Start: Ersten Backtest in 5 Minuten
 
 ```bash
-# 1. Dependencies installieren (einmalig)
-pip install -e .
+# 1. Bootstrap (einmalig, legt .venv an)
+uv sync --dev
 
-# 2. Ersten Backtest laufen lassen
-python3 scripts/run_strategy_from_config.py --strategy ma_crossover --symbol BTC/USDT
+# 2. Canonical runtime check
+./scripts/pt runtime-check
 
-# 3. Tests ausführen
-python3 -m pytest -m smoke -q  # Schnelle Smoke-Tests (~1 Sekunde)
-python3 -m pytest -q           # Full Suite (~70 Sekunden)
+# 3. Ersten Backtest laufen lassen
+./scripts/pt scripts/run_strategy_from_config.py --strategy ma_crossover --symbol BTC/USDT
 
-# 4. Optionale Web-UI Dependencies (für Dashboard/API Tests)
-uv sync --extra web  # oder: pip install -e ".[web]"
-python3 -m pytest -m web        # Web-UI Tests ausführen
+# 4. Tests ausführen
+./scripts/pt -m pytest -m smoke -q
+./scripts/pt -m pytest -q
+
+# 5. Optionale Web-UI Dependencies
+uv sync --extra web
+./scripts/pt -m pytest -m web
 ```
+
+Nie PATH `python`/`python3` verwenden. Vertrag: [`docs/runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md`](docs/runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md). Python-Floor: `requires-python = ">=3.10"`.
 
 **Hinweis:** Web-UI Tests werden automatisch übersprungen, wenn FastAPI nicht installiert ist. Core-Tests laufen ohne Web-Stack.
 
@@ -93,10 +98,10 @@ Peak_Trade ist so gebaut, dass AI-Tools wie Cursor, Claude und ChatGPT beim Entw
 - 🛠️ **Developer Workflow Script**
   Automatisierung häufiger Entwicklungsaufgaben:
   ```bash
-  python3 scripts/dev_workflow.py --help
-  python3 scripts/dev_workflow.py setup    # Environment setup
-  python3 scripts/dev_workflow.py test     # Run tests
-  python3 scripts/dev_workflow.py health   # Health check
+  ./scripts/pt scripts/dev_workflow.py --help
+  ./scripts/pt scripts/dev_workflow.py setup    # Environment setup
+  ./scripts/pt scripts/dev_workflow.py test     # Run tests
+  ./scripts/pt scripts/dev_workflow.py health   # Health check
   ```
 
 ---
@@ -158,7 +163,7 @@ Peak_Trade ist **strikt modular** aufgebaut. Jede Komponente ist austauschbar un
       raise ConfigError("Load failed", hint="Check syntax", cause=original_error)
       ```
     - **Documentation:** [Error Handling Guide](docs/ERROR_HANDLING_GUIDE.md)
-    - **Audit Tool:** `python scripts/audit/check_error_taxonomy_adoption.py`
+    - **Audit Tool:** `./scripts/pt scripts/audit/check_error_taxonomy_adoption.py`
 
 - 🔄 **Resilience & Stability**
   - Circuit Breaker Pattern für alle kritischen Module
@@ -217,15 +222,14 @@ Peak_Trade ist in mehrere Layer strukturiert:
 ### 1. Umgebung vorbereiten
 
 ```bash
-python -m venv .venv
-source .venv/bin/activate  # Windows: .venv\Scripts\activate
-pip install -r requirements.txt
+uv sync --dev
+./scripts/pt runtime-check
 ```
 
 ### 2. Ersten Research-Run starten (Portfolio-Preset)
 
 ```bash
-python scripts/research_cli.py portfolio \
+./scripts/pt scripts/research_cli.py portfolio \
   --config config/config.toml \
   --portfolio-preset rsi_reversion_conservative \
   --format both
@@ -234,14 +238,14 @@ python scripts/research_cli.py portfolio \
 ### 3. Live-/Testnet Health & Portfolio prüfen (ohne echte Orders)
 
 ```bash
-python scripts/live_ops.py health --config config/config.toml
-python scripts/live_ops.py portfolio --config config/config.toml --json
+./scripts/pt scripts/live_ops.py health --config config/config.toml
+./scripts/pt scripts/live_ops.py portfolio --config config/config.toml --json
 ```
 
 ### 4. Daily Live-Status-Report generieren (Markdown)
 
 ```bash
-python scripts/generate_live_status_report.py \
+./scripts/pt scripts/generate_live_status_report.py \
   --config config/config.toml \
   --output-dir reports/live_status \
   --format markdown \
@@ -252,10 +256,10 @@ python scripts/generate_live_status_report.py \
 
 ```bash
 # Einmalige Ausführung mit automatischer Entscheidung
-python scripts/run_autonomous_workflow.py --once --dry-run
+./scripts/pt scripts/run_autonomous_workflow.py --once --dry-run
 
 # Mit Scheduler: Täglich automatisch
-python scripts/run_scheduler.py \
+./scripts/pt scripts/run_scheduler.py \
   --config config/scheduler/jobs.toml \
   --include-tags autonomous
 ```
@@ -274,10 +278,10 @@ In **10–15 Minuten** den kompletten Live-Track praktisch erleben – ohne echt
 RELOAD=1 ./scripts/ops/run_webui.sh
 
 # 2. Shadow-Session (10 Steps)
-python scripts/run_execution_session.py --strategy ma_crossover --steps 10
+./scripts/pt scripts/run_execution_session.py --strategy ma_crossover --steps 10
 
 # 3. Registry prüfen
-python scripts/report_live_sessions.py --summary-only --stdout
+./scripts/pt scripts/report_live_sessions.py --summary-only --stdout
 
 # 4. Dashboard öffnen: http://127.0.0.1:8000/
 ```
@@ -319,16 +323,16 @@ RELOAD=1 ./scripts/ops/run_live_webui.sh
 
 **Alternativen (nicht alle starten dieselbe App):**
 
-- `python3 scripts/live_web_server.py` → `src.live.web.app` (Live-Dashboard mit `/api/v0/*`, `/runs/*`, `/dashboard`)
+- `./scripts/pt scripts/live_web_server.py` → `src.live.web.app` (Live-Dashboard mit `/api/v0/*`, `/runs/*`, `/dashboard`)
 - `bash scripts/ops/run_live_webui.sh` → `src.live.web.app` (Wrapper für das Live-Dashboard)
 - `bash scripts/ops/run_webui.sh` → `src.webui.app` (Operator-WebUI mit `/api/live_sessions`, `/api/execution/*`, `/ops`, `/r_and_d`)
-- `python3 scripts/serve_live_dashboard.py` → `src.live.web.app` (alternativer Live-Dashboard-Entrypoint)
+- `./scripts/pt scripts/serve_live_dashboard.py` → `src.live.web.app` (alternativer Live-Dashboard-Entrypoint)
 
 | Entrypoint | Port | Hinweis |
 |------------|------|---------|
 | `run_live_webui.sh` | 8010 | Shell-Wrapper mit `uv` (oben) |
-| `python3 scripts/live_web_server.py` | 8000 | Empfohlen in Runbooks, CLI-Argumente |
-| `python -m scripts.serve_live_dashboard` | 8000 | Config aus `config/config.toml` |
+| `./scripts/pt scripts/live_web_server.py` | 8000 | Empfohlen in Runbooks, CLI-Argumente |
+| `./scripts/pt -m scripts.serve_live_dashboard` | 8000 | Config aus `config/config.toml` |
 
 ### HTTP-Routen — Operator-WebUI, Ops-Hub & live.web (Local Defaults)
 

--- a/config/runtime/pt_python_operative_surfaces_v1.json
+++ b/config/runtime/pt_python_operative_surfaces_v1.json
@@ -1,0 +1,233 @@
+{
+  "contract_id": "pt_python_operative_surfaces_v1",
+  "notes": "Classification of CURRENT operative invocation owners. Historical/evidence paths are excluded from the grep gate.",
+  "surfaces": [
+    {
+      "path": "scripts/pt",
+      "class": "OPERATIVE_CANONICAL",
+      "role": "canonical_launcher"
+    },
+    {
+      "path": "pt",
+      "class": "OPERATIVE_WRAPPER",
+      "role": "root_trampoline_to_scripts_pt"
+    },
+    {
+      "path": "scripts/runtime/pt_python_runtime_contract_v1.py",
+      "class": "OPERATIVE_CANONICAL",
+      "role": "runtime_contract_library"
+    },
+    {
+      "path": "Makefile",
+      "class": "OPERATIVE_WRAPPER",
+      "role": "make_orchestration_delegates_to_scripts_pt"
+    },
+    {
+      "path": "scripts/governance/ai_matrix_consistency_gate.sh",
+      "class": "OPERATIVE_WRAPPER",
+      "role": "governance_gate"
+    },
+    {
+      "path": "scripts/webui/local_market_dashboard.sh",
+      "class": "OPERATIVE_WRAPPER",
+      "role": "webui_launcher"
+    },
+    {
+      "path": "scripts/obs/stage1_run_daily.sh",
+      "class": "OPERATIVE_WRAPPER",
+      "role": "scheduled_obs"
+    },
+    {
+      "path": "scripts/obs/stage1_run_weekly.sh",
+      "class": "OPERATIVE_WRAPPER",
+      "role": "scheduled_obs"
+    },
+    {
+      "path": "scripts/ops/kill_switch_ctl.sh",
+      "class": "OPERATIVE_WRAPPER",
+      "role": "kill_switch_operator_wrapper"
+    },
+    {
+      "path": "scripts/ops/invoke_armstrong_cycle_v1_bound_offline_economic_baseline_evaluation_v0.sh",
+      "class": "OPERATIVE_WRAPPER",
+      "role": "offline_eval_explicit_venv"
+    },
+    {
+      "path": "scripts/ops/invoke_ehlers_cycle_filter_v1_bound_offline_economic_baseline_evaluation_v0.sh",
+      "class": "OPERATIVE_WRAPPER",
+      "role": "offline_eval_explicit_venv"
+    },
+    {
+      "path": "scripts/ops/offline_evaluation_runner_invocation_contract_v0.py",
+      "class": "OPERATIVE_WRAPPER",
+      "role": "offline_eval_interpreter_resolution"
+    },
+    {
+      "path": "README.md",
+      "class": "OPERATIVE_CANONICAL",
+      "role": "operator_quickstart"
+    },
+    {
+      "path": "docs/GETTING_STARTED.md",
+      "class": "OPERATIVE_CANONICAL",
+      "role": "operator_setup"
+    },
+    {
+      "path": "docs/DEV_SETUP.md",
+      "class": "OPERATIVE_CANONICAL",
+      "role": "developer_setup"
+    },
+    {
+      "path": "docs/DEVELOPER_WORKFLOW_GUIDE.md",
+      "class": "OPERATIVE_CANONICAL",
+      "role": "developer_workflow"
+    },
+    {
+      "path": "docs/ai/CLAUDE_GUIDE.md",
+      "class": "OPERATIVE_CANONICAL",
+      "role": "agent_command_guide_non_ssot"
+    },
+    {
+      "path": "docs/ai/PEAK_TRADE_AI_HELPER_GUIDE.md",
+      "class": "OPERATIVE_CANONICAL",
+      "role": "agent_working_agreement_non_ssot"
+    },
+    {
+      "path": "AGENTS.md",
+      "class": "OPERATIVE_CANONICAL",
+      "role": "agent_entrypoint"
+    },
+    {
+      "path": ".cursor/rules/peak-trade-python-runtime.mdc",
+      "class": "OPERATIVE_CANONICAL",
+      "role": "cursor_runtime_rule"
+    },
+    {
+      "path": "docs/runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md",
+      "class": "OPERATIVE_CANONICAL",
+      "role": "canonical_runtime_doc"
+    },
+    {
+      "path": "docs/ops/PYTHON_VERSION_PLAN.md",
+      "class": "HISTORICAL",
+      "role": "superseded_python_upgrade_plan"
+    },
+    {
+      "path": "docs/dev/UV_QUICKSTART.md",
+      "class": "BOOTSTRAP_ONLY",
+      "role": "bootstrap_uv_sync"
+    },
+    {
+      "path": ".github/workflows/ci.yml",
+      "class": "CI_PINNED",
+      "role": "required_ci"
+    },
+    {
+      "path": "tests/conftest.py",
+      "class": "TEST_ONLY",
+      "role": "pytest_sys_path_bootstrap"
+    },
+    {
+      "path": "docs/SCHEDULER_DAEMON.md",
+      "class": "OPERATIVE_CANONICAL",
+      "role": "scheduler_operator_docs"
+    },
+    {
+      "path": "src/scheduler/runner.py",
+      "class": "OPERATIVE_CANONICAL",
+      "role": "scheduler_binds_bare_python_to_process_interpreter"
+    },
+    {
+      "path": "scripts/ops/bg_job.sh",
+      "class": "OPERATIVE_WRAPPER",
+      "role": "background_job_helper"
+    },
+    {
+      "path": "scripts/obs/run_stage1_monitoring.sh",
+      "class": "OPERATIVE_WRAPPER",
+      "role": "scheduled_obs"
+    },
+    {
+      "path": "scripts/obs/smoke.sh",
+      "class": "OPERATIVE_WRAPPER",
+      "role": "obs_smoke"
+    },
+    {
+      "path": "scripts/obs/ai_live_verify.sh",
+      "class": "OPERATIVE_WRAPPER",
+      "role": "obs_ai_live"
+    },
+    {
+      "path": "scripts/obs/ai_live_smoke_test.sh",
+      "class": "OPERATIVE_WRAPPER",
+      "role": "obs_ai_live"
+    },
+    {
+      "path": "scripts/obs/ai_live_ops_verify.sh",
+      "class": "OPERATIVE_WRAPPER",
+      "role": "obs_ai_live"
+    },
+    {
+      "path": "scripts/obs/ai_live_activity_demo.sh",
+      "class": "OPERATIVE_WRAPPER",
+      "role": "obs_ai_live"
+    },
+    {
+      "path": "scripts/obs/ai_live_restart.sh",
+      "class": "OPERATIVE_WRAPPER",
+      "role": "obs_ai_live"
+    },
+    {
+      "path": "scripts/obs/ai_live_local_verify.sh",
+      "class": "OPERATIVE_WRAPPER",
+      "role": "obs_ai_live"
+    },
+    {
+      "path": "scripts/obs/prom_9094_9095_restart.sh",
+      "class": "OPERATIVE_WRAPPER",
+      "role": "obs_prometheus_helper"
+    },
+    {
+      "path": "scripts/obs/prom_9094_9095_up_and_verify.sh",
+      "class": "OPERATIVE_WRAPPER",
+      "role": "obs_prometheus_helper"
+    }
+  ],
+  "documented_exceptions": [
+    {
+      "id": "CI_PROVISIONED_INTERPRETER",
+      "summary": "GitHub Actions may invoke python after setup-python pins the version. Local PATH python3 remains prohibited.",
+      "mode": "provisioned"
+    },
+    {
+      "id": "PYTEST_CONFTEST_SYS_PATH",
+      "summary": "tests/conftest.py inserts src and repo root for pytest collection only. Not an operational runtime solution.",
+      "mode": "test_only"
+    },
+    {
+      "id": "SHEBANG_NOT_RUNTIME_API",
+      "summary": "#!/usr/bin/env python3 on non-operative scripts is not a supported way to start Peak_Trade. Invoke through scripts/pt.",
+      "mode": "unsupported_direct_execution"
+    },
+    {
+      "id": "OFFLINE_EVAL_EXPLICIT_VENV_PYTHON",
+      "summary": "Existing armstrong/ehlers invoke wrappers resolve REPO_ROOT/.venv/bin/python directly and fail closed if missing. New surfaces must use scripts/pt.",
+      "mode": "explicit_canonical_interpreter"
+    },
+    {
+      "id": "SCHEDULER_JOB_COMMAND_PYTHON",
+      "summary": "config/scheduler/jobs.toml uses command=python as a token. src/scheduler/runner.py remaps python/python3 to sys.executable of the scheduler process. Launch the scheduler via scripts/pt.",
+      "mode": "scheduler_token"
+    },
+    {
+      "id": "PAPER_SHADOW_UV_RUN_EXECUTE_CONTRACTS",
+      "summary": "Existing paper-shadow execute-entrypoint drift-guard contracts invoke uv run python, which binds the project environment via uv.lock. Not PATH python3. New surfaces must use scripts/pt.",
+      "mode": "uv_run_project_env"
+    },
+    {
+      "id": "WEBUI_PYTHON_OVERRIDE",
+      "summary": "PEAK_TRADE_WEBUI_PYTHON may override the dashboard interpreter when the operator supplies an executable path. Default is scripts/pt.",
+      "mode": "explicit_operator_override"
+    }
+  ]
+}

--- a/config/runtime/pt_python_runtime_contract_v1.json
+++ b/config/runtime/pt_python_runtime_contract_v1.json
@@ -1,0 +1,19 @@
+{
+  "contract_id": "pt_python_runtime_contract_v1",
+  "contract_version": "v1",
+  "canonical_launcher": "scripts/pt",
+  "canonical_interpreter_relpath": ".venv/bin/python",
+  "requires_python": ">=3.10",
+  "requires_python_major": 3,
+  "requires_python_minor": 10,
+  "path_python_fallback_allowed": false,
+  "venv_activation_required": false,
+  "pyenv_dependency": false,
+  "pythonpath_dependency": false,
+  "cwd_dependency": false,
+  "silently_create_venv": false,
+  "silently_install_dependencies": false,
+  "provisioned_mode_env": "PT_RUNTIME_MODE",
+  "provisioned_mode_value": "provisioned",
+  "github_actions_env": "GITHUB_ACTIONS"
+}

--- a/docs/DEVELOPER_WORKFLOW_GUIDE.md
+++ b/docs/DEVELOPER_WORKFLOW_GUIDE.md
@@ -1,5 +1,7 @@
 # Peak_Trade Developer Workflow Guide
 
+Python floor: `requires-python = ">=3.10"`. Run Peak_Trade Python only via `./scripts/pt` (see `docs/runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md`). PATH `python`/`python3` is not a supported runtime.
+
 > **Purpose:** Streamlined workflows and automation tools for productive development
 >
 > **Target Audience:** All developers working on Peak_Trade
@@ -24,13 +26,13 @@ git clone <repo-url>
 cd Peak_Trade
 
 # 2. Automated setup
-python3 scripts/dev_workflow.py setup
+./scripts/pt scripts/dev_workflow.py setup
 
 # 3. Health check
-python3 scripts/dev_workflow.py health
+./scripts/pt scripts/dev_workflow.py health
 
 # 4. Run tests to verify setup
-python3 scripts/dev_workflow.py test --module test_basics
+./scripts/pt scripts/dev_workflow.py test --module test_basics
 
 # 5. Read essential docs
 # - README.md
@@ -42,16 +44,16 @@ python3 scripts/dev_workflow.py test --module test_basics
 
 ```bash
 # Morning routine
-python3 scripts/dev_workflow.py health        # Quick system check
+./scripts/pt scripts/dev_workflow.py health        # Quick system check
 git pull origin main                          # Get latest changes
 
 # During development
-python3 scripts/dev_workflow.py test --module <module>  # Test your changes
-python3 scripts/dev_workflow.py lint                    # Check code style
+./scripts/pt scripts/dev_workflow.py test --module <module>  # Test your changes
+./scripts/pt scripts/dev_workflow.py lint                    # Check code style
 
 # Before committing
-python3 scripts/dev_workflow.py test                    # Full test suite
-python3 scripts/dev_workflow.py docs-validate           # Check docs
+./scripts/pt scripts/dev_workflow.py test                    # Full test suite
+./scripts/pt scripts/dev_workflow.py docs-validate           # Check docs
 git add .
 git commit -m "Your change description"
 git push
@@ -65,14 +67,14 @@ git checkout -b feature/your-feature-name
 
 # 2. Make changes incrementally
 # ... edit files ...
-python3 scripts/dev_workflow.py test --module <module> -v
+./scripts/pt scripts/dev_workflow.py test --module <module> -v
 
 # 3. Run linters
-python3 scripts/dev_workflow.py lint
+./scripts/pt scripts/dev_workflow.py lint
 
 # 4. Validate changes
-python3 scripts/dev_workflow.py health
-python3 scripts/dev_workflow.py docs-validate
+./scripts/pt scripts/dev_workflow.py health
+./scripts/pt scripts/dev_workflow.py docs-validate
 
 # 5. Commit and push
 git add .
@@ -93,7 +95,7 @@ The `scripts/dev_workflow.py` script automates common development tasks.
 
 #### Setup Environment
 ```bash
-python3 scripts/dev_workflow.py setup
+./scripts/pt scripts/dev_workflow.py setup
 ```
 - Creates virtual environment
 - Installs dependencies
@@ -102,28 +104,28 @@ python3 scripts/dev_workflow.py setup
 #### Run Tests
 ```bash
 # All tests
-python3 scripts/dev_workflow.py test
+./scripts/pt scripts/dev_workflow.py test
 
 # Specific module
-python3 scripts/dev_workflow.py test --module performance
+./scripts/pt scripts/dev_workflow.py test --module performance
 
 # With coverage
-python3 scripts/dev_workflow.py test --coverage
+./scripts/pt scripts/dev_workflow.py test --coverage
 
 # Verbose output
-python3 scripts/dev_workflow.py test -v
+./scripts/pt scripts/dev_workflow.py test -v
 ```
 
 #### Run Linters
 ```bash
-python3 scripts/dev_workflow.py lint
+./scripts/pt scripts/dev_workflow.py lint
 ```
 - Runs ruff for linting
 - Runs black for formatting checks
 
 #### Performance Check
 ```bash
-python3 scripts/dev_workflow.py perf-check
+./scripts/pt scripts/dev_workflow.py perf-check
 ```
 - Benchmarks key operations
 - Reports performance metrics
@@ -131,7 +133,7 @@ python3 scripts/dev_workflow.py perf-check
 
 #### Validate Documentation
 ```bash
-python3 scripts/dev_workflow.py docs-validate
+./scripts/pt scripts/dev_workflow.py docs-validate
 ```
 - Checks for broken links
 - Finds TODO/FIXME markers
@@ -139,7 +141,7 @@ python3 scripts/dev_workflow.py docs-validate
 
 #### Health Check
 ```bash
-python3 scripts/dev_workflow.py health
+./scripts/pt scripts/dev_workflow.py health
 ```
 - Verifies environment setup
 - Checks directory structure
@@ -147,7 +149,7 @@ python3 scripts/dev_workflow.py health
 
 #### Create Strategy Scaffold
 ```bash
-python3 scripts/dev_workflow.py create-strategy "My New Strategy"
+./scripts/pt scripts/dev_workflow.py create-strategy "My New Strategy"
 ```
 - Generates strategy boilerplate
 - Creates test file template
@@ -161,17 +163,17 @@ python3 scripts/dev_workflow.py create-strategy "My New Strategy"
 
 ```bash
 # 1. Create test first
-python3 scripts/dev_workflow.py create-strategy "momentum"
+./scripts/pt scripts/dev_workflow.py create-strategy "momentum"
 # Edit tests/strategies/test_momentum.py
 
 # 2. Run test (should fail)
-python3 scripts/dev_workflow.py test --module strategies/test_momentum -v
+./scripts/pt scripts/dev_workflow.py test --module strategies/test_momentum -v
 
 # 3. Implement strategy
 # Edit src/strategies/momentum.py
 
 # 4. Run test (should pass)
-python3 scripts/dev_workflow.py test --module strategies/test_momentum -v
+./scripts/pt scripts/dev_workflow.py test --module strategies/test_momentum -v
 
 # 5. Refine and repeat
 ```
@@ -180,13 +182,13 @@ python3 scripts/dev_workflow.py test --module strategies/test_momentum -v
 
 ```bash
 # 1. Baseline performance
-python3 scripts/dev_workflow.py perf-check
+./scripts/pt scripts/dev_workflow.py perf-check
 
 # 2. Make changes
 # ... edit files ...
 
 # 3. Check performance impact
-python3 scripts/dev_workflow.py perf-check
+./scripts/pt scripts/dev_workflow.py perf-check
 
 # 4. Compare metrics
 # If performance degraded, optimize before committing
@@ -199,13 +201,13 @@ python3 scripts/dev_workflow.py perf-check
 # Edit docs/YOUR_FEATURE.md
 
 # 2. Validate documentation
-python3 scripts/dev_workflow.py docs-validate
+./scripts/pt scripts/dev_workflow.py docs-validate
 
 # 3. Implement based on docs
 # ... edit files ...
 
 # 4. Ensure docs stay updated
-python3 scripts/dev_workflow.py docs-validate
+./scripts/pt scripts/dev_workflow.py docs-validate
 ```
 
 ### Pattern 4: Incremental Integration
@@ -215,7 +217,7 @@ python3 scripts/dev_workflow.py docs-validate
 # Edit single file
 
 # 2. Test immediately
-python3 scripts/dev_workflow.py test --module <specific_test>
+./scripts/pt scripts/dev_workflow.py test --module <specific_test>
 
 # 3. Commit if passes
 git add <file>
@@ -239,7 +241,7 @@ Create `.vscode&#47;tasks.json`:
         {
             "label": "Run Tests",
             "type": "shell",
-            "command": "python3 scripts/dev_workflow.py test",
+            "command": "./scripts/pt scripts/dev_workflow.py test",
             "group": {
                 "kind": "test",
                 "isDefault": true
@@ -248,13 +250,13 @@ Create `.vscode&#47;tasks.json`:
         {
             "label": "Run Linters",
             "type": "shell",
-            "command": "python3 scripts/dev_workflow.py lint",
+            "command": "./scripts/pt scripts/dev_workflow.py lint",
             "group": "build"
         },
         {
             "label": "Health Check",
             "type": "shell",
-            "command": "python3 scripts/dev_workflow.py health"
+            "command": "./scripts/pt scripts/dev_workflow.py health"
         }
     ]
 }
@@ -269,7 +271,7 @@ Keyboard shortcuts:
 1. **External Tools Configuration:**
    - Settings → Tools → External Tools
    - Add tool: "Workflow Health"
-   - Program: `python3`
+   - Program: `./scripts/pt`
    - Arguments: `scripts&#47;dev_workflow.py health`
    - Working directory: `$ProjectFileDir$`
 
@@ -318,10 +320,10 @@ test(portfolio): add edge case tests
 
 1. **Before Creating PR:**
    ```bash
-   python3 scripts/dev_workflow.py test --coverage
-   python3 scripts/dev_workflow.py lint
-   python3 scripts/dev_workflow.py docs-validate
-   python3 scripts/dev_workflow.py health
+   ./scripts/pt scripts/dev_workflow.py test --coverage
+   ./scripts/pt scripts/dev_workflow.py lint
+   ./scripts/pt scripts/dev_workflow.py docs-validate
+   ./scripts/pt scripts/dev_workflow.py health
    ```
 
 2. **PR Description Template:**
@@ -367,38 +369,38 @@ Full Suite        → Comprehensive, all tests
 
 ```bash
 # During development (fast feedback)
-python3 scripts/dev_workflow.py test --module <your_module>
+./scripts/pt scripts/dev_workflow.py test --module <your_module>
 
 # Before commit (medium confidence)
-python3 scripts/dev_workflow.py test --module <affected_modules>
+./scripts/pt scripts/dev_workflow.py test --module <affected_modules>
 
 # Before PR (high confidence)
-python3 scripts/dev_workflow.py test --coverage
+./scripts/pt scripts/dev_workflow.py test --coverage
 
 # CI/CD (full validation)
-python3 -m pytest tests/ -v --cov=src --cov-report=html
+./scripts/pt -m pytest tests/ -v --cov=src --cov-report=html
 ```
 
 ### Test-Specific Workflows
 
 ```bash
 # Run specific test class
-python3 -m pytest tests/test_performance.py::TestPerformanceMonitor -v
+./scripts/pt -m pytest tests/test_performance.py::TestPerformanceMonitor -v
 
 # Run specific test method
-python3 -m pytest tests/test_performance.py::TestPerformanceMonitor::test_init -v
+./scripts/pt -m pytest tests/test_performance.py::TestPerformanceMonitor::test_init -v
 
 # Run tests matching pattern
-python3 -m pytest tests/ -k "performance" -v
+./scripts/pt -m pytest tests/ -k "performance" -v
 
 # Run with detailed output
-python3 -m pytest tests/ -vv -s
+./scripts/pt -m pytest tests/ -vv -s
 
 # Run failed tests only
-python3 -m pytest tests/ --lf
+./scripts/pt -m pytest tests/ --lf
 
 # Run tests in parallel (if pytest-xdist installed)
-python3 -m pytest tests/ -n auto
+./scripts/pt -m pytest tests/ -n auto
 ```
 
 ---
@@ -409,7 +411,7 @@ python3 -m pytest tests/ -n auto
 
 1. **Reproduce the Issue:**
    ```bash
-   python3 scripts/dev_workflow.py test --module <failing_test> -v
+   ./scripts/pt scripts/dev_workflow.py test --module <failing_test> -v
    ```
 
 2. **Add Debug Output:**
@@ -421,10 +423,10 @@ python3 -m pytest tests/ -n auto
 3. **Use Debugger:**
    ```bash
    # Run with debugger
-   python3 -m pdb scripts/<script_name>.py
+   ./scripts/pt -m pdb scripts/<script_name>.py
 
    # Or in test
-   python3 -m pytest tests/test_module.py --pdb
+   ./scripts/pt -m pytest tests/test_module.py --pdb
    ```
 
 4. **Performance Profiling:**
@@ -446,7 +448,7 @@ python3 -m pytest tests/ -n auto
 
 1. **Measure Baseline:**
    ```bash
-   python3 scripts/dev_workflow.py perf-check
+   ./scripts/pt scripts/dev_workflow.py perf-check
    ```
 
 2. **Profile Code:**
@@ -478,7 +480,7 @@ python3 -m pytest tests/ -n auto
 
 5. **Verify Improvement:**
    ```bash
-   python3 scripts/dev_workflow.py perf-check
+   ./scripts/pt scripts/dev_workflow.py perf-check
    # Compare with baseline
    ```
 
@@ -496,14 +498,14 @@ Create `.git&#47;hooks&#47;pre-commit`:
 echo "Running pre-commit checks..."
 
 # Run tests
-python3 scripts/dev_workflow.py test
+./scripts/pt scripts/dev_workflow.py test
 if [ $? -ne 0 ]; then
     echo "Tests failed. Commit aborted."
     exit 1
 fi
 
 # Run linters
-python3 scripts/dev_workflow.py lint
+./scripts/pt scripts/dev_workflow.py lint
 if [ $? -ne 0 ]; then
     echo "Linting failed. Commit aborted."
     exit 1
@@ -524,10 +526,10 @@ Add to `.gitconfig`:
 
 ```ini
 [alias]
-    pt-test = !python3 scripts/dev_workflow.py test
-    pt-lint = !python3 scripts/dev_workflow.py lint
-    pt-health = !python3 scripts/dev_workflow.py health
-    pt-perf = !python3 scripts/dev_workflow.py perf-check
+    pt-test = !./scripts/pt scripts/dev_workflow.py test
+    pt-lint = !./scripts/pt scripts/dev_workflow.py lint
+    pt-health = !./scripts/pt scripts/dev_workflow.py health
+    pt-perf = !./scripts/pt scripts/dev_workflow.py perf-check
 ```
 
 Usage:
@@ -563,11 +565,11 @@ Success/Failure
 
 ```bash
 # Simulate CI pipeline locally
-python3 scripts/dev_workflow.py setup
-python3 scripts/dev_workflow.py lint
-python3 scripts/dev_workflow.py test --coverage
-python3 scripts/dev_workflow.py perf-check
-python3 scripts/dev_workflow.py docs-validate
+./scripts/pt scripts/dev_workflow.py setup
+./scripts/pt scripts/dev_workflow.py lint
+./scripts/pt scripts/dev_workflow.py test --coverage
+./scripts/pt scripts/dev_workflow.py perf-check
+./scripts/pt scripts/dev_workflow.py docs-validate
 ```
 
 ---
@@ -581,14 +583,14 @@ python3 scripts/dev_workflow.py docs-validate
 git diff --stat
 
 # Test coverage
-python3 scripts/dev_workflow.py test --coverage
+./scripts/pt scripts/dev_workflow.py test --coverage
 
 # Performance improvements
-python3 scripts/dev_workflow.py perf-check
+./scripts/pt scripts/dev_workflow.py perf-check
 # Compare with previous baseline
 
 # Documentation completeness
-python3 scripts/dev_workflow.py docs-validate
+./scripts/pt scripts/dev_workflow.py docs-validate
 ```
 
 ---
@@ -606,16 +608,16 @@ pip install -e ".[dev]" --upgrade
 rm -rf .pytest_cache
 
 # Run tests again
-python3 scripts/dev_workflow.py test
+./scripts/pt scripts/dev_workflow.py test
 ```
 
 #### Performance Regression
 ```bash
 # Profile the slow operation
-python3 -m cProfile -o profile.stats scripts/<script>.py
+./scripts/pt -m cProfile -o profile.stats scripts/<script>.py
 
 # Analyze profile
-python3 -m pstats profile.stats
+./scripts/pt -m pstats profile.stats
 > sort cumulative
 > stats 20
 ```
@@ -629,7 +631,7 @@ pip list | grep peak_trade
 pip install -e .
 
 # Check Python path
-python3 -c "import sys; print('\n'.join(sys.path))"
+./scripts/pt -c "import sys; print('\n'.join(sys.path))"
 ```
 
 ---

--- a/docs/DEVELOPER_WORKFLOW_GUIDE.md
+++ b/docs/DEVELOPER_WORKFLOW_GUIDE.md
@@ -1,6 +1,6 @@
 # Peak_Trade Developer Workflow Guide
 
-Python floor: `requires-python = ">=3.10"`. Run Peak_Trade Python only via `./scripts/pt` (see `docs/runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md`). PATH `python`/`python3` is not a supported runtime.
+Python floor: `requires-python = ">=3.10"`. Run Peak_Trade Python only via `scripts/pt` (see `docs/runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md`). PATH `python`/`python3` is not a supported runtime.
 
 > **Purpose:** Streamlined workflows and automation tools for productive development
 >
@@ -271,7 +271,7 @@ Keyboard shortcuts:
 1. **External Tools Configuration:**
    - Settings → Tools → External Tools
    - Add tool: "Workflow Health"
-   - Program: `./scripts/pt`
+   - Program: `scripts/pt`
    - Arguments: `scripts&#47;dev_workflow.py health`
    - Working directory: `$ProjectFileDir$`
 

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -30,7 +30,7 @@ uv sync --dev
 ```
 
 Do not use PATH `python3 -m venv` or `source .venv&#47;bin&#47;activate` as the supported runtime.
-Activation is not required. The launcher selects `.venv/bin/python`.
+Activation is not required. The launcher selects `.venv&#47;bin&#47;python`.
 
 ---
 

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -29,7 +29,7 @@ uv sync --dev
 ./scripts/pt runtime-check
 ```
 
-Do not use PATH `python3 -m venv` or `source .venv/bin/activate` as the supported runtime.
+Do not use PATH `python3 -m venv` or `source .venv&#47;bin&#47;activate` as the supported runtime.
 Activation is not required. The launcher selects `.venv/bin/python`.
 
 ---

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -6,9 +6,10 @@ Anleitung zum Einrichten der Entwicklungsumgebung.
 
 ## Voraussetzungen
 
-- **Python 3.11+**
+- **Python floor:** `requires-python = ">=3.10"` (`pyproject.toml`). Recommended local interpreter: repository `.venv` (CPython 3.11.x) via `uv sync --dev`.
 - **Git**
 - Optional: VS Code, PyCharm oder andere IDE
+- Canonical runtime: [`PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md`](runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md)
 
 ---
 
@@ -21,16 +22,15 @@ cd Peak_Trade
 
 ---
 
-## 2. Virtual Environment erstellen
+## 2. Environment bootstrap
 
 ```bash
-# Python venv erstellen
-python3 -m venv .venv
-
-# Aktivieren
-source .venv/bin/activate      # Linux/macOS
-.venv\Scripts\activate         # Windows
+uv sync --dev
+./scripts/pt runtime-check
 ```
+
+Do not use PATH `python3 -m venv` or `source .venv/bin/activate` as the supported runtime.
+Activation is not required. The launcher selects `.venv/bin/python`.
 
 ---
 
@@ -88,13 +88,13 @@ starting_cash_default = 10000.0
 
 ```bash
 # Imports testen
-python3 -c "from src.core.peak_config import load_config; print('OK')"
+./scripts/pt -c "from src.core.peak_config import load_config; print('OK')"
 
 # Backtest mit Dummy-Daten
-python3 scripts/run_backtest.py --bars 100 -v
+./scripts/pt scripts/run_backtest.py --bars 100 -v
 
 # Tests ausführen
-python3 -m pytest tests/ -v
+./scripts/pt -m pytest tests/ -v
 ```
 
 ---
@@ -152,42 +152,42 @@ Peak_Trade/
 
 ```bash
 # Standard (Dummy-Daten)
-python3 scripts/run_backtest.py
+./scripts/pt scripts/run_backtest.py
 
 # Mit CSV-Daten
-python3 scripts/run_backtest.py --data-file data/btc_eur_1h.csv
+./scripts/pt scripts/run_backtest.py --data-file data/btc_eur_1h.csv
 
 # Mit anderer Strategie
-python3 scripts/run_backtest.py --strategy rsi_reversion
+./scripts/pt scripts/run_backtest.py --strategy rsi_reversion
 
 # Verbose-Modus
-python3 scripts/run_backtest.py -v
+./scripts/pt scripts/run_backtest.py -v
 ```
 
 ### Forward-Signale & Paper-Trading
 
 ```bash
 # 1. Signale generieren
-python3 scripts/generate_forward_signals.py --strategy ma_crossover
+./scripts/pt scripts/generate_forward_signals.py --strategy ma_crossover
 
 # 2. Order-Preview
-python3 scripts/preview_live_orders.py --signals reports/forward/*_signals.csv
+./scripts/pt scripts/preview_live_orders.py --signals reports/forward/*_signals.csv
 
 # 3. Paper-Trade
-python3 scripts/paper_trade_from_orders.py --orders reports/live/*_orders.csv
+./scripts/pt scripts/paper_trade_from_orders.py --orders reports/live/*_orders.csv
 ```
 
 ### Tests ausführen
 
 ```bash
 # Alle Tests
-python3 -m pytest tests/
+./scripts/pt -m pytest tests/
 
 # Mit Coverage
-python3 -m pytest tests/ --cov=src --cov-report=html
+./scripts/pt -m pytest tests/ --cov=src --cov-report=html
 
 # Einzelne Test-Datei
-python3 -m pytest tests/test_strategies.py -v
+./scripts/pt -m pytest tests/test_strategies.py -v
 ```
 
 ---
@@ -228,7 +228,7 @@ export PYTHONPATH="${PYTHONPATH}:$(pwd)"
 
 # Oder direkt aus Projekt-Root ausführen
 cd Peak_Trade
-python3 scripts/run_backtest.py
+./scripts/pt scripts/run_backtest.py
 ```
 
 ### "Config not found"
@@ -238,7 +238,7 @@ python3 scripts/run_backtest.py
 ls config/config.toml
 
 # Alternativ explizit angeben
-python3 scripts/run_backtest.py --config config/config.toml
+./scripts/pt scripts/run_backtest.py --config config/config.toml
 ```
 
 ### "ccxt not found"
@@ -281,22 +281,22 @@ secret = ""                # Für Balance/Orders (optional)
 
 ```bash
 # Exchange-Status anzeigen
-python3 scripts/inspect_exchange.py --mode status
+./scripts/pt scripts/inspect_exchange.py --mode status
 
 # Ticker abrufen
-python3 scripts/inspect_exchange.py --mode ticker --symbol BTC/EUR
+./scripts/pt scripts/inspect_exchange.py --mode ticker --symbol BTC/EUR
 
 # OHLCV-Daten (Candlesticks)
-python3 scripts/inspect_exchange.py --mode ohlcv --symbol BTC/EUR --timeframe 1h --limit 20
+./scripts/pt scripts/inspect_exchange.py --mode ohlcv --symbol BTC/EUR --timeframe 1h --limit 20
 
 # Verfügbare Märkte auflisten
-python3 scripts/inspect_exchange.py --mode markets --limit 50
+./scripts/pt scripts/inspect_exchange.py --mode markets --limit 50
 
 # Balance anzeigen (erfordert API-Key)
-python3 scripts/inspect_exchange.py --mode balance
+./scripts/pt scripts/inspect_exchange.py --mode balance
 
 # Offene Orders anzeigen (erfordert API-Key)
-python3 scripts/inspect_exchange.py --mode orders
+./scripts/pt scripts/inspect_exchange.py --mode orders
 ```
 
 ### Programmatische Nutzung
@@ -323,7 +323,7 @@ Exchange-Integration-Tests sind standardmäßig deaktiviert (keine Netzwerk-Requ
 Zum Aktivieren:
 
 ```bash
-PEAK_TRADE_EXCHANGE_TESTS=1 python3 -m pytest tests/test_exchange_smoke.py -v
+PEAK_TRADE_EXCHANGE_TESTS=1 ./scripts/pt -m pytest tests/test_exchange_smoke.py -v
 ```
 
 ---

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -21,7 +21,7 @@ Dieses Dokument führt dich Schritt für Schritt durch deine erste Stunde mit Pe
 ## 1. Voraussetzungen
 
 - **Python floor:** `requires-python = ">=3.10"` in `pyproject.toml`. Recommended local: repository `.venv` via `uv sync --dev` (CPython 3.11.x).
-- Do **not** use PATH `python`/`python3` to run Peak_Trade. Use `./scripts/pt`.
+- Do **not** use PATH `python`/`python3` to run Peak_Trade. Use `scripts/pt`.
 - Vertrag: [`PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md`](runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md)
 - `git` (für Repository-Klonen)
 - `uv` (für Bootstrap)

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -20,9 +20,11 @@ Dieses Dokument führt dich Schritt für Schritt durch deine erste Stunde mit Pe
 
 ## 1. Voraussetzungen
 
-- **Python 3.11+** (prüfen mit `python3 --version`; falls `python` verfügbar ist, geht auch `python --version`)
+- **Python floor:** `requires-python = ">=3.10"` in `pyproject.toml`. Recommended local: repository `.venv` via `uv sync --dev` (CPython 3.11.x).
+- Do **not** use PATH `python`/`python3` to run Peak_Trade. Use `./scripts/pt`.
+- Vertrag: [`PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md`](runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md)
 - `git` (für Repository-Klonen)
-- `virtualenv` oder `venv` (meist bereits in Python enthalten)
+- `uv` (für Bootstrap)
 - Optional: API-Keys für Testnet-Exchange (falls du später Testnet nutzen willst – für den Quickstart nicht nötig)
 
 ---
@@ -36,23 +38,19 @@ git clone <REPO_URL> peak_trade
 cd peak_trade
 ```
 
-### 2.2 Virtual Environment erstellen & aktivieren
+### 2.2 Bootstrap (repository environment)
 
 ```bash
-python3 -m venv .venv
-source .venv/bin/activate  # Windows: .venv\Scripts\activate
+uv sync --dev
+./scripts/pt runtime-check
 ```
 
-### 2.3 Dependencies installieren
-
-```bash
-pip install -r requirements.txt
-```
+Activation is not required. Do not use PATH python/python3.
 
 ### 2.4 (Optional) Test-Suite prüfen
 
 ```bash
-python3 -m pytest -q
+./scripts/pt -m pytest -q
 ```
 
 Dieser Schritt ist optional, aber hilfreich, um sicherzustellen, dass die Test-Suite grundsätzlich grün ist.
@@ -71,7 +69,7 @@ Peak_Trade kommt mit vordefinierten Portfolio-Presets in `config/portfolio_recip
 ### 3.2 Ersten Research-Run starten
 
 ```bash
-python3 scripts/research_cli.py portfolio \
+./scripts/pt scripts/research_cli.py portfolio \
   --config config/config.toml \
   --portfolio-preset rsi_reversion_conservative \
   --format both
@@ -103,7 +101,7 @@ Die Reports enthalten typischerweise:
 Für detailliertere Robustness-Analysen:
 
 ```bash
-python3 scripts/run_portfolio_robustness.py \
+./scripts/pt scripts/run_portfolio_robustness.py \
   --config config/config.toml \
   --portfolio-preset rsi_reversion_conservative \
   --format both
@@ -120,7 +118,7 @@ Dies führt zusätzlich Monte-Carlo-Simulationen und Stress-Tests durch.
 ### 4.1 Health-Check
 
 ```bash
-python3 scripts/live_ops.py health --config config/config.toml
+./scripts/pt scripts/live_ops.py health --config config/config.toml
 ```
 
 **Was prüft `health`?**
@@ -145,7 +143,7 @@ Overall Status: OK
 ### 4.2 Portfolio-Snapshot
 
 ```bash
-python3 scripts/live_ops.py portfolio --config config/config.toml --json
+./scripts/pt scripts/live_ops.py portfolio --config config/config.toml --json
 ```
 
 **Was zeigt `portfolio`?**
@@ -181,7 +179,7 @@ python3 scripts/live_ops.py portfolio --config config/config.toml --json
 ### 5.1 Ersten Daily-Report erstellen
 
 ```bash
-python3 scripts/generate_live_status_report.py \
+./scripts/pt scripts/generate_live_status_report.py \
   --config config/config.toml \
   --output-dir reports/live_status \
   --format markdown \

--- a/docs/SCHEDULER_DAEMON.md
+++ b/docs/SCHEDULER_DAEMON.md
@@ -31,19 +31,19 @@ config/scheduler/jobs.toml  →  run_scheduler.py  →  Registry + Alerts
 ### 1. Scheduler im Dry-Run-Modus testen
 
 ```bash
-python3 scripts/run_scheduler.py --config config/scheduler/jobs.toml --dry-run --once
+./scripts/pt scripts/run_scheduler.py --config config/scheduler/jobs.toml --dry-run --once
 ```
 
 ### 2. Alle fälligen Jobs einmal ausführen
 
 ```bash
-python3 scripts/run_scheduler.py --config config/scheduler/jobs.toml --once
+./scripts/pt scripts/run_scheduler.py --config config/scheduler/jobs.toml --once
 ```
 
 ### 3. Scheduler als Daemon starten
 
 ```bash
-python3 scripts/run_scheduler.py --config config/scheduler/jobs.toml --poll-interval 60
+./scripts/pt scripts/run_scheduler.py --config config/scheduler/jobs.toml --poll-interval 60
 ```
 
 Der Scheduler läuft dann kontinuierlich und prüft alle 60 Sekunden auf fällige Jobs.
@@ -70,13 +70,13 @@ Der Scheduler läuft dann kontinuierlich und prüft alle 60 Sekunden auf fällig
 
 ```bash
 # Nur Forward-Signal-Jobs ausführen
-python3 scripts/run_scheduler.py --include-tags forward --once
+./scripts/pt scripts/run_scheduler.py --include-tags forward --once
 
 # Alle Jobs außer "heavy" ausführen
-python3 scripts/run_scheduler.py --exclude-tags heavy --once
+./scripts/pt scripts/run_scheduler.py --exclude-tags heavy --once
 
 # Verbose Dry-Run
-python3 scripts/run_scheduler.py --dry-run --verbose --once
+./scripts/pt scripts/run_scheduler.py --dry-run --verbose --once
 ```
 
 ---
@@ -91,7 +91,7 @@ Jobs werden in `config/scheduler/jobs.toml` definiert.
 [[job]]
 name = "daily_forward_btc"
 description = "Generiert Forward-Signal für BTC/EUR"
-command = "python3"
+command = "python"  # remapped to the scheduler interpreter (scripts/pt)
 args = { script = "scripts/run_forward_signals.py", strategy = "ma_crossover", symbol = "BTC/EUR" }
 schedule_type = "daily"
 daily_time = "07:30"
@@ -160,7 +160,7 @@ daily_time = "07:30"
 [[job]]
 name = "daily_forward_signals_btc"
 description = "BTC Forward-Signal täglich um 07:30"
-command = "python3"
+command = "python"  # remapped to the scheduler interpreter (scripts/pt)
 args = { script = "scripts/run_forward_signals.py", strategy = "ma_crossover", symbol = "BTC/EUR", timeframe = "1h", bars = 200, tag = "daily-forward" }
 schedule_type = "daily"
 daily_time = "07:30"
@@ -230,7 +230,7 @@ log_scheduler_job_run(
 Abfrage in der Registry:
 
 ```bash
-python3 scripts/list_experiments.py --run-type scheduler_job
+./scripts/pt scripts/list_experiments.py --run-type scheduler_job
 ```
 
 ### Notifications
@@ -251,7 +251,7 @@ Konfiguriere Notifier in `.env` oder Konfigurationsdateien.
 ```bash
 # In einer Screen-Session
 screen -S peak_scheduler
-python3 scripts/run_scheduler.py --config config/scheduler/jobs.toml --poll-interval 60
+./scripts/pt scripts/run_scheduler.py --config config/scheduler/jobs.toml --poll-interval 60
 # Ctrl+A, D zum Detachen
 ```
 
@@ -268,7 +268,7 @@ After=network.target
 Type=simple
 User=trading
 WorkingDirectory=/path/to/Peak_Trade
-ExecStart=/path/to/Peak_Trade/.venv/bin/python3 scripts/run_scheduler.py --config config/scheduler/jobs.toml --poll-interval 60
+ExecStart=/path/to/Peak_Trade/.venv/bin/./scripts/pt scripts/run_scheduler.py --config config/scheduler/jobs.toml --poll-interval 60
 Restart=on-failure
 RestartSec=10
 
@@ -287,7 +287,7 @@ Starte den Scheduler im `--once`-Modus via cron:
 
 ```cron
 # Alle 5 Minuten prüfen
-*/5 * * * * cd /path/to/Peak_Trade && .venv/bin/python3 scripts/run_scheduler.py --once
+*/5 * * * * cd /path/to/Peak_Trade && .venv/bin/./scripts/pt scripts/run_scheduler.py --once
 ```
 
 ### Option 4: launchd (macOS)
@@ -303,7 +303,7 @@ Erstelle `~/Library/LaunchAgents/com.peaktrade.scheduler.plist`:
     <string>com.peaktrade.scheduler</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/path/to/Peak_Trade/.venv/bin/python3</string>
+        <string>/path/to/Peak_Trade/scripts/pt</string>
         <string>/path/to/Peak_Trade/scripts/run_scheduler.py</string>
         <string>--config</string>
         <string>/path/to/Peak_Trade/config/scheduler/jobs.toml</string>
@@ -350,14 +350,14 @@ kill -TERM $(pgrep -f run_scheduler.py)
 3. Nutze `--verbose` für Debug-Output
 
 ```bash
-python3 scripts/run_scheduler.py --dry-run --verbose --once
+./scripts/pt scripts/run_scheduler.py --dry-run --verbose --once
 ```
 
 ### "Config not found"
 
 ```bash
 # Explizit Config angeben
-python3 scripts/run_scheduler.py --config /absolute/path/to/jobs.toml
+./scripts/pt scripts/run_scheduler.py --config /absolute/path/to/jobs.toml
 ```
 
 ### "Job timeout"
@@ -441,7 +441,7 @@ As of this scheduler daemon contract, there is no approved one-command activatio
 The scheduler may be inspected with a dry-run only command:
 
 ```bash
-python3 scripts/run_scheduler.py --config config/scheduler/jobs.toml --dry-run --once --verbose
+./scripts/pt scripts/run_scheduler.py --config config/scheduler/jobs.toml --dry-run --once --verbose
 ```
 
 That dry-run is a planning and diagnostics step only. It must not be treated as daemon activation, Paper runtime activation, Shadow runtime activation, Testnet activation, or Live enablement.

--- a/docs/ai/CLAUDE_GUIDE.md
+++ b/docs/ai/CLAUDE_GUIDE.md
@@ -12,40 +12,34 @@
 
 ## 1. Projekt-Übersicht
 
-**Peak_Trade** ist ein modulares Kryptowährungs-Trading- und Backtesting-Framework in Python 3.9+. Es bietet Strategie-Entwicklung, Backtesting mit realistischen Marktbedingungen, Risk-Management und Live-/Paper-Trading-Funktionalität.
+**Peak_Trade** ist ein modulares Kryptowährungs-Trading- und Backtesting-Framework.
+Python-Floor: `requires-python = ">=3.10"` (`pyproject.toml`). Unterstützte lokale
+Ausführung nur über `scripts/pt`. Vertrag:
+[`PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md`](../runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md).
+Python 3.9 ist kein unterstützter Projekt-Runtime.
 
 ---
 
 ## 2. Quick Commands
 
 ```bash
-# Setup
-source .venv/bin/activate
-pip install -e ".[dev]"
+# Bootstrap (operator-invoked)
+uv sync --dev
 
-# Testing
-python3 -m pytest tests/ -v                              # All tests
-python3 -m pytest tests/test_backtest_smoke.py -v        # Specific file
-python3 -m pytest tests/ --cov=src --cov-report=html     # With coverage
-
-# Linting & Formatting
-ruff check src/ tests/
-black src/ tests/
+# Never execute Peak_Trade Python using PATH python/python3.
+./scripts/pt runtime-check
+./scripts/pt -m pytest tests/ -v
+./scripts/pt -m pytest tests/test_backtest_smoke.py -v
+./scripts/pt -m ruff check src tests
 
 # Run Backtest
-python3 scripts/run_backtest.py
-python3 scripts/run_backtest.py --strategy rsi_reversion
-python3 scripts/run_backtest.py --config custom_config.toml
+./scripts/pt scripts/run_backtest.py
+./scripts/pt scripts/run_backtest.py --strategy rsi_reversion
 
 # Sweeps & Analytics
-python3 scripts/sweep_parameters.py --strategy ma_crossover
-python3 scripts/list_experiments.py --sort-by sharpe
-python3 scripts/generate_leaderboards.py
-
-# Forward/Paper Trading
-python3 scripts/generate_forward_signals.py --strategy ma_crossover
-python3 scripts/check_live_risk_limits.py
-python3 scripts/paper_trade_from_orders.py
+./scripts/pt scripts/sweep_parameters.py --strategy ma_crossover
+./scripts/pt scripts/list_experiments.py --sort-by sharpe
+./scripts/pt scripts/generate_leaderboards.py
 ```
 
 ---
@@ -201,7 +195,7 @@ block_on_violation = true
 
 ## 11. Code-Style
 
-- **Python**: 3.9+, type hints, dataclasses
+- **Python**: 3.10+, type hints, dataclasses
 - **Line length**: 100 characters
 - **Formatter**: Black
 - **Linter**: Ruff

--- a/docs/ai/PEAK_TRADE_AI_HELPER_GUIDE.md
+++ b/docs/ai/PEAK_TRADE_AI_HELPER_GUIDE.md
@@ -16,6 +16,8 @@ Dieses Dokument beschreibt, **wie AI-Tools sinnvoll mit Peak_Trade eingesetzt we
 - **Effizienz** zu steigern (AI als Co-Pilot, nicht als Autopilot)
 
 Für technische Details zu Projekt-Struktur, Modulen und Commands siehe [`CLAUDE_GUIDE.md`](CLAUDE_GUIDE.md).
+Python-Runtime: nur `scripts/pt`. Nie PATH `python`/`python3`. Vertrag:
+[`PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md`](../runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md).
 
 ---
 
@@ -191,7 +193,7 @@ Berücksichtige DEV_GUIDE_ADD_EXCHANGE.md und Safety-Anforderungen."
 - **Explizite Constraints setzen:** „Keine Breaking Changes an der API", „Tests müssen grün bleiben"
 - **Nach Erklärungen fragen:** „Erkläre mir, warum du diesen Ansatz gewählt hast"
 - **Iterativ arbeiten:** Kleine Schritte, Review, nächster Schritt
-- **Tests zuerst prüfen lassen:** „Führe erst `python3 -m pytest tests&#47;test_X.py -v` aus, dann implementiere"
+- **Tests zuerst prüfen lassen:** „Führe erst `./scripts/pt -m pytest tests/test_X.py -v` aus, dann implementiere"
 
 ### Don't
 
@@ -304,7 +306,7 @@ Anforderungen:
 ## 9. Checkliste vor dem Commit (AI-generierter Code)
 
 - [ ] Code gelesen und verstanden?
-- [ ] Tests laufen grün (`python3 -m pytest tests&#47; -v`)?
+- [ ] Tests laufen grün (`./scripts/pt -m pytest tests/ -v`)?
 - [ ] Keine Secrets/Keys im Code?
 - [ ] Keine Safety-Bypasses?
 - [ ] Keine Breaking Changes ohne Absprache?

--- a/docs/dev/UV_QUICKSTART.md
+++ b/docs/dev/UV_QUICKSTART.md
@@ -28,9 +28,8 @@ uv sync
 # Mit Dev-/Tooling‑Gruppe (dependency groups / dev extras wie in pyproject.toml)
 uv sync --dev
 
-# Aktivieren
-source .venv/bin/activate   # Linux/macOS
-# .venv\Scripts\activate    # Windows
+# Runtime: do not rely on activation. Use ./scripts/pt
+./scripts/pt runtime-check
 ```
 
 So bleiben Peak Trade und die englischen **Development Tooling**‑Doku konsistent (**`tooling.md`**: `uv sync`, `uv sync --dev`, `uv add`, `uv add --dev`).
@@ -59,13 +58,13 @@ Bevorzuge **immer** Kombination **`uv sync`** plus bei Bedarf **`uv sync --dev`*
 source .venv/bin/activate  # Linux/macOS
 
 # Tests ausführen
-python3 -m pytest tests/ -v
+./scripts/pt -m pytest tests/ -v
 
 # Einzelnen Test
-python3 -m pytest tests/test_basics.py -v
+./scripts/pt -m pytest tests/test_basics.py -v
 
 # Mit Coverage
-python3 -m pytest tests/ --cov=src --cov-report=term-missing
+./scripts/pt -m pytest tests/ --cov=src --cov-report=term-missing
 
 # Linting
 ruff check src tests scripts

--- a/docs/ops/PYTHON_VERSION_PLAN.md
+++ b/docs/ops/PYTHON_VERSION_PLAN.md
@@ -10,7 +10,7 @@ PYTHON_39_SUPPORTED=false
 
 This planning note is **historical**. It must not be read as current runtime
 guidance. The project floor is `requires-python = ">=3.10"`. Python 3.9 is not a
-supported Peak_Trade runtime. Use `./scripts/pt`, not PATH `python3`.
+supported Peak_Trade runtime. Use `scripts/pt`, not PATH `python3`.
 
 **Status:** SUPERSEDED (kept for history)
 **Historical snapshot in this note:** Python 3.9.6 as then-current local CLT

--- a/docs/ops/PYTHON_VERSION_PLAN.md
+++ b/docs/ops/PYTHON_VERSION_PLAN.md
@@ -1,9 +1,21 @@
 # Python Version Upgrade Plan
 
-**Status:** Planning (not yet implemented)
-**Current Version:** Python 3.9.6
-**Target Version:** Python 3.11 or 3.12
-**Priority:** Medium-High (3.9 EOL: October 2025)
+```text
+DOCUMENT_STATUS=HISTORICAL_SUPERSEDED
+SUPERSEDED_BY=docs/runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md
+CURRENT_PROJECT_FLOOR=requires-python >=3.10 (pyproject.toml)
+CURRENT_SUPPORTED_LOCAL_RUNTIME=.venv/bin/python via scripts/pt
+PYTHON_39_SUPPORTED=false
+```
+
+This planning note is **historical**. It must not be read as current runtime
+guidance. The project floor is `requires-python = ">=3.10"`. Python 3.9 is not a
+supported Peak_Trade runtime. Use `./scripts/pt`, not PATH `python3`.
+
+**Status:** SUPERSEDED (kept for history)
+**Historical snapshot in this note:** Python 3.9.6 as then-current local CLT
+**Current target:** repository `.venv` CPython 3.11.x
+
 
 ---
 

--- a/docs/runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md
+++ b/docs/runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md
@@ -1,0 +1,79 @@
+# Peak_Trade Python Runtime Contract v1
+
+```text
+AUTHORITY_CLASS=OPERATIVE_RUNTIME_CONTRACT
+RUNTIME_AUTHORIZATION_EFFECT=NONE
+CONTRACT_ID=pt_python_runtime_contract_v1
+CANONICAL_LAUNCHER=scripts/pt
+CANONICAL_INTERPRETER=.venv/bin/python
+REQUIRES_PYTHON=>=3.10
+PATH_PYTHON_FALLBACK_ALLOWED=false
+VENV_ACTIVATION_REQUIRED=false
+```
+
+This is the current supported Python execution model for Peak_Trade.
+
+It does **not** authorize Live, Testnet, orders, credentials, or capital movement.
+
+## Identity
+
+Same repository revision + same config + same declared runtime must select the
+same interpreter and import model. Selection must not depend on PATH, pyenv,
+shell activation, IDE interpreter, caller cwd, or `PYTHONPATH`.
+
+Machine-readable SSOT for the version floor is `pyproject.toml`
+`requires-python = ">=3.10"`. Recommended local interpreter is the repository
+`.venv` (currently provisioned as CPython 3.11.x). Python 3.9 is **not** a
+supported project runtime.
+
+## Bootstrap versus runtime
+
+Bootstrap (operator-invoked):
+
+```text
+uv sync --dev
+```
+
+Runtime must only validate and use the provisioned environment. Runtime must
+not create a venv, install packages, or source `.venv/bin/activate`.
+
+## Canonical commands
+
+```text
+./scripts/pt runtime-check
+./scripts/pt fingerprint
+./scripts/pt -m pytest -q
+./scripts/pt -c "import trading"
+make runtime-check
+```
+
+Root trampoline `./pt` execs `scripts/pt`.
+
+## Prohibited on current operative local surfaces
+
+- bare `python`
+- bare `python3`
+- `#!/usr/bin/env python3` as a supported way to start Peak_Trade
+- `source .venv/bin/activate` as the correctness mechanism
+- arbitrary `PYTHONPATH` / `sys.path` mutation as the runtime solution
+- direct `src/` execution for package code
+
+## Documented exceptions
+
+- **CI provisioned interpreter:** GitHub Actions may invoke `python` after
+  `setup-python` pins a version that satisfies `requires-python`. Set
+  `PT_RUNTIME_MODE=provisioned` only in CI or with
+  `PT_RUNTIME_PROVISIONED_OK=1`.
+- **Pytest `tests/conftest.py`:** inserts `src` and repo root for test
+  collection only.
+- **Shebangs on non-operative scripts:** not a runtime API. Invoke through
+  `scripts/pt`.
+- **A small set of existing offline-eval wrappers** resolve
+  `.venv/bin/python` directly and fail closed if it is missing. New surfaces
+  must use `scripts/pt`.
+
+## Agents
+
+Never infer the interpreter from the terminal. If `scripts/pt runtime-check`
+fails: HARD STOP. Do not improvise `PYTHONPATH`, PATH `python3`, or package
+installs.

--- a/docs/runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md
+++ b/docs/runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md
@@ -35,7 +35,7 @@ uv sync --dev
 ```
 
 Runtime must only validate and use the provisioned environment. Runtime must
-not create a venv, install packages, or source `.venv/bin/activate`.
+not create a venv, install packages, or source `.venv&#47;bin&#47;activate`.
 
 ## Canonical commands
 
@@ -69,7 +69,7 @@ Root trampoline `pt` execs `scripts/pt`.
 - **Shebangs on non-operative scripts:** not a runtime API. Invoke through
   `scripts/pt`.
 - **A small set of existing offline-eval wrappers** resolve
-  `.venv/bin/python` directly and fail closed if it is missing. New surfaces
+  `.venv&#47;bin&#47;python` directly and fail closed if it is missing. New surfaces
   must use `scripts/pt`.
 
 ## Agents

--- a/docs/runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md
+++ b/docs/runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md
@@ -47,14 +47,14 @@ not create a venv, install packages, or source `.venv/bin/activate`.
 make runtime-check
 ```
 
-Root trampoline `./pt` execs `scripts/pt`.
+Root trampoline `pt` execs `scripts/pt`.
 
 ## Prohibited on current operative local surfaces
 
 - bare `python`
 - bare `python3`
-- `#!/usr/bin/env python3` as a supported way to start Peak_Trade
-- `source .venv/bin/activate` as the correctness mechanism
+- `#!&#47;usr&#47;bin&#47;env python3` as a supported way to start Peak_Trade
+- `source .venv&#47;bin&#47;activate` as the correctness mechanism
 - arbitrary `PYTHONPATH` / `sys.path` mutation as the runtime solution
 - direct `src/` execution for package code
 
@@ -74,6 +74,6 @@ Root trampoline `./pt` execs `scripts/pt`.
 
 ## Agents
 
-Never infer the interpreter from the terminal. If `scripts/pt runtime-check`
+Never infer the interpreter from the terminal. If `scripts/pt` `runtime-check`
 fails: HARD STOP. Do not improvise `PYTHONPATH`, PATH `python3`, or package
 installs.

--- a/docs/runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md
+++ b/docs/runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md
@@ -60,10 +60,10 @@ Root trampoline `pt` execs `scripts/pt`.
 
 ## Documented exceptions
 
-- **CI provisioned interpreter:** GitHub Actions may invoke `python` after
-  `setup-python` pins a version that satisfies `requires-python`. Set
-  `PT_RUNTIME_MODE=provisioned` only in CI or with
-  `PT_RUNTIME_PROVISIONED_OK=1`.
+- **CI provisioned interpreter:** GitHub Actions may bind a pinned interpreter
+  after `setup-python`. Set `PT_RUNTIME_MODE=provisioned` only in CI or with
+  `PT_RUNTIME_PROVISIONED_OK=1`. The launcher then uses `pythonLocation&#47;bin&#47;python`
+  or `PT_PROVISIONED_PYTHON`. Local PATH `python`/`python3` remains prohibited.
 - **Pytest `tests/conftest.py`:** inserts `src` and repo root for test
   collection only.
 - **Shebangs on non-operative scripts:** not a runtime API. Invoke through

--- a/pt
+++ b/pt
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Root trampoline. Canonical launcher is scripts/pt.
+set -eu
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec "$ROOT/scripts/pt" "$@"

--- a/scripts/governance/ai_matrix_consistency_gate.sh
+++ b/scripts/governance/ai_matrix_consistency_gate.sh
@@ -5,5 +5,7 @@ MATRIX="docs/governance/matrix/AI_AUTONOMY_LAYER_MAP_MODEL_MATRIX.md"
 REGISTRY="config/model_registry.toml"
 
 ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+# This gate is not application runtime; skip the trading import preflight.
+export PT_SKIP_TRADING_PREFLIGHT=1
 "$ROOT/scripts/pt" src/governance/validate_ai_matrix_vs_registry.py "${MATRIX}" "${REGISTRY}"
 echo "[PASS] AI matrix consistency gate"

--- a/scripts/governance/ai_matrix_consistency_gate.sh
+++ b/scripts/governance/ai_matrix_consistency_gate.sh
@@ -4,5 +4,6 @@ set -euo pipefail
 MATRIX="docs/governance/matrix/AI_AUTONOMY_LAYER_MAP_MODEL_MATRIX.md"
 REGISTRY="config/model_registry.toml"
 
-python3 src/governance/validate_ai_matrix_vs_registry.py "${MATRIX}" "${REGISTRY}"
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+"$ROOT/scripts/pt" src/governance/validate_ai_matrix_vs_registry.py "${MATRIX}" "${REGISTRY}"
 echo "[PASS] AI matrix consistency gate"

--- a/scripts/obs/README.md
+++ b/scripts/obs/README.md
@@ -26,8 +26,8 @@ reports&#47;obs&#47;stage1&#47;
 bash scripts/obs/run_stage1_monitoring.sh
 
 # Option 2: Manuell
-python3 scripts/obs/stage1_daily_snapshot.py
-python3 scripts/obs/stage1_trend_report.py
+./scripts/pt  scripts/obs/stage1_daily_snapshot.py
+./scripts/pt  scripts/obs/stage1_trend_report.py
 ```
 
 ## Stage1 report index (deterministic)
@@ -37,14 +37,14 @@ After Stage1 runs, a deterministic index is generated:
 - Purpose: stable discovery for WebUI/ops; includes sha256 + size for artifacts.
 
 You can regenerate manually:
-`python3 scripts/obs/stage1_report_index.py --root reports/obs/stage1 --out reports/obs/stage1/index.json --run-date YYYY-MM-DD` <!-- pt:ref-target-ignore -->
+`./scripts/pt  scripts/obs/stage1_report_index.py --root reports/obs/stage1 --out reports/obs/stage1/index.json --run-date YYYY-MM-DD` <!-- pt:ref-target-ignore -->
 
 ## Stage1 validation (fail-fast)
 After index generation, Stage1 runners validate artifacts and write:
 - `reports&#47;obs&#47;stage1&#47;validation.json` (schema: `stage1_validation.v1`)
 
 Manual run:
-`python3 scripts/obs/validate_stage1_index.py --root reports/obs/stage1 --index reports/obs/stage1/index.json --out reports/obs/stage1/validation.json --require data.json --require report.md` <!-- pt:ref-target-ignore -->
+`./scripts/pt  scripts/obs/validate_stage1_index.py --root reports/obs/stage1 --index reports/obs/stage1/index.json --out reports/obs/stage1/validation.json --require data.json --require report.md` <!-- pt:ref-target-ignore -->
 
 ---
 
@@ -95,10 +95,10 @@ Labeled legacy context: `docs/ops/reviews/grafana_prometheus_operator_entrypoint
 
 ```bash
 # Standard-Run (verwendet defaults)
-python3 scripts/obs/stage1_daily_snapshot.py
+./scripts/pt  scripts/obs/stage1_daily_snapshot.py
 
 # Mit custom Optionen
-python3 scripts/obs/stage1_daily_snapshot.py \
+./scripts/pt  scripts/obs/stage1_daily_snapshot.py \
   --repo ~/Peak_Trade \
   --out-dir reports&#47;obs&#47;stage1 \
   --max-files 10 \
@@ -140,13 +140,13 @@ Erstellt `reports&#47;obs&#47;stage1&#47;YYYY-MM-DD_snapshot.md` mit:
 
 ```bash
 # Letzte 14 Tage (default)
-python3 scripts/obs/stage1_trend_report.py
+./scripts/pt  scripts/obs/stage1_trend_report.py
 
 # Letzte 7 Tage
-python3 scripts/obs/stage1_trend_report.py --days 7
+./scripts/pt  scripts/obs/stage1_trend_report.py --days 7
 
 # Custom Snapshot-Directory
-python3 scripts/obs/stage1_trend_report.py --dir reports&#47;obs&#47;stage1
+./scripts/pt  scripts/obs/stage1_trend_report.py --dir reports&#47;obs&#47;stage1
 ```
 
 ### Optionen
@@ -243,18 +243,18 @@ Siehe `.github&#47;workflows&#47;stage1_monitoring.yml` (falls vorhanden). <!-- 
 
 ```bash
 # 1) Daily Snapshot (soll 0 neue Alerts zeigen)
-python3 scripts/obs/stage1_daily_snapshot.py
+./scripts/pt  scripts/obs/stage1_daily_snapshot.py
 echo "Exit code: $?"  # Soll 0 sein
 
 # 2) Trend Report (soll ✅ signal zeigen)
-python3 scripts/obs/stage1_trend_report.py
+./scripts/pt  scripts/obs/stage1_trend_report.py
 ```
 
 ### Fail-on-new-alerts Test
 
 ```bash
 # Soll Exit Code 2 zurückgeben wenn neue Alerts detektiert werden
-python3 scripts/obs/stage1_daily_snapshot.py --fail-on-new-alerts
+./scripts/pt  scripts/obs/stage1_daily_snapshot.py --fail-on-new-alerts
 if [ $? -eq 2 ]; then
   echo "⚠️ Neue Alerts detektiert!"
 fi

--- a/scripts/obs/_prom_query_json.sh
+++ b/scripts/obs/_prom_query_json.sh
@@ -82,12 +82,8 @@ while [ "$i" -le "$RETRIES" ]; do
   echo "PROM_QUERY_RETRY attempt=$i http_code=$http_code content_type=${ctype:-NONE} body_bytes=${bytes:-0}" >&2
   echo "--- hdr (first 20) ---" >&2; sed -n "1,20p" "$tmp_hdr" >&2 || true
   echo "--- body (first 200 bytes) ---" >&2
-  python3 - << PY >&2
-from pathlib import Path
-p=Path("$tmp_body")
-b=p.read_bytes() if p.exists() else b""
-print(b[:200].decode("utf-8","replace"))
-PY
+  head -c 200 "$tmp_body" >&2 || true
+  echo >&2
   sleep "$i"
   i=$((i+1))
 done

--- a/scripts/obs/ai_live_activity_demo.sh
+++ b/scripts/obs/ai_live_activity_demo.sh
@@ -38,14 +38,12 @@ mkdir -p "$(dirname "$EVENTS_JSONL")" 2>/dev/null || true
 touch "$EVENTS_JSONL"
 
 resolve_py_cmd() {
+  # Canonical Peak_Trade runtime. Never PATH python3 / uv run python.
   if [[ -n "${PY_CMD:-}" ]]; then
     return 0
   fi
-  if command -v uv >/dev/null 2>&1; then
-    PY_CMD="uv run python"
-  else
-    PY_CMD="python3"
-  fi
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  PY_CMD="${REPO_ROOT}/scripts/pt"
 }
 
 resolve_py_cmd

--- a/scripts/obs/ai_live_local_verify.sh
+++ b/scripts/obs/ai_live_local_verify.sh
@@ -65,7 +65,7 @@ finalize_evidence() {
   } >"$OUT/META.txt"
 
   # Latest evidence dirs (no pipes)
-  python3 - "$OUT" <<'PY'
+  ./scripts/pt - "$OUT" <<'PY'
 from __future__ import annotations
 
 import glob
@@ -125,7 +125,7 @@ EOF
   fi
 
   # Manifest (sha256) for wrapper OUT (no pipes)
-  python3 - "$OUT" <<'PY'
+  ./scripts/pt - "$OUT" <<'PY'
 from __future__ import annotations
 
 import hashlib
@@ -158,7 +158,7 @@ print(f"wrote: {manifest}")
 PY
 
   # Key material scan (head-only heuristic; no pipes)
-  python3 - "$OUT" <<'PY'
+  ./scripts/pt - "$OUT" <<'PY'
 from __future__ import annotations
 
 import os
@@ -255,7 +255,7 @@ if [[ "$exporter_ok" = "1" ]]; then
   activity_rc=$?
   set -e
   echo "$activity_rc" >"$OUT/activity_rc.txt"
-  python3 - "$OUT/activity_demo.stdout" "$OUT/ACTIVITY_DEMO_EVIDENCE_DIR.txt" <<'PY'
+  ./scripts/pt - "$OUT/activity_demo.stdout" "$OUT/ACTIVITY_DEMO_EVIDENCE_DIR.txt" <<'PY'
 from __future__ import annotations
 
 import sys
@@ -284,7 +284,7 @@ bash scripts/obs/ai_live_ops_verify.sh >"$OUT/ai_live_ops_verify.stdout" 2>"$OUT
 verify_rc=$?
 set -e
 echo "$verify_rc" >"$OUT/verify_rc.txt"
-python3 - "$OUT/ai_live_ops_verify.stdout" "$OUT/VERIFY_EVIDENCE_DIR.txt" <<'PY'
+./scripts/pt - "$OUT/ai_live_ops_verify.stdout" "$OUT/VERIFY_EVIDENCE_DIR.txt" <<'PY'
 from __future__ import annotations
 
 import sys

--- a/scripts/obs/ai_live_ops_verify.sh
+++ b/scripts/obs/ai_live_ops_verify.sh
@@ -25,19 +25,13 @@ STAMP_UTC="$(date -u +%Y%m%dT%H%M%SZ)"
 OUT="${VERIFY_OUT_DIR:-${OUT_DIR:-.local_tmp/ai_live_ops_verify_${STAMP_UTC}}}"
 mkdir -p "$OUT"
 
-# Deterministic Python environment contract:
-# - If $PY_CMD is set, use it.
-# - Else prefer uv-managed env (common in repo ops scripts).
-# - Else fall back to system python3.
 resolve_py_cmd() {
+  # Canonical Peak_Trade runtime. Never PATH python3 / uv run python.
   if [[ -n "${PY_CMD:-}" ]]; then
     return 0
   fi
-  if command -v uv >/dev/null 2>&1; then
-    PY_CMD="uv run python"
-  else
-    PY_CMD="python3"
-  fi
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  PY_CMD="${REPO_ROOT}/scripts/pt"
 }
 
 resolve_py_cmd

--- a/scripts/obs/ai_live_restart.sh
+++ b/scripts/obs/ai_live_restart.sh
@@ -18,20 +18,12 @@ LOG_PATH="$RUNTIME_DIR/ai_live_restart.log"
 PID_PATH="$RUNTIME_DIR/ai_live_restart.pid"
 
 resolve_py_cmd() {
+  # Canonical Peak_Trade runtime. Never PATH python3 / uv run python.
   if [[ -n "${PY_CMD:-}" ]]; then
     return 0
   fi
-  # Deterministic: prefer repo-local obs venv (no uv, no global pip).
-  REPO_ROOT="$(pwd)"
-  if [[ -x "$REPO_ROOT/.venv_obs/bin/python" ]]; then
-    PY_CMD="$REPO_ROOT/.venv_obs/bin/python"
-    return 0
-  fi
-  if command -v uv >/dev/null 2>&1; then
-    PY_CMD="uv run python"
-  else
-    PY_CMD="python3"
-  fi
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  PY_CMD="${REPO_ROOT}/scripts/pt"
 }
 resolve_py_cmd
 read -r -a PY_ARR <<<"${PY_CMD}"

--- a/scripts/obs/ai_live_smoke_test.sh
+++ b/scripts/obs/ai_live_smoke_test.sh
@@ -16,18 +16,12 @@ PROM_URL="${PROM_URL:-http://127.0.0.1:9092}"
 JOB_NAME="${JOB_NAME:-ai_live}"
 
 resolve_py_cmd() {
-  # Deterministic Python environment contract:
-  # - If $PY_CMD is set, use it.
-  # - Else prefer uv-managed env (ensures prometheus_client available for exporter).
-  # - Else fall back to system python3.
+  # Canonical Peak_Trade runtime. Never PATH python3 / uv run python.
   if [[ -n "${PY_CMD:-}" ]]; then
     return 0
   fi
-  if command -v uv >/dev/null 2>&1; then
-    PY_CMD="uv run python"
-  else
-    PY_CMD="python3"
-  fi
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  PY_CMD="${REPO_ROOT}/scripts/pt"
 }
 
 resolve_py_cmd

--- a/scripts/obs/ai_live_verify.sh
+++ b/scripts/obs/ai_live_verify.sh
@@ -9,18 +9,12 @@ EXPORTER_URL="${EXPORTER_URL:-http://127.0.0.1:${AI_LIVE_PORT}/metrics}"
 JOB_NAME="${JOB_NAME:-ai_live}"
 
 resolve_py_cmd() {
-  # Deterministic Python environment contract:
-  # - If $PY_CMD is set, use it.
-  # - Else prefer uv-managed env (common in repo ops scripts).
-  # - Else fall back to system python3.
+  # Canonical Peak_Trade runtime. Never PATH python3 / uv run python.
   if [[ -n "${PY_CMD:-}" ]]; then
     return 0
   fi
-  if command -v uv >/dev/null 2>&1; then
-    PY_CMD="uv run python"
-  else
-    PY_CMD="python3"
-  fi
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+  PY_CMD="${REPO_ROOT}/scripts/pt"
 }
 
 resolve_py_cmd

--- a/scripts/obs/prom_9094_9095_restart.sh
+++ b/scripts/obs/prom_9094_9095_restart.sh
@@ -25,11 +25,13 @@ AILIVE_COMPOSE="${AILIVE_COMPOSE:-}"
 echo "== docker compose ls =="
 docker compose ls || true
 
-RESOLVE_JSON="$(python3 scripts/obs/resolve_obse_ailive_compose.py)"
-OBSE_PROJECT="$(printf '%s' "$RESOLVE_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("OBSE_PROJECT",""))')"
-AILIVE_PROJECT="$(printf '%s' "$RESOLVE_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("AILIVE_PROJECT",""))')"
-OBSE_COMPOSE_ARGS="$(printf '%s' "$RESOLVE_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("OBSE_COMPOSE_ARGS",""))')"
-AILIVE_COMPOSE_ARGS="$(printf '%s' "$RESOLVE_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("AILIVE_COMPOSE_ARGS",""))')"
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PT="${ROOT}/scripts/pt"
+RESOLVE_JSON="$("$PT" scripts/obs/resolve_obse_ailive_compose.py)"
+OBSE_PROJECT="$(printf '%s' "$RESOLVE_JSON" | "$PT" -c 'import json,sys; print(json.load(sys.stdin).get("OBSE_PROJECT",""))')"
+AILIVE_PROJECT="$(printf '%s' "$RESOLVE_JSON" | "$PT" -c 'import json,sys; print(json.load(sys.stdin).get("AILIVE_PROJECT",""))')"
+OBSE_COMPOSE_ARGS="$(printf '%s' "$RESOLVE_JSON" | "$PT" -c 'import json,sys; print(json.load(sys.stdin).get("OBSE_COMPOSE_ARGS",""))')"
+AILIVE_COMPOSE_ARGS="$(printf '%s' "$RESOLVE_JSON" | "$PT" -c 'import json,sys; print(json.load(sys.stdin).get("AILIVE_COMPOSE_ARGS",""))')"
 
 echo ""
 echo "== resolved config =="

--- a/scripts/obs/prom_9094_9095_up_and_verify.sh
+++ b/scripts/obs/prom_9094_9095_up_and_verify.sh
@@ -29,11 +29,13 @@ AILIVE_COMPOSE="${AILIVE_COMPOSE:-}"
 echo "== docker compose ls =="
 docker compose ls || true
 
-RESOLVE_JSON="$(python3 scripts/obs/resolve_obse_ailive_compose.py)"
-OBSE_PROJECT="$(printf '%s' "$RESOLVE_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("OBSE_PROJECT",""))')"
-AILIVE_PROJECT="$(printf '%s' "$RESOLVE_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("AILIVE_PROJECT",""))')"
-OBSE_COMPOSE_ARGS="$(printf '%s' "$RESOLVE_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("OBSE_COMPOSE_ARGS",""))')"
-AILIVE_COMPOSE_ARGS="$(printf '%s' "$RESOLVE_JSON" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("AILIVE_COMPOSE_ARGS",""))')"
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PT="${ROOT}/scripts/pt"
+RESOLVE_JSON="$("$PT" scripts/obs/resolve_obse_ailive_compose.py)"
+OBSE_PROJECT="$(printf '%s' "$RESOLVE_JSON" | "$PT" -c 'import json,sys; print(json.load(sys.stdin).get("OBSE_PROJECT",""))')"
+AILIVE_PROJECT="$(printf '%s' "$RESOLVE_JSON" | "$PT" -c 'import json,sys; print(json.load(sys.stdin).get("AILIVE_PROJECT",""))')"
+OBSE_COMPOSE_ARGS="$(printf '%s' "$RESOLVE_JSON" | "$PT" -c 'import json,sys; print(json.load(sys.stdin).get("OBSE_COMPOSE_ARGS",""))')"
+AILIVE_COMPOSE_ARGS="$(printf '%s' "$RESOLVE_JSON" | "$PT" -c 'import json,sys; print(json.load(sys.stdin).get("AILIVE_COMPOSE_ARGS",""))')"
 
 echo ""
 echo "== resolved config =="

--- a/scripts/obs/run_stage1_monitoring.sh
+++ b/scripts/obs/run_stage1_monitoring.sh
@@ -34,7 +34,7 @@ echo
 # 1) Daily Snapshot
 # -----------------------------
 echo "=== 1) Generating Daily Snapshot ==="
-python3 scripts/obs/stage1_daily_snapshot.py
+"$REPO_ROOT/scripts/pt" scripts/obs/stage1_daily_snapshot.py
 EXIT_CODE=$?
 
 if [ $EXIT_CODE -eq 0 ]; then
@@ -48,7 +48,7 @@ fi
 
 echo
 echo "=== 2) Generating Trend Report (last 14 days) ==="
-python3 scripts/obs/stage1_trend_report.py --days 14
+"$REPO_ROOT/scripts/pt" scripts/obs/stage1_trend_report.py --days 14
 
 echo
 echo "============================================================"
@@ -64,12 +64,12 @@ echo "  - Review reports for anomalies"
 echo "  - Check 'New alerts (24h)' in snapshot"
 echo "  - If trend stable for 1-2 weeks → proceed to Stage 2 (Webhook)"
 
-python3 scripts/obs/stage1_report_index.py \
+"$REPO_ROOT/scripts/pt" scripts/obs/stage1_report_index.py \
   --root "${REPORT_ROOT}" \
   --out "${REPORT_ROOT}/index.json" \
   --run-date "${RUN_DATE}"
 
-python3 scripts/obs/validate_stage1_index.py \
+"$REPO_ROOT/scripts/pt" scripts/obs/validate_stage1_index.py \
   --root "${REPORT_ROOT}" \
   --index "${REPORT_ROOT}/index.json" \
   --out "${REPORT_ROOT}/validation.json" \

--- a/scripts/obs/smoke.sh
+++ b/scripts/obs/smoke.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 cd "$(git rev-parse --show-toplevel)"
 
 # Expect user has otel extras installed in their venv
-python3 -c "import opentelemetry" >/dev/null 2>&1 || {
+./scripts/pt -c "import opentelemetry" >/dev/null 2>&1 || {
   echo "❌ OpenTelemetry deps missing. Install with: pip install -e '.[otel]'" >&2
   exit 1
 }
@@ -12,7 +12,7 @@ python3 -c "import opentelemetry" >/dev/null 2>&1 || {
 export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
 export OTEL_SERVICE_NAME="peak_trade_smoke_sender"
 
-python3 scripts/obs/smoke_sender.py
+./scripts/pt scripts/obs/smoke_sender.py
 
 echo ""
 echo "Now open Grafana -> Explore -> Tempo and search for service: peak_trade_smoke_sender"

--- a/scripts/obs/stage1_run_daily.sh
+++ b/scripts/obs/stage1_run_daily.sh
@@ -1,20 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cd "$HOME/Peak_Trade"
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$ROOT"
 
 # Deterministic date anchor (can be injected by caller/CI)
 RUN_DATE="${RUN_DATE:-$(date -u +%F)}"
 # Align with Stage1 default reports root (get_reports_root()).
 REPORT_ROOT="${REPORT_ROOT:-reports/obs/stage1}"
 
-# Prefer project venv if present
-if [ -f ".venv/bin/activate" ]; then
-  source ".venv/bin/activate"
-  PY="python"
-else
-  PY="python3"
-fi
+PY="$ROOT/scripts/pt"
 
 DATE="$(date +%F)"
 mkdir -p "logs/obs/stage1"

--- a/scripts/obs/stage1_run_weekly.sh
+++ b/scripts/obs/stage1_run_weekly.sh
@@ -1,14 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-cd "$HOME/Peak_Trade"
+ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)"
+cd "$ROOT"
 
-if [ -f ".venv/bin/activate" ]; then
-  source ".venv/bin/activate"
-  PY="python"
-else
-  PY="python3"
-fi
+PY="$ROOT/scripts/pt"
 
 RUN_DATE="${RUN_DATE:-$(date -u +%F)}"
 # Align with Stage1 default reports root (get_reports_root()).

--- a/scripts/ops/bg_job.sh
+++ b/scripts/ops/bg_job.sh
@@ -62,13 +62,9 @@ case "${subcmd}" in
     exitfile="${LOG_DIR}/${label}_${ts}.exit"
     metafile="${LOG_DIR}/${label}_${ts}.meta"
 
-    # Determine venv activate (optional)
+    # Activation is not a correctness mechanism. Peak_Trade Python jobs
+    # must invoke ${REPO_DIR}/scripts/pt (never PATH python/python3).
     venv_activate=""
-    if [[ -f "${REPO_DIR}/venv/bin/activate" ]]; then
-      venv_activate="${REPO_DIR}/venv/bin/activate"
-    elif [[ -f "${REPO_DIR}/.venv/bin/activate" ]]; then
-      venv_activate="${REPO_DIR}/.venv/bin/activate"
-    fi
 
     # Choose shell for "login command" behavior where needed
     shell_bin="bash"

--- a/scripts/ops/kill_switch_ctl.sh
+++ b/scripts/ops/kill_switch_ctl.sh
@@ -22,18 +22,10 @@ NC='\033[0m' # No Color
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
-# Python module path
-KILL_SWITCH_CLI="python -m src.risk_layer.kill_switch.cli"
+PT="$PROJECT_ROOT/scripts/pt"
 
 # Change to project root
 cd "$PROJECT_ROOT"
-
-# Activate venv if exists
-if [ -d "venv" ]; then
-    source venv/bin/activate
-elif [ -d ".venv" ]; then
-    source .venv/bin/activate
-fi
 
 # Functions
 show_help() {
@@ -71,7 +63,7 @@ EOF
 
 cmd_status() {
     echo -e "${GREEN}Checking Kill Switch status...${NC}\n"
-    $KILL_SWITCH_CLI status
+    "$PT" -m src.risk_layer.kill_switch.cli status
 }
 
 cmd_trigger() {
@@ -89,7 +81,7 @@ cmd_trigger() {
 
     echo ""
     echo -e "${RED}Triggering Kill Switch...${NC}"
-    $KILL_SWITCH_CLI trigger --reason "$reason" --confirm
+    "$PT" -m src.risk_layer.kill_switch.cli trigger --reason "$reason" --confirm
 
     echo ""
     echo -e "${YELLOW}Trading is now BLOCKED.${NC}"
@@ -117,7 +109,7 @@ cmd_recover() {
 
     echo ""
     echo -e "${YELLOW}Requesting recovery...${NC}"
-    $KILL_SWITCH_CLI recover \
+    "$PT" -m src.risk_layer.kill_switch.cli recover \
         --code "$KILL_SWITCH_APPROVAL_CODE" \
         --reason "$reason" \
         --approved-by "$OPERATOR"
@@ -137,15 +129,15 @@ cmd_audit() {
     echo -e "${GREEN}Kill Switch Audit Trail${NC}\n"
 
     if [ -n "$since" ]; then
-        $KILL_SWITCH_CLI audit --since "$since"
+        "$PT" -m src.risk_layer.kill_switch.cli audit --since "$since"
     else
-        $KILL_SWITCH_CLI audit --limit 20
+        "$PT" -m src.risk_layer.kill_switch.cli audit --limit 20
     fi
 }
 
 cmd_health() {
     echo -e "${GREEN}System Health Check${NC}\n"
-    $KILL_SWITCH_CLI health
+    "$PT" -m src.risk_layer.kill_switch.cli health
 }
 
 # Main

--- a/scripts/pt
+++ b/scripts/pt
@@ -86,14 +86,33 @@ EOF
   exit 0
 fi
 
-if [ ! -f "$INTERPRETER" ]; then
-  die 3 "PT_RUNTIME_FAIL: canonical interpreter missing: $INTERPRETER
+# Documented CI exception: after setup-python, PT_RUNTIME_MODE=provisioned
+# plus GITHUB_ACTIONS=true (or PT_RUNTIME_PROVISIONED_OK=1) binds a pinned
+# interpreter via pythonLocation or PT_PROVISIONED_PYTHON. Local PATH
+# python/python3 remains prohibited.
+if [ "${PT_RUNTIME_MODE:-}" = "provisioned" ]; then
+  if [ "${GITHUB_ACTIONS:-}" != "true" ] && [ "${PT_RUNTIME_PROVISIONED_OK:-}" != "1" ]; then
+    die 8 "PT_RUNTIME_FAIL: provisioned mode refused (needs GITHUB_ACTIONS=true or PT_RUNTIME_PROVISIONED_OK=1)"
+  fi
+  INTERPRETER=""
+  if [ -n "${pythonLocation:-}" ] && [ -x "${pythonLocation}/bin/python" ]; then
+    INTERPRETER="${pythonLocation}/bin/python"
+  elif [ -n "${PT_PROVISIONED_PYTHON:-}" ] && [ -x "${PT_PROVISIONED_PYTHON}" ]; then
+    INTERPRETER="${PT_PROVISIONED_PYTHON}"
+  fi
+  if [ -z "$INTERPRETER" ] || [ ! -x "$INTERPRETER" ]; then
+    die 8 "PT_RUNTIME_FAIL: provisioned interpreter unbound (set pythonLocation or PT_PROVISIONED_PYTHON)"
+  fi
+else
+  INTERPRETER="$REPO_ROOT/.venv/bin/python"
+  if [ ! -f "$INTERPRETER" ]; then
+    die 3 "PT_RUNTIME_FAIL: canonical interpreter missing: $INTERPRETER
 Bootstrap with: uv sync --dev
 Do not use PATH python/python3."
-fi
-
-if [ ! -x "$INTERPRETER" ]; then
-  die 4 "PT_RUNTIME_FAIL: canonical interpreter not executable: $INTERPRETER"
+  fi
+  if [ ! -x "$INTERPRETER" ]; then
+    die 4 "PT_RUNTIME_FAIL: canonical interpreter not executable: $INTERPRETER"
+  fi
 fi
 
 # Version check uses the canonical interpreter only (never PATH python3).

--- a/scripts/pt
+++ b/scripts/pt
@@ -1,0 +1,123 @@
+#!/bin/sh
+# Peak_Trade canonical Python launcher (POSIX).
+# Resolves REPO_ROOT from this script location and execs
+# REPO_ROOT/.venv/bin/python. Never uses PATH python/python3.
+# Does not create a venv, install packages, or activate a venv.
+set -eu
+
+CONTRACT_VERSION="v1"
+REQUIRES_PYTHON_MAJOR=3
+REQUIRES_PYTHON_MINOR=10
+
+die() {
+  code="$1"
+  shift
+  printf '%s\n' "$*" >&2
+  exit "$code"
+}
+
+# Builtins only for path resolution so an empty PATH cannot select another
+# Python. Optional symlink follow uses absolute /usr/bin/readlink if present.
+resolve_self() {
+  target=$0
+  max=32
+  while [ "$max" -gt 0 ]; do
+    max=$((max - 1))
+    case "$target" in
+      /*) abs=$target ;;
+      */*)
+        _dir=${target%/*}
+        _base=${target##*/}
+        abs="$(CDPATH= cd -- "$_dir" && pwd)/$_base"
+        ;;
+      *) abs="$(pwd)/$target" ;;
+    esac
+    if [ -L "$abs" ]; then
+      _link=
+      if [ -x /usr/bin/readlink ]; then
+        _link=$(/usr/bin/readlink "$abs")
+      elif [ -x /bin/readlink ]; then
+        _link=$(/bin/readlink "$abs")
+      else
+        die 7 "PT_RUNTIME_FAIL: cannot resolve launcher symlink without readlink"
+      fi
+      case "$_link" in
+        /*) target=$_link ;;
+        *) target="${abs%/*}/$_link" ;;
+      esac
+    else
+      printf '%s\n' "$abs"
+      return 0
+    fi
+  done
+  die 7 "PT_RUNTIME_FAIL: cannot resolve launcher path"
+}
+
+SELF=$(resolve_self)
+SCRIPTS_DIR=$(CDPATH= cd -- "${SELF%/*}" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SCRIPTS_DIR/.." && pwd)
+INTERPRETER="$REPO_ROOT/.venv/bin/python"
+CONTRACT_PY="$REPO_ROOT/scripts/runtime/pt_python_runtime_contract_v1.py"
+
+if [ ! -f "$REPO_ROOT/pyproject.toml" ]; then
+  die 7 "PT_RUNTIME_FAIL: repository root unresolved at $REPO_ROOT"
+fi
+
+cmd=${1:-}
+
+if [ "$cmd" = "bootstrap-help" ]; then
+  cat <<EOF
+Peak_Trade Python runtime contract ${CONTRACT_VERSION}
+
+BOOTSTRAP (operator-invoked, not runtime):
+  uv sync --dev
+
+RUNTIME (no activation, no PATH python3):
+  ./scripts/pt runtime-check
+  ./scripts/pt fingerprint
+  ./scripts/pt -m pytest -q
+  ./scripts/pt -c "import trading"
+
+Canonical interpreter:
+  ${INTERPRETER}
+
+Do not use python, python3, venv activation, or PYTHONPATH as the runtime.
+EOF
+  exit 0
+fi
+
+if [ ! -f "$INTERPRETER" ]; then
+  die 3 "PT_RUNTIME_FAIL: canonical interpreter missing: $INTERPRETER
+Bootstrap with: uv sync --dev
+Do not use PATH python/python3."
+fi
+
+if [ ! -x "$INTERPRETER" ]; then
+  die 4 "PT_RUNTIME_FAIL: canonical interpreter not executable: $INTERPRETER"
+fi
+
+# Version check uses the canonical interpreter only (never PATH python3).
+if ! "$INTERPRETER" -c "import sys; raise SystemExit(0 if sys.version_info >= (${REQUIRES_PYTHON_MAJOR}, ${REQUIRES_PYTHON_MINOR}) else 2)"; then
+  die 2 "PT_RUNTIME_FAIL: canonical interpreter is older than Python ${REQUIRES_PYTHON_MAJOR}.${REQUIRES_PYTHON_MINOR}"
+fi
+
+# Deterministic cwd: repository root unless caller exports PT_KEEP_CWD=1.
+if [ "${PT_KEEP_CWD:-0}" != "1" ]; then
+  cd "$REPO_ROOT"
+fi
+
+if [ "$cmd" = "runtime-check" ] || [ "$cmd" = "fingerprint" ]; then
+  exec "$INTERPRETER" "$CONTRACT_PY" "$cmd"
+fi
+
+# Preflight import trading before application argv, unless skipped for
+# bootstrap-adjacent tooling that must not import application packages.
+if [ "${PT_SKIP_TRADING_PREFLIGHT:-0}" != "1" ]; then
+  if ! "$INTERPRETER" -c "import importlib.util, sys; spec = importlib.util.find_spec('trading');
+raise SystemExit(0 if spec is not None else 6)"; then
+    die 6 "PT_RUNTIME_FAIL: import trading failed under $INTERPRETER
+Do not set PYTHONPATH. Bootstrap with: uv sync --dev"
+  fi
+fi
+
+exec "$INTERPRETER" "$@"

--- a/scripts/runtime/__init__.py
+++ b/scripts/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Peak_Trade runtime helpers (non-authorizing)."""

--- a/scripts/runtime/pt_python_runtime_contract_v1.py
+++ b/scripts/runtime/pt_python_runtime_contract_v1.py
@@ -1,0 +1,395 @@
+"""Peak_Trade deterministic Python runtime contract v1.
+
+Stdlib-only. Non-authorizing. Does not create a venv, install packages,
+call exchanges, or mutate global machine configuration.
+
+Local/unattended mode requires REPO_ROOT/.venv/bin/python and rejects PATH
+fallback. Provisioned mode is a documented CI exception after setup-python.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Final, Mapping
+
+CONTRACT_ID: Final = "pt_python_runtime_contract_v1"
+CONTRACT_VERSION: Final = "v1"
+CANONICAL_LAUNCHER_REL: Final = Path("scripts/pt")
+CANONICAL_INTERPRETER_REL: Final = Path(".venv/bin/python")
+REQUIRES_PYTHON: Final = ">=3.10"
+REQUIRES_PYTHON_MAJOR: Final = 3
+REQUIRES_PYTHON_MINOR: Final = 10
+MODE_REPO_VENV: Final = "repo_venv"
+MODE_PROVISIONED: Final = "provisioned"
+PROVISIONED_ENV: Final = "PT_RUNTIME_MODE"
+GITHUB_ACTIONS_ENV: Final = "GITHUB_ACTIONS"
+
+REASON_PASS: Final = "RUNTIME_CONTRACT_PASS"
+REASON_REPO_ROOT_UNRESOLVED: Final = "REPO_ROOT_UNRESOLVED"
+REASON_VENV_MISSING: Final = "REPO_VENV_PYTHON_MISSING"
+REASON_VENV_NOT_EXECUTABLE: Final = "REPO_VENV_PYTHON_NOT_EXECUTABLE"
+REASON_UNSUPPORTED_PYTHON: Final = "UNSUPPORTED_PYTHON_VERSION"
+REASON_INTERPRETER_MISMATCH: Final = "INTERPRETER_IDENTITY_MISMATCH"
+REASON_TRADING_IMPORT_FAILED: Final = "TRADING_IMPORT_FAILED"
+REASON_PROVISIONED_REFUSED: Final = "PROVISIONED_MODE_REFUSED"
+REASON_PYPROJECT_DRIFT: Final = "PYPROJECT_REQUIRES_PYTHON_DRIFT"
+
+EXIT_PASS: Final = 0
+EXIT_UNSUPPORTED_PYTHON: Final = 2
+EXIT_VENV_MISSING: Final = 3
+EXIT_VENV_NOT_EXECUTABLE: Final = 4
+EXIT_INTERPRETER_MISMATCH: Final = 5
+EXIT_TRADING_IMPORT_FAILED: Final = 6
+EXIT_REPO_ROOT_UNRESOLVED: Final = 7
+EXIT_PROVISIONED_REFUSED: Final = 8
+EXIT_PYPROJECT_DRIFT: Final = 9
+
+_REASON_EXIT: Final = {
+    REASON_PASS: EXIT_PASS,
+    REASON_UNSUPPORTED_PYTHON: EXIT_UNSUPPORTED_PYTHON,
+    REASON_VENV_MISSING: EXIT_VENV_MISSING,
+    REASON_VENV_NOT_EXECUTABLE: EXIT_VENV_NOT_EXECUTABLE,
+    REASON_INTERPRETER_MISMATCH: EXIT_INTERPRETER_MISMATCH,
+    REASON_TRADING_IMPORT_FAILED: EXIT_TRADING_IMPORT_FAILED,
+    REASON_REPO_ROOT_UNRESOLVED: EXIT_REPO_ROOT_UNRESOLVED,
+    REASON_PROVISIONED_REFUSED: EXIT_PROVISIONED_REFUSED,
+    REASON_PYPROJECT_DRIFT: EXIT_PYPROJECT_DRIFT,
+}
+
+
+@dataclass(frozen=True)
+class RuntimeValidation:
+    ok: bool
+    reason_code: str
+    exit_code: int
+    mode: str
+    repo_root: str
+    interpreter: str
+    interpreter_version: str
+    contract_version: str
+    requires_python: str
+    trading_origin: str
+    diagnostic: str
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def repo_root_from_this_file(start: Path | None = None) -> Path | None:
+    cursor = (start or Path(__file__)).resolve()
+    if cursor.is_file():
+        cursor = cursor.parent
+    for candidate in (cursor, *cursor.parents):
+        if (candidate / "pyproject.toml").is_file() and (
+            candidate / CANONICAL_LAUNCHER_REL
+        ).is_file():
+            return candidate
+    return None
+
+
+def load_contract_config(repo_root: Path) -> dict[str, Any]:
+    path = repo_root / "config" / "runtime" / "pt_python_runtime_contract_v1.json"
+    if not path.is_file():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def pyproject_requires_python(repo_root: Path) -> str | None:
+    path = repo_root / "pyproject.toml"
+    if not path.is_file():
+        return None
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped.startswith("requires-python"):
+            _, _, raw = stripped.partition("=")
+            return raw.strip().strip('"').strip("'")
+    return None
+
+
+def resolve_mode(env: Mapping[str, str] | None = None) -> str:
+    mapping = os.environ if env is None else env
+    if mapping.get(PROVISIONED_ENV, "").strip() == MODE_PROVISIONED:
+        return MODE_PROVISIONED
+    return MODE_REPO_VENV
+
+
+def provisioned_mode_allowed(env: Mapping[str, str] | None = None) -> bool:
+    mapping = os.environ if env is None else env
+    if mapping.get(PROVISIONED_ENV, "").strip() != MODE_PROVISIONED:
+        return False
+    if mapping.get(GITHUB_ACTIONS_ENV, "").strip().lower() == "true":
+        return True
+    return mapping.get("PT_RUNTIME_PROVISIONED_OK", "").strip() == "1"
+
+
+def canonical_interpreter_path(repo_root: Path) -> Path:
+    return repo_root / CANONICAL_INTERPRETER_REL
+
+
+def _venv_root_from_executable(executable: Path) -> Path | None:
+    path = Path(executable)
+    if path.parent.name in {"bin", "Scripts"}:
+        return path.parent.parent
+    return None
+
+
+def is_canonical_running_interpreter(repo_root: Path, running: Path) -> bool:
+    """True when this process was launched via REPO_ROOT/.venv/bin/python.
+
+    Compares venv homes, not the fully resolved uv/CPython binary. Multiple
+    repository checkouts may share the same CPython build.
+    """
+    expected = (repo_root / ".venv").resolve()
+    invoked_root = _venv_root_from_executable(running)
+    if invoked_root is None:
+        return False
+    return invoked_root.resolve() == expected
+
+
+def interpreter_version_tuple(executable: Path) -> tuple[int, int, str] | None:
+    running_root = _venv_root_from_executable(Path(sys.executable))
+    selected_root = _venv_root_from_executable(executable)
+    if running_root is None or selected_root is None:
+        return None
+    if running_root.resolve() != selected_root.resolve():
+        return None
+    info = sys.version_info
+    return int(info.major), int(info.minor), sys.version.split()[0]
+
+
+def version_satisfies_floor(major: int, minor: int) -> bool:
+    return (major, minor) >= (REQUIRES_PYTHON_MAJOR, REQUIRES_PYTHON_MINOR)
+
+
+def _fail(
+    *,
+    reason: str,
+    mode: str,
+    repo_root: Path | None,
+    interpreter: Path | None,
+    diagnostic: str,
+    interpreter_version: str = "",
+    trading_origin: str = "",
+) -> RuntimeValidation:
+    return RuntimeValidation(
+        ok=False,
+        reason_code=reason,
+        exit_code=_REASON_EXIT[reason],
+        mode=mode,
+        repo_root="" if repo_root is None else str(repo_root),
+        interpreter="" if interpreter is None else str(interpreter),
+        interpreter_version=interpreter_version,
+        contract_version=CONTRACT_VERSION,
+        requires_python=REQUIRES_PYTHON,
+        trading_origin=trading_origin,
+        diagnostic=diagnostic,
+    )
+
+
+def _trading_origin() -> str:
+    import importlib.util
+
+    spec = importlib.util.find_spec("trading")
+    if spec is None:
+        return ""
+    if spec.submodule_search_locations:
+        return str(list(spec.submodule_search_locations)[0])
+    return str(spec.origin or "")
+
+
+def validate_runtime(
+    *,
+    repo_root: Path | None = None,
+    env: Mapping[str, str] | None = None,
+    require_trading_import: bool = True,
+    running_executable: Path | None = None,
+    check_running_identity: bool = False,
+) -> RuntimeValidation:
+    mode = resolve_mode(env)
+    root = repo_root or repo_root_from_this_file()
+    if root is None:
+        return _fail(
+            reason=REASON_REPO_ROOT_UNRESOLVED,
+            mode=mode,
+            repo_root=None,
+            interpreter=None,
+            diagnostic="Cannot resolve repository root (pyproject.toml + scripts/pt required).",
+        )
+
+    declared = pyproject_requires_python(root)
+    if declared is not None and declared != REQUIRES_PYTHON:
+        return _fail(
+            reason=REASON_PYPROJECT_DRIFT,
+            mode=mode,
+            repo_root=root,
+            interpreter=None,
+            diagnostic=(
+                f"Contract floor {REQUIRES_PYTHON} drifts from pyproject.toml "
+                f"requires-python={declared}."
+            ),
+        )
+
+    current = running_executable or Path(sys.executable)
+
+    if mode == MODE_PROVISIONED:
+        if not provisioned_mode_allowed(env):
+            return _fail(
+                reason=REASON_PROVISIONED_REFUSED,
+                mode=mode,
+                repo_root=root,
+                interpreter=current,
+                diagnostic=(
+                    "Provisioned mode requires PT_RUNTIME_MODE=provisioned and "
+                    "GITHUB_ACTIONS=true or PT_RUNTIME_PROVISIONED_OK=1."
+                ),
+            )
+        selected = current
+    else:
+        selected = canonical_interpreter_path(root)
+        if not selected.is_file():
+            return _fail(
+                reason=REASON_VENV_MISSING,
+                mode=mode,
+                repo_root=root,
+                interpreter=selected,
+                diagnostic=(
+                    "Canonical interpreter missing. Bootstrap with: uv sync --dev "
+                    f"(creates {CANONICAL_INTERPRETER_REL}). Do not use PATH python3."
+                ),
+            )
+        if not os.access(selected, os.X_OK):
+            return _fail(
+                reason=REASON_VENV_NOT_EXECUTABLE,
+                mode=mode,
+                repo_root=root,
+                interpreter=selected,
+                diagnostic=f"Canonical interpreter is not executable: {selected}",
+            )
+        if check_running_identity and not is_canonical_running_interpreter(root, current):
+            return _fail(
+                reason=REASON_INTERPRETER_MISMATCH,
+                mode=mode,
+                repo_root=root,
+                interpreter=current,
+                diagnostic=(
+                    "This process is not the canonical repository interpreter. "
+                    f"Use {CANONICAL_LAUNCHER_REL} (never PATH python/python3)."
+                ),
+            )
+
+    version = interpreter_version_tuple(selected)
+    if version is None:
+        # selected is canonical venv python but this process is a different
+        # interpreter (launcher already checked version via selected -c).
+        interpreter_version = ""
+        major = REQUIRES_PYTHON_MAJOR
+        minor = REQUIRES_PYTHON_MINOR
+        version_ok = True
+    else:
+        major, minor, interpreter_version = version
+        version_ok = version_satisfies_floor(major, minor)
+
+    if not version_ok:
+        return _fail(
+            reason=REASON_UNSUPPORTED_PYTHON,
+            mode=mode,
+            repo_root=root,
+            interpreter=selected,
+            interpreter_version=interpreter_version,
+            diagnostic=(
+                f"Python {interpreter_version} is unsupported. "
+                f"Need {REQUIRES_PYTHON}. System 3.9.x is not a Peak_Trade runtime."
+            ),
+        )
+
+    trading_origin = ""
+    if require_trading_import:
+        try:
+            trading_origin = _trading_origin()
+            if not trading_origin:
+                raise ModuleNotFoundError("No module named 'trading'")
+        except Exception as exc:  # noqa: BLE001 — fail-closed diagnostic
+            return _fail(
+                reason=REASON_TRADING_IMPORT_FAILED,
+                mode=mode,
+                repo_root=root,
+                interpreter=selected,
+                interpreter_version=interpreter_version,
+                diagnostic=(
+                    "import trading failed under the selected interpreter. "
+                    "Do not set PYTHONPATH. Bootstrap with uv sync --dev. "
+                    f"error={exc}"
+                ),
+            )
+
+    return RuntimeValidation(
+        ok=True,
+        reason_code=REASON_PASS,
+        exit_code=EXIT_PASS,
+        mode=mode,
+        repo_root=str(root),
+        interpreter=str(selected),
+        interpreter_version=interpreter_version or sys.version.split()[0],
+        contract_version=CONTRACT_VERSION,
+        requires_python=REQUIRES_PYTHON,
+        trading_origin=trading_origin,
+        diagnostic="canonical repository runtime validated",
+    )
+
+
+def fingerprint_payload(result: RuntimeValidation) -> dict[str, Any]:
+    payload = result.as_dict()
+    payload["contract_id"] = CONTRACT_ID
+    payload["path_python_fallback_allowed"] = False
+    payload["venv_activation_required"] = False
+    payload["pyenv_dependency"] = False
+    payload["pythonpath_dependency"] = False
+    payload["cwd_dependency"] = False
+    payload["git_revision"] = _git_revision(Path(result.repo_root) if result.repo_root else None)
+    payload["project_name"] = "peak_trade"
+    return payload
+
+
+def _git_revision(repo_root: Path | None) -> str:
+    if repo_root is None:
+        return ""
+    try:
+        completed = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if completed.returncode != 0:
+        return ""
+    return completed.stdout.strip()
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    command = args[0] if args else "validate"
+    require_trading = command in {"fingerprint", "runtime-check", "validate"}
+    result = validate_runtime(
+        require_trading_import=require_trading,
+        check_running_identity=True,
+    )
+    if command in {"fingerprint", "runtime-check"}:
+        print(json.dumps(fingerprint_payload(result), indent=2, sort_keys=True))
+    else:
+        print(f"REASON_CODE={result.reason_code}")
+        print(f"EXIT_CODE={result.exit_code}")
+        print(f"INTERPRETER={result.interpreter}")
+        print(f"DIAGNOSTIC={result.diagnostic}")
+    return int(result.exit_code)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/webui/local_market_dashboard.sh
+++ b/scripts/webui/local_market_dashboard.sh
@@ -115,15 +115,7 @@ resolve_python() {
     printf '%s' "${PEAK_TRADE_WEBUI_PYTHON}"
     return 0
   fi
-  if [[ -x "${REPO_ROOT}/.venv/bin/python3" ]]; then
-    printf '%s' "${REPO_ROOT}/.venv/bin/python3"
-    return 0
-  fi
-  if [[ -x "${REPO_ROOT}/.venv/bin/python" ]]; then
-    printf '%s' "${REPO_ROOT}/.venv/bin/python"
-    return 0
-  fi
-  die "missing repo venv python at ${REPO_ROOT}/.venv/bin/python3"
+  printf '%s' "${REPO_ROOT}/scripts/pt"
 }
 
 gui_domain() {

--- a/src/scheduler/runner.py
+++ b/src/scheduler/runner.py
@@ -15,6 +15,14 @@ from typing import Any, Callable, List, Optional, cast
 
 from .models import JobDefinition, JobSchedule, JobResult
 
+_BARE_PYTHON_COMMANDS = frozenset({"python", "python3", "python.exe", "python3.exe"})
+
+
+def _is_bare_python_command(command: str) -> bool:
+    """True when a job command is a PATH python alias, not an explicit interpreter."""
+    name = Path(command).name.lower()
+    return name in _BARE_PYTHON_COMMANDS
+
 
 def compute_next_run_at(
     schedule: JobSchedule,
@@ -201,8 +209,9 @@ def run_job(
     now_fn = datetime.utcnow if utcnow is None else utcnow
     started_at = now_fn()
 
-    # Kommando bauen
-    if job.command == "python":
+    # Kommando bauen. Bare python/python3 bind to this process interpreter
+    # (canonical when the scheduler was launched via scripts/pt).
+    if _is_bare_python_command(job.command):
         cmd = [sys.executable] + build_command_args(job)
     else:
         cmd = [job.command] + build_command_args(job)

--- a/tests/ci/test_pt_python_runtime_operative_surfaces_contract_v1.py
+++ b/tests/ci/test_pt_python_runtime_operative_surfaces_contract_v1.py
@@ -1,0 +1,62 @@
+"""Operative Python invocation surface contract (non-authorizing)."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = REPO_ROOT / "config" / "runtime" / "pt_python_operative_surfaces_v1.json"
+
+_OPERATIVE = {"OPERATIVE_CANONICAL", "OPERATIVE_WRAPPER"}
+_INVOCATION = re.compile(
+    r"(?m)^(?P<line>[^#\n]*(?:\bpython3\s+|/usr/bin/env python3\b|PY_CMD=\"python3\"|"
+    r"source\s+\.venv/bin/activate|PYTHONPATH=\. python))"
+)
+
+
+def test_operative_surfaces_exist_and_are_classified() -> None:
+    payload = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    assert payload["contract_id"] == "pt_python_operative_surfaces_v1"
+    missing = []
+    for item in payload["surfaces"]:
+        path = REPO_ROOT / item["path"]
+        if not path.exists():
+            missing.append(item["path"])
+    assert missing == []
+
+
+def test_operative_surfaces_have_no_path_python3_invocations() -> None:
+    payload = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    offenders: list[str] = []
+    for item in payload["surfaces"]:
+        if item["class"] not in _OPERATIVE:
+            continue
+        if item["path"].endswith(".yml"):
+            continue
+        path = REPO_ROOT / item["path"]
+        if path.suffix not in {".sh", ".md", ".py", ""} and path.name not in {
+            "Makefile",
+            "pt",
+        }:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for match in _INVOCATION.finditer(text):
+            line = match.group("line").strip()
+            lowered = line.lower()
+            if "never" in lowered or "do not use" in lowered or "prohibited" in lowered:
+                continue
+            if "PATH `python3`" in line or "PATH python3" in line or "PATH `python`" in line:
+                continue
+            if line.lstrip().startswith("-") and "source .venv/bin/activate" in line:
+                continue
+            offenders.append(f"{item['path']}: {line}")
+    assert offenders == []
+
+
+def test_canonical_launcher_rejects_path_fallback_comment() -> None:
+    text = (REPO_ROOT / "scripts" / "pt").read_text(encoding="utf-8")
+    assert "Never uses PATH python/python3" in text or "never uses PATH" in text.lower()
+    assert "source .venv/bin/activate" not in text
+    assert "command -v python" not in text

--- a/tests/ops/test_pt_python_runtime_contract_v1.py
+++ b/tests/ops/test_pt_python_runtime_contract_v1.py
@@ -16,6 +16,7 @@ from scripts.runtime.pt_python_runtime_contract_v1 import (
     CANONICAL_INTERPRETER_REL,
     CONTRACT_VERSION,
     EXIT_INTERPRETER_MISMATCH,
+    EXIT_PROVISIONED_REFUSED,
     EXIT_UNSUPPORTED_PYTHON,
     EXIT_VENV_MISSING,
     MODE_PROVISIONED,
@@ -212,6 +213,89 @@ def test_direct_contract_module_on_path_python_fails_identity() -> None:
     if Path(sys.executable).parent.parent.resolve() == (REPO_ROOT / ".venv").resolve():
         pytest.skip("pytest already running under canonical interpreter")
     assert proc.returncode == EXIT_INTERPRETER_MISMATCH
+
+
+def test_launcher_provisioned_refused_without_ci_flag(tmp_path: Path) -> None:
+    repo = _seed_fake_repo(tmp_path)
+    poison = tmp_path / "poison" / "bin"
+    poison.mkdir(parents=True)
+    _write_executable(poison / "python", "#!/bin/sh\necho POISONED >&2\nexit 99\n")
+    _write_executable(poison / "python3", "#!/bin/sh\necho POISONED >&2\nexit 99\n")
+    proc = subprocess.run(
+        [str(repo / "scripts" / "pt"), "-c", "print('should-not-run')"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": f"{poison}:/usr/bin:/bin",
+            "HOME": str(tmp_path / "home"),
+            "PT_RUNTIME_MODE": MODE_PROVISIONED,
+            "GITHUB_ACTIONS": "",
+            "PT_RUNTIME_PROVISIONED_OK": "",
+            "PT_SKIP_TRADING_PREFLIGHT": "1",
+        },
+        check=False,
+    )
+    assert proc.returncode == EXIT_PROVISIONED_REFUSED
+    assert "should-not-run" not in proc.stdout
+    assert "POISONED" not in proc.stderr
+
+
+def test_launcher_provisioned_uses_bound_interpreter(tmp_path: Path) -> None:
+    if sys.version_info < (3, 10):
+        pytest.skip("host interpreter below project floor")
+    repo = _seed_fake_repo(tmp_path)
+    poison = tmp_path / "poison" / "bin"
+    poison.mkdir(parents=True)
+    _write_executable(poison / "python", "#!/bin/sh\necho POISONED >&2\nexit 99\n")
+    _write_executable(poison / "python3", "#!/bin/sh\necho POISONED >&2\nexit 99\n")
+    proc = subprocess.run(
+        [str(repo / "scripts" / "pt"), "-c", "import sys; print(sys.executable)"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": f"{poison}:/usr/bin:/bin",
+            "HOME": str(tmp_path / "home"),
+            "PT_RUNTIME_MODE": MODE_PROVISIONED,
+            "PT_RUNTIME_PROVISIONED_OK": "1",
+            "PT_PROVISIONED_PYTHON": sys.executable,
+            "PT_SKIP_TRADING_PREFLIGHT": "1",
+        },
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "POISONED" not in proc.stderr
+    assert Path(proc.stdout.strip()).resolve() == Path(sys.executable).resolve()
+
+
+def test_launcher_provisioned_unbound_without_python_location(tmp_path: Path) -> None:
+    repo = _seed_fake_repo(tmp_path)
+    proc = subprocess.run(
+        [str(repo / "scripts" / "pt"), "-c", "print('should-not-run')"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": "/usr/bin:/bin",
+            "HOME": str(tmp_path / "home"),
+            "PT_RUNTIME_MODE": MODE_PROVISIONED,
+            "PT_RUNTIME_PROVISIONED_OK": "1",
+            "PT_SKIP_TRADING_PREFLIGHT": "1",
+        },
+        check=False,
+    )
+    assert proc.returncode == EXIT_PROVISIONED_REFUSED
+    assert "should-not-run" not in proc.stdout
+    assert "unbound" in proc.stderr
+
+
+def test_lint_gate_binds_provisioned_runtime() -> None:
+    text = (REPO_ROOT / ".github" / "workflows" / "lint_gate.yml").read_text(encoding="utf-8")
+    assert "PT_RUNTIME_MODE: provisioned" in text
+    assert "PT_SKIP_TRADING_PREFLIGHT" in text
+    assert "PT_PROVISIONED_PYTHON" in text
+    assert "ai_matrix_consistency_gate.sh" in text
 
 
 def test_provisioned_mode_refused_without_ci_flag() -> None:

--- a/tests/ops/test_pt_python_runtime_contract_v1.py
+++ b/tests/ops/test_pt_python_runtime_contract_v1.py
@@ -1,0 +1,418 @@
+"""Deterministic Python runtime contract v1 tests (non-authorizing)."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.runtime.pt_python_runtime_contract_v1 import (
+    CANONICAL_INTERPRETER_REL,
+    CONTRACT_VERSION,
+    EXIT_INTERPRETER_MISMATCH,
+    EXIT_UNSUPPORTED_PYTHON,
+    EXIT_VENV_MISSING,
+    MODE_PROVISIONED,
+    REASON_PASS,
+    REASON_PROVISIONED_REFUSED,
+    REASON_UNSUPPORTED_PYTHON,
+    REASON_VENV_MISSING,
+    REQUIRES_PYTHON,
+    pyproject_requires_python,
+    repo_root_from_this_file,
+    validate_runtime,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LAUNCHER = REPO_ROOT / "scripts" / "pt"
+CONTRACT_PY = REPO_ROOT / "scripts" / "runtime" / "pt_python_runtime_contract_v1.py"
+SYSTEM_CLT_PYTHON = Path("/Library/Developer/CommandLineTools/usr/bin/python3")
+POISON_BIN_HINT = "/Library/Developer/CommandLineTools/usr/bin"
+
+
+def _write_executable(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def _seed_fake_repo(tmp: Path) -> Path:
+    (tmp / "scripts" / "runtime").mkdir(parents=True)
+    shutil.copy2(LAUNCHER, tmp / "scripts" / "pt")
+    (tmp / "scripts" / "pt").chmod(
+        (tmp / "scripts" / "pt").stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    )
+    shutil.copy2(CONTRACT_PY, tmp / "scripts" / "runtime" / "pt_python_runtime_contract_v1.py")
+    (tmp / "pyproject.toml").write_text(
+        '[project]\nname = "peak_trade_runtime_fixture"\nrequires-python = ">=3.10"\n',
+        encoding="utf-8",
+    )
+    return tmp
+
+
+def test_contract_floor_matches_pyproject() -> None:
+    declared = pyproject_requires_python(REPO_ROOT)
+    assert declared == REQUIRES_PYTHON
+    assert CONTRACT_VERSION == "v1"
+
+
+def test_repo_root_resolver_finds_launcher() -> None:
+    root = repo_root_from_this_file(CONTRACT_PY)
+    assert root == REPO_ROOT
+
+
+def test_missing_venv_fails_closed(tmp_path: Path) -> None:
+    repo = _seed_fake_repo(tmp_path)
+    result = validate_runtime(
+        repo_root=repo,
+        require_trading_import=False,
+        check_running_identity=False,
+    )
+    assert result.ok is False
+    assert result.reason_code == REASON_VENV_MISSING
+    assert result.exit_code == EXIT_VENV_MISSING
+
+
+def test_launcher_missing_venv_fail_closed(tmp_path: Path) -> None:
+    repo = _seed_fake_repo(tmp_path)
+    proc = subprocess.run(
+        [str(repo / "scripts" / "pt"), "-c", "print('should-not-run')"],
+        cwd=repo / "scripts",
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", "HOME": str(tmp_path / "home")},
+        check=False,
+    )
+    assert proc.returncode == EXIT_VENV_MISSING
+    assert "should-not-run" not in proc.stdout
+    assert "canonical interpreter missing" in proc.stderr
+
+
+@pytest.mark.skipif(not SYSTEM_CLT_PYTHON.is_file(), reason="CLT python not present")
+def test_unsupported_python_in_venv_slot_fails_closed(tmp_path: Path) -> None:
+    repo = _seed_fake_repo(tmp_path)
+    venv_python = repo / CANONICAL_INTERPRETER_REL
+    venv_python.parent.mkdir(parents=True)
+    venv_python.symlink_to(SYSTEM_CLT_PYTHON)
+    proc = subprocess.run(
+        [str(repo / "scripts" / "pt"), "-c", "print('should-not-run')"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env={"PATH": f"{POISON_BIN_HINT}:/usr/bin:/bin", "HOME": str(tmp_path / "home")},
+        check=False,
+    )
+    assert proc.returncode == EXIT_UNSUPPORTED_PYTHON
+    assert "should-not-run" not in proc.stdout
+
+
+def test_path_poisoning_does_not_select_system_python(tmp_path: Path) -> None:
+    if sys.version_info < (3, 10):
+        pytest.skip("host interpreter below project floor")
+    repo = _seed_fake_repo(tmp_path)
+    venv_python = repo / CANONICAL_INTERPRETER_REL
+    venv_python.parent.mkdir(parents=True)
+    venv_python.symlink_to(Path(sys.executable).resolve())
+    poison = tmp_path / "poison" / "bin"
+    poison.mkdir(parents=True)
+    _write_executable(
+        poison / "python3",
+        "#!/bin/sh\necho POISONED >&2\nexit 99\n",
+    )
+    _write_executable(
+        poison / "python",
+        "#!/bin/sh\necho POISONED >&2\nexit 99\n",
+    )
+    proc = subprocess.run(
+        [str(repo / "scripts" / "pt"), "-c", "import sys; print(sys.executable)"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": f"{poison}:{POISON_BIN_HINT}:/usr/bin:/bin",
+            "HOME": str(tmp_path / "home"),
+            "PT_SKIP_TRADING_PREFLIGHT": "1",
+        },
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "POISONED" not in proc.stderr
+    assert str(venv_python.resolve()) in Path(proc.stdout.strip()).resolve().as_posix() or (
+        Path(proc.stdout.strip()).resolve() == Path(sys.executable).resolve()
+    )
+
+
+def test_nested_cwd_and_no_activation(tmp_path: Path) -> None:
+    if sys.version_info < (3, 10):
+        pytest.skip("host interpreter below project floor")
+    repo = _seed_fake_repo(tmp_path)
+    nested = repo / "docs" / "runtime"
+    nested.mkdir(parents=True)
+    venv_python = repo / CANONICAL_INTERPRETER_REL
+    venv_python.parent.mkdir(parents=True)
+    venv_python.symlink_to(Path(sys.executable).resolve())
+    env = {
+        "PATH": "/usr/bin:/bin",
+        "HOME": str(tmp_path / "home"),
+        "PT_SKIP_TRADING_PREFLIGHT": "1",
+    }
+    env.pop("VIRTUAL_ENV", None)
+    proc = subprocess.run(
+        [str(repo / "scripts" / "pt"), "-c", "import os, pathlib; print(pathlib.Path.cwd())"],
+        cwd=nested,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert Path(proc.stdout.strip()).resolve() == repo.resolve()
+
+
+def test_empty_path_still_uses_canonical_interpreter(tmp_path: Path) -> None:
+    if sys.version_info < (3, 10):
+        pytest.skip("host interpreter below project floor")
+    repo = _seed_fake_repo(tmp_path)
+    venv_python = repo / CANONICAL_INTERPRETER_REL
+    venv_python.parent.mkdir(parents=True)
+    venv_python.symlink_to(Path(sys.executable).resolve())
+    proc = subprocess.run(
+        [str(repo / "scripts" / "pt"), "-c", "print('ok')"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env={"PATH": "", "HOME": str(tmp_path / "home"), "PT_SKIP_TRADING_PREFLIGHT": "1"},
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "ok"
+
+
+def test_direct_contract_module_on_path_python_fails_identity() -> None:
+    if not (REPO_ROOT / CANONICAL_INTERPRETER_REL).is_file():
+        pytest.skip("worktree has no provisioned .venv")
+    proc = subprocess.run(
+        [sys.executable, str(CONTRACT_PY), "validate"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": f"{POISON_BIN_HINT}:/usr/bin:/bin",
+            "HOME": str(Path.home()),
+            "PT_RUNTIME_MODE": "",
+        },
+        check=False,
+    )
+    if Path(sys.executable).parent.parent.resolve() == (REPO_ROOT / ".venv").resolve():
+        pytest.skip("pytest already running under canonical interpreter")
+    assert proc.returncode == EXIT_INTERPRETER_MISMATCH
+
+
+def test_provisioned_mode_refused_without_ci_flag() -> None:
+    result = validate_runtime(
+        repo_root=REPO_ROOT,
+        env={"PT_RUNTIME_MODE": MODE_PROVISIONED},
+        require_trading_import=False,
+        check_running_identity=False,
+    )
+    assert result.ok is False
+    assert result.reason_code == REASON_PROVISIONED_REFUSED
+
+
+def test_provisioned_mode_accepted_with_explicit_ok() -> None:
+    if sys.version_info < (3, 10):
+        pytest.skip("host interpreter below project floor")
+    result = validate_runtime(
+        repo_root=REPO_ROOT,
+        env={"PT_RUNTIME_MODE": MODE_PROVISIONED, "PT_RUNTIME_PROVISIONED_OK": "1"},
+        require_trading_import=False,
+        check_running_identity=False,
+        running_executable=Path(sys.executable),
+    )
+    assert result.ok is True
+    assert result.reason_code == REASON_PASS
+    assert result.mode == MODE_PROVISIONED
+
+
+def test_makefile_delegates_to_canonical_launcher() -> None:
+    text = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+    assert "PT :=" in text or "PT:=" in text
+    assert "scripts/pt" in text
+    assert "PYTHONPATH=." not in text
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#") or stripped.startswith(".PHONY"):
+            continue
+        if stripped.startswith("python3 ") or " python3 " in f" {stripped}":
+            pytest.fail(f"Makefile still contains bare python3: {stripped}")
+        if stripped.startswith("python ") and "python-version" not in stripped:
+            pytest.fail(f"Makefile still contains bare python: {stripped}")
+
+
+def test_agent_guidance_points_at_canonical_launcher() -> None:
+    agents = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+    rule = (REPO_ROOT / ".cursor" / "rules" / "peak-trade-python-runtime.mdc").read_text(
+        encoding="utf-8"
+    )
+    helper = (REPO_ROOT / "docs" / "ai" / "PEAK_TRADE_AI_HELPER_GUIDE.md").read_text(
+        encoding="utf-8"
+    )
+    claude = (REPO_ROOT / "docs" / "ai" / "CLAUDE_GUIDE.md").read_text(encoding="utf-8")
+    for text in (agents, rule, helper, claude):
+        assert "scripts/pt" in text
+        assert "never execute Peak_Trade Python using PATH" in text or "scripts/pt" in text
+    assert "Python 3.9+" not in claude
+    assert "source .venv/bin/activate" not in claude.split("##")[0]
+
+
+def test_active_docs_do_not_claim_python_39_supported() -> None:
+    for rel in (
+        "README.md",
+        "docs/GETTING_STARTED.md",
+        "docs/DEV_SETUP.md",
+        "docs/DEVELOPER_WORKFLOW_GUIDE.md",
+        "docs/ai/CLAUDE_GUIDE.md",
+        "docs/runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md",
+    ):
+        text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        assert "Python 3.9+" not in text
+        assert 'requires-python = ">=3.10"' in text or ">=3.10" in text or "3.10" in text
+
+
+def test_operative_surface_manifest_exists() -> None:
+    path = REPO_ROOT / "config" / "runtime" / "pt_python_operative_surfaces_v1.json"
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["contract_id"] == "pt_python_operative_surfaces_v1"
+    classes = {item["path"]: item["class"] for item in payload["surfaces"]}
+    assert classes["scripts/pt"] == "OPERATIVE_CANONICAL"
+    assert classes["tests/conftest.py"] == "TEST_ONLY"
+    assert classes["docs/ops/PYTHON_VERSION_PLAN.md"] == "HISTORICAL"
+
+
+def test_ci_active_python_versions_meet_floor() -> None:
+    root = REPO_ROOT / ".github" / "workflows"
+    offenders: list[str] = []
+    for path in sorted(root.glob("*.yml")):
+        text = path.read_text(encoding="utf-8")
+        if 'python-version: ["3.9"' in text or "python-version: ['3.9'" in text:
+            offenders.append(path.name)
+        if 'python-version: "3.9"' in text or "python-version: '3.9'" in text:
+            if "NEGATIVE" not in text and "unsupported" not in text.lower():
+                offenders.append(path.name)
+    assert offenders == []
+
+
+def test_pyenv_system_does_not_alter_selected_runtime(tmp_path: Path) -> None:
+    if sys.version_info < (3, 10):
+        pytest.skip("host interpreter below project floor")
+    repo = _seed_fake_repo(tmp_path)
+    venv_python = repo / CANONICAL_INTERPRETER_REL
+    venv_python.parent.mkdir(parents=True)
+    venv_python.symlink_to(Path(sys.executable).resolve())
+    poison = tmp_path / "pyenv" / "shims"
+    poison.mkdir(parents=True)
+    _write_executable(poison / "python3", "#!/bin/sh\necho PYENV_SYSTEM >&2\nexit 99\n")
+    _write_executable(poison / "python", "#!/bin/sh\necho PYENV_SYSTEM >&2\nexit 99\n")
+    proc = subprocess.run(
+        [str(repo / "scripts" / "pt"), "-c", "print('ok')"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": f"{poison}:/usr/bin:/bin",
+            "HOME": str(tmp_path / "home"),
+            "PYENV_VERSION": "system",
+            "PYENV_ROOT": str(tmp_path / "pyenv"),
+            "PT_SKIP_TRADING_PREFLIGHT": "1",
+        },
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "PYENV_SYSTEM" not in proc.stderr
+    assert proc.stdout.strip() == "ok"
+
+
+def test_makefile_runtime_check_target() -> None:
+    text = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+    assert "runtime-check:" in text
+    assert "$(PT) runtime-check" in text
+
+
+def test_scheduler_bare_python3_binds_process_interpreter() -> None:
+    from src.scheduler.models import JobDefinition, JobSchedule
+    from src.scheduler.runner import run_job
+
+    job = JobDefinition(
+        name="runtime_contract_python3",
+        command="python3",
+        args={"script": "scripts/run_backtest.py"},
+        schedule=JobSchedule(type="once"),
+        enabled=True,
+    )
+    result = run_job(job, dry_run=True)
+    assert result.success is True
+    assert sys.executable in result.stdout
+    assert result.stdout.endswith(f"{sys.executable} scripts/run_backtest.py") or (
+        sys.executable in result.stdout and "scripts/run_backtest.py" in result.stdout
+    )
+
+
+def test_operative_docs_do_not_endorse_direct_src_python3() -> None:
+    for rel in (
+        "README.md",
+        "docs/GETTING_STARTED.md",
+        "docs/DEV_SETUP.md",
+        "docs/DEVELOPER_WORKFLOW_GUIDE.md",
+        "docs/ai/CLAUDE_GUIDE.md",
+        "docs/runtime/PEAK_TRADE_PYTHON_RUNTIME_CONTRACT_V1.md",
+        "AGENTS.md",
+    ):
+        text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        for line in text.splitlines():
+            stripped = line.strip()
+            if "prohibited" in stripped.lower() or stripped.startswith("- "):
+                if "package code" in stripped:
+                    continue
+            assert "python3 src/" not in stripped
+            assert "python src/" not in stripped
+
+
+@pytest.mark.skipif(
+    not (REPO_ROOT / CANONICAL_INTERPRETER_REL).is_file(),
+    reason="worktree has no provisioned .venv",
+)
+def test_trading_imports_under_canonical_launcher() -> None:
+    proc = subprocess.run(
+        [str(LAUNCHER), "-c", "import trading; print('trading-ok')"],
+        cwd=REPO_ROOT / "docs",
+        capture_output=True,
+        text=True,
+        env={"PATH": f"{POISON_BIN_HINT}:/usr/bin:/bin", "HOME": str(Path.home())},
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "trading-ok" in proc.stdout
+
+
+def test_fingerprint_payload_has_no_secrets() -> None:
+    from scripts.runtime.pt_python_runtime_contract_v1 import fingerprint_payload
+
+    result = validate_runtime(
+        repo_root=REPO_ROOT,
+        require_trading_import=False,
+        check_running_identity=False,
+        env={"PT_RUNTIME_MODE": MODE_PROVISIONED, "PT_RUNTIME_PROVISIONED_OK": "1"},
+    )
+    payload = fingerprint_payload(result)
+    blob = json.dumps(payload)
+    assert "SECRET" not in blob
+    assert "API_KEY" not in blob
+    assert "path_python_fallback_allowed" in payload
+    assert payload["path_python_fallback_allowed"] is False
+    assert "contract_version" in payload


### PR DESCRIPTION
## Summary
- Adds a repository-wide Python runtime contract (`scripts/pt` → `.venv/bin/python`) so local, agent, Make, scheduler, and ops invocation no longer depend on PATH `python3`, pyenv, or venv activation.
- Separates bootstrap (`uv sync --dev`) from runtime validation; missing or unsupported interpreters fail closed before application code runs.
- Aligns operative docs, Make, CI Python floors, and scheduled wrappers; adds contract tests including PATH poisoning and cwd independence.

## Test plan
- [x] `pytest tests/ops/test_pt_python_runtime_contract_v1.py tests/ci/test_pt_python_runtime_operative_surfaces_contract_v1.py`
- [x] PR_BOUNDED_FULL selector targets (868 passed locally)
- [x] Ruff format/check on changed Python
- [x] Docs token policy and docs reference-target gates vs `origin/main`
- [x] Runtime demos: root, nested cwd, poisoned PATH, no activation, pyenv=system, `import trading`, `make runtime-check`, `python -m`
- [ ] GitHub required checks (confirmation after push)


Made with [Cursor](https://cursor.com)