### PR TITLE
test: bind fail-closed acctLv=2 unfilled-order documentary discriminator

### DIFF
--- a/src/ops/section_11_13_5_okx_acct_lv2_unfilled_order_documentary_discriminator_contract_v1.py
+++ b/src/ops/section_11_13_5_okx_acct_lv2_unfilled_order_documentary_discriminator_contract_v1.py
@@ -1,0 +1,182 @@
+"""§11.13.5 Branch-B documentary discriminator (acctLv=2).
+
+Fail-closed, non-executing. Encodes official OKX V5 contract facts plus
+already-captured live EEA ``GET /api/v5/account/config`` evidence.
+
+Does not place orders, call OKX, unlock submit, or prove Rule C.
+
+Official V5 (global): POST /api/v5/trade/order-precheck is documented as
+applicable only to Multi-currency margin and Portfolio margin. EEA regional
+V5 docs do not list this endpoint. This module never executes it.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Mapping
+
+ENDPOINT_ORDER_PRECHECK = "/api/v5/trade/order-precheck"
+ENDPOINT_ORDER_SUBMIT = "/api/v5/trade/order"
+EEA_REST_HOST = "eea.okx.com"
+
+PRECHECK_DEFAULT_ENABLED = False
+PRECHECK_EXECUTION_AUTHORIZED = False
+PRECHECK_CANNOT_CREATE_ORDER = True
+
+ACCT_LV_SPOT = "1"
+ACCT_LV_FUTURES = "2"
+ACCT_LV_MULTI_CURRENCY = "3"
+ACCT_LV_PORTFOLIO = "4"
+DOCUMENTED_PRECHECK_APPLICABLE_ACCT_LV: frozenset[str] = frozenset(
+    {ACCT_LV_MULTI_CURRENCY, ACCT_LV_PORTFOLIO}
+)
+
+LIVE_EEA_ACCT_LV_EVIDENCE_VALUE = "2"
+LIVE_EEA_ACCT_LV_EVIDENCE_PATH = (
+    "evidence/ops/section_11_13_5_post_k_cross_imr_leverage_get_bind_v1/"
+    "20260816T033800Z/GET_SNAPSHOT.sanitized.json"
+)
+LIVE_EEA_ACCT_LV_EVIDENCE_UID = "856964404452495999"
+LIVE_EEA_ACCT_LV_EVIDENCE_CLASS = "PROVEN_EXISTING_LIVE_EEA_GET_ACCOUNT_CONFIG"
+LIVE_EEA_ACCT_LV_ENVIRONMENT = "LIVE_EEA"
+
+ORDER_FIELD_NOTIONAL_USD = "notionalUsd"
+LINEAR_NOTIONAL_ALGEBRA = "sz * ctVal * markPx"
+DISCRIMINATION_CLASS = "THEORETICAL_DOCUMENTARY_ONLY"
+NOT_OKX_RUNTIME_PROOF = True
+RULE_C_STATUS = "UNPROVEN"
+FACE_VALUE_CONFLICT_STATUS = "UNRESOLVED"
+COVER_USDC_STATUS = "UNINSTANTIATED"
+
+CANDIDATE_A_CT_VAL = Decimal("0.0001")
+CANDIDATE_B_CT_VAL = Decimal("0.01")
+DOCUMENTARY_SZ = Decimal("1")
+EXPECTED_DISCRIMINATION_FACTOR = Decimal("100")
+
+# Official OKX V5 request names for POST /api/v5/trade/order-precheck.
+PRECHECK_REQUEST_FIELDS: tuple[str, ...] = (
+    "instId",
+    "tdMode",
+    "side",
+    "ordType",
+    "sz",
+    "px",
+)
+# Official OKX V5 response names from POST /api/v5/trade/order-precheck.
+PRECHECK_RESPONSE_FIELDS: tuple[str, ...] = (
+    "imr",
+    "imrChg",
+    "mmr",
+    "mmrChg",
+    "adjEq",
+    "adjEqChg",
+    "mgnRatio",
+    "mgnRatioChg",
+    "liqPxDiff",
+)
+
+SELECTED_PATH = "UNFILLED_ORDER_DOCUMENTARY_DISCRIMINATOR"
+
+
+class OrderPrecheckExecutionForbiddenError(RuntimeError):
+    """Raised when any execution of order-precheck is attempted."""
+
+
+class UnsupportedAcctLvFailClosedError(RuntimeError):
+    """Raised for missing/unknown account mode (fail-closed)."""
+
+
+def normalize_acct_lv(acct_lv: object) -> str:
+    if acct_lv is None:
+        raise UnsupportedAcctLvFailClosedError("ACCT_LV_UNKNOWN")
+    text = str(acct_lv).strip()
+    if text not in {
+        ACCT_LV_SPOT,
+        ACCT_LV_FUTURES,
+        ACCT_LV_MULTI_CURRENCY,
+        ACCT_LV_PORTFOLIO,
+    }:
+        raise UnsupportedAcctLvFailClosedError(f"ACCT_LV_UNSUPPORTED:{text or '<empty>'}")
+    return text
+
+
+def supports_order_precheck(acct_lv: object) -> bool:
+    """Official V5: precheck only for Multi-currency (3) and Portfolio (4)."""
+    return normalize_acct_lv(acct_lv) in DOCUMENTED_PRECHECK_APPLICABLE_ACCT_LV
+
+
+def order_precheck_documented_applicable(acct_lv: object) -> bool:
+    return supports_order_precheck(acct_lv)
+
+
+def order_precheck_execution_allowed(acct_lv: object | None = None) -> bool:
+    del acct_lv
+    return False
+
+
+def refuse_order_precheck_execution_v1() -> None:
+    raise OrderPrecheckExecutionForbiddenError(
+        "ORDER_PRECHECK_EXECUTION_FORBIDDEN:"
+        f"PRECHECK_EXECUTION_AUTHORIZED={PRECHECK_EXECUTION_AUTHORIZED}"
+    )
+
+
+def theoretical_linear_notional_usd(
+    *,
+    sz: Decimal | str,
+    ct_val: Decimal | str,
+    mark_px: Decimal | str,
+) -> Decimal:
+    """Documentary linear notional: sz × ctVal × markPx. Not OKX runtime proof."""
+    return Decimal(str(sz)) * Decimal(str(ct_val)) * Decimal(str(mark_px))
+
+
+def theoretical_candidate_notional_ratio(
+    *,
+    mark_px: Decimal | str,
+    sz: Decimal | str = DOCUMENTARY_SZ,
+) -> Decimal:
+    notional_a = theoretical_linear_notional_usd(sz=sz, ct_val=CANDIDATE_A_CT_VAL, mark_px=mark_px)
+    notional_b = theoretical_linear_notional_usd(sz=sz, ct_val=CANDIDATE_B_CT_VAL, mark_px=mark_px)
+    if notional_a == 0:
+        raise ZeroDivisionError("CANDIDATE_A_NOTIONAL_ZERO")
+    return notional_b / notional_a
+
+
+def unfilled_order_documentary_binding_v1() -> dict[str, object]:
+    return {
+        "SELECTED_PATH": SELECTED_PATH,
+        "ORDER_OBJECT_FIELD": ORDER_FIELD_NOTIONAL_USD,
+        "ORDER_FIELD_SEMANTICS": "ESTIMATED_NOTIONAL_VALUE_IN_USD_OF_ORDER",
+        "LINEAR_NOTIONAL_ALGEBRA": LINEAR_NOTIONAL_ALGEBRA,
+        "DISCRIMINATION_CLASS": DISCRIMINATION_CLASS,
+        "NOT_OKX_RUNTIME_PROOF": NOT_OKX_RUNTIME_PROOF,
+        "RULE_C_STATUS": RULE_C_STATUS,
+        "FACE_VALUE_CONFLICT_STATUS": FACE_VALUE_CONFLICT_STATUS,
+        "COVER_USDC_STATUS": COVER_USDC_STATUS,
+        "SUBMIT_UNLOCKED": False,
+        "LIVE_ARMED": False,
+        "PRECHECK_DEFAULT_ENABLED": PRECHECK_DEFAULT_ENABLED,
+        "PRECHECK_EXECUTION_AUTHORIZED": PRECHECK_EXECUTION_AUTHORIZED,
+        "PRECHECK_CANNOT_CREATE_ORDER": PRECHECK_CANNOT_CREATE_ORDER,
+        "ENDPOINT_ORDER_PRECHECK": ENDPOINT_ORDER_PRECHECK,
+        "ENDPOINT_ORDER_SUBMIT": ENDPOINT_ORDER_SUBMIT,
+        "ENDPOINTS_ISOLATED": ENDPOINT_ORDER_PRECHECK != ENDPOINT_ORDER_SUBMIT,
+        "LIVE_EEA_ACCT_LV": LIVE_EEA_ACCT_LV_EVIDENCE_VALUE,
+        "LIVE_EEA_ACCT_LV_EVIDENCE_CLASS": LIVE_EEA_ACCT_LV_EVIDENCE_CLASS,
+        "LIVE_EEA_ACCT_LV_ENVIRONMENT": LIVE_EEA_ACCT_LV_ENVIRONMENT,
+        "LIVE_EEA_ACCT_LV_EVIDENCE_PATH": LIVE_EEA_ACCT_LV_EVIDENCE_PATH,
+        "ORDER_PRECHECK_APPLICABLE_FOR_LIVE_EEA_ACCT_LV_2": False,
+        "CANDIDATE_A_CT_VAL": str(CANDIDATE_A_CT_VAL),
+        "CANDIDATE_B_CT_VAL": str(CANDIDATE_B_CT_VAL),
+        "EXPECTED_DISCRIMINATION_FACTOR": str(EXPECTED_DISCRIMINATION_FACTOR),
+    }
+
+
+def assert_no_submit_unlock_in_binding(binding: Mapping[str, object]) -> None:
+    if binding.get("SUBMIT_UNLOCKED") is not False:
+        raise RuntimeError("SUBMIT_UNLOCK_FORBIDDEN_IN_DOCUMENTARY_BINDING")
+    if binding.get("PRECHECK_EXECUTION_AUTHORIZED") is not False:
+        raise RuntimeError("PRECHECK_EXECUTION_FORBIDDEN_IN_DOCUMENTARY_BINDING")
+    if binding.get("LIVE_ARMED") is not False:
+        raise RuntimeError("LIVE_ARM_FORBIDDEN_IN_DOCUMENTARY_BINDING")

--- a/tests/ops/test_section_11_13_5_okx_acct_lv2_unfilled_order_documentary_discriminator_contract_v1.py
+++ b/tests/ops/test_section_11_13_5_okx_acct_lv2_unfilled_order_documentary_discriminator_contract_v1.py
@@ -1,0 +1,151 @@
+"""Offline tests for §11.13.5 acctLv=2 documentary discriminator contract.
+
+No network. Does not prove Rule C or unlock submit/live/canary.
+
+Theoretical candidate A/B notional ratio is THEORETICAL_DOCUMENTARY_ONLY,
+NOT_OKX_RUNTIME_PROOF.
+"""
+
+from __future__ import annotations
+
+import inspect
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.constants_v1 import (
+    LIVE_ARMED,
+    SUBMIT_UNLOCKED,
+)
+from src.ops.section_11_13_5_okx_acct_lv2_unfilled_order_documentary_discriminator_contract_v1 import (
+    ACCT_LV_FUTURES,
+    ACCT_LV_MULTI_CURRENCY,
+    ACCT_LV_PORTFOLIO,
+    ACCT_LV_SPOT,
+    CANDIDATE_A_CT_VAL,
+    CANDIDATE_B_CT_VAL,
+    DISCRIMINATION_CLASS,
+    ENDPOINT_ORDER_PRECHECK,
+    ENDPOINT_ORDER_SUBMIT,
+    EXPECTED_DISCRIMINATION_FACTOR,
+    LIVE_EEA_ACCT_LV_EVIDENCE_PATH,
+    LIVE_EEA_ACCT_LV_EVIDENCE_VALUE,
+    NOT_OKX_RUNTIME_PROOF,
+    ORDER_FIELD_NOTIONAL_USD,
+    PRECHECK_CANNOT_CREATE_ORDER,
+    PRECHECK_DEFAULT_ENABLED,
+    PRECHECK_EXECUTION_AUTHORIZED,
+    PRECHECK_REQUEST_FIELDS,
+    PRECHECK_RESPONSE_FIELDS,
+    RULE_C_STATUS,
+    SELECTED_PATH,
+    OrderPrecheckExecutionForbiddenError,
+    UnsupportedAcctLvFailClosedError,
+    assert_no_submit_unlock_in_binding,
+    order_precheck_execution_allowed,
+    refuse_order_precheck_execution_v1,
+    supports_order_precheck,
+    theoretical_candidate_notional_ratio,
+    theoretical_linear_notional_usd,
+    unfilled_order_documentary_binding_v1,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_live_eea_acct_lv_2_is_bound_to_existing_evidence_file() -> None:
+    evidence = REPO_ROOT / LIVE_EEA_ACCT_LV_EVIDENCE_PATH
+    assert evidence.is_file()
+    text = evidence.read_text(encoding="utf-8")
+    assert '"acctLv": "2"' in text
+    assert '"path": "/api/v5/account/config"' in text
+    assert '"HOST": "eea.okx.com"' in text
+    assert LIVE_EEA_ACCT_LV_EVIDENCE_VALUE == ACCT_LV_FUTURES
+
+
+def test_precheck_applicability_follows_official_v5_modes() -> None:
+    assert supports_order_precheck(ACCT_LV_MULTI_CURRENCY) is True
+    assert supports_order_precheck(ACCT_LV_PORTFOLIO) is True
+    assert supports_order_precheck(ACCT_LV_FUTURES) is False
+    assert supports_order_precheck(ACCT_LV_SPOT) is False
+    with pytest.raises(UnsupportedAcctLvFailClosedError, match="ACCT_LV_UNKNOWN"):
+        supports_order_precheck(None)
+    with pytest.raises(UnsupportedAcctLvFailClosedError, match="ACCT_LV_UNSUPPORTED"):
+        supports_order_precheck("UNKNOWN")
+
+
+def test_precheck_execution_is_hard_blocked_for_every_acct_lv() -> None:
+    assert PRECHECK_DEFAULT_ENABLED is False
+    assert PRECHECK_EXECUTION_AUTHORIZED is False
+    assert PRECHECK_CANNOT_CREATE_ORDER is True
+    for acct_lv in (
+        ACCT_LV_SPOT,
+        ACCT_LV_FUTURES,
+        ACCT_LV_MULTI_CURRENCY,
+        ACCT_LV_PORTFOLIO,
+        None,
+    ):
+        assert order_precheck_execution_allowed(acct_lv) is False
+    with pytest.raises(OrderPrecheckExecutionForbiddenError):
+        refuse_order_precheck_execution_v1()
+
+
+def test_precheck_endpoint_is_isolated_from_order_submit() -> None:
+    assert ENDPOINT_ORDER_PRECHECK == "/api/v5/trade/order-precheck"
+    assert ENDPOINT_ORDER_SUBMIT == "/api/v5/trade/order"
+    assert ENDPOINT_ORDER_PRECHECK != ENDPOINT_ORDER_SUBMIT
+    source = inspect.getsource(
+        __import__(
+            "src.ops.section_11_13_5_okx_acct_lv2_unfilled_order_documentary_discriminator_contract_v1",
+            fromlist=["refuse_order_precheck_execution_v1"],
+        )
+    )
+    assert "urlopen" not in source
+    assert "http.client" not in source
+    assert "requests." not in source
+    assert "post_entry_order" not in source
+    assert "run_canary_submit_transport_v1" not in source
+
+
+def test_precheck_fields_match_official_v5_names() -> None:
+    assert PRECHECK_REQUEST_FIELDS == (
+        "instId",
+        "tdMode",
+        "side",
+        "ordType",
+        "sz",
+        "px",
+    )
+    assert "imr" in PRECHECK_RESPONSE_FIELDS
+    assert "imrChg" in PRECHECK_RESPONSE_FIELDS
+    assert "mmr" in PRECHECK_RESPONSE_FIELDS
+    assert "mmrChg" in PRECHECK_RESPONSE_FIELDS
+    assert "adjEqChg" in PRECHECK_RESPONSE_FIELDS
+    assert "mgnRatioChg" in PRECHECK_RESPONSE_FIELDS
+    assert "liqPxDiff" in PRECHECK_RESPONSE_FIELDS
+
+
+def test_theoretical_linear_notional_discrimination_factor_is_100() -> None:
+    # THEORETICAL_DOCUMENTARY_ONLY / NOT_OKX_RUNTIME_PROOF
+    mark_px = Decimal("63043.7")
+    notional_a = theoretical_linear_notional_usd(sz="1", ct_val=CANDIDATE_A_CT_VAL, mark_px=mark_px)
+    notional_b = theoretical_linear_notional_usd(sz="1", ct_val=CANDIDATE_B_CT_VAL, mark_px=mark_px)
+    ratio = theoretical_candidate_notional_ratio(mark_px=mark_px)
+    assert ratio == EXPECTED_DISCRIMINATION_FACTOR
+    assert notional_b / notional_a == Decimal("100")
+    assert DISCRIMINATION_CLASS == "THEORETICAL_DOCUMENTARY_ONLY"
+    assert NOT_OKX_RUNTIME_PROOF is True
+
+
+def test_unfilled_order_binding_does_not_unlock_submit_or_claim_rule_c() -> None:
+    binding = unfilled_order_documentary_binding_v1()
+    assert_no_submit_unlock_in_binding(binding)
+    assert binding["SELECTED_PATH"] == SELECTED_PATH
+    assert binding["ORDER_OBJECT_FIELD"] == ORDER_FIELD_NOTIONAL_USD
+    assert binding["RULE_C_STATUS"] == RULE_C_STATUS == "UNPROVEN"
+    assert binding["NOT_OKX_RUNTIME_PROOF"] is True
+    assert binding["PRECHECK_CANNOT_CREATE_ORDER"] is True
+    assert binding["ORDER_PRECHECK_APPLICABLE_FOR_LIVE_EEA_ACCT_LV_2"] is False
+    assert SUBMIT_UNLOCKED is False
+    assert LIVE_ARMED is False


### PR DESCRIPTION
## Summary
- Bind existing live EEA `acctLv=2` evidence to a fail-closed documentary discriminator for accepted unfilled orders (`order.notionalUsd` + linear notional algebra).
- Encode official OKX V5 `POST /api/v5/trade/order-precheck` as documented only for Multi-currency (3) and Portfolio (4); never execute it; keep submit/live/canary locked.
- Do not prove Rule C, do not resolve face value, and do not add a new Z-section.

## Test plan
- [x] New contract tests (no network)
- [x] Submit/canary/confirm-token safety tests
- [x] PR_BOUNDED_FULL selector targets
- [ ] GitHub required checks (non-draft PR)


Made with [Cursor](https://cursor.com)