### PR TITLE
chore: ignore Playwright MCP local output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,8 @@ test_runs/
 
 # Local AI / test artefacts
 .claude/
+# Playwright MCP local output (Cursor @playwright/mcp default outputDir)
+.playwright-mcp/
 test_results/
 
 # Live runs & sessions (generierte Session-Daten)


### PR DESCRIPTION
## Summary
- Ignore `.playwright-mcp/` repository-wide as the default Cursor Playwright MCP output directory.
- Prevents Git noise and accidental check-in of generated local MCP snapshots/console dumps.
- No `.playwright-mcp/` files are committed. No runtime, trading, or §11.13.5 semantics change.

## Test plan
- [x] `git check-ignore -v` confirms the new `.playwright-mcp/` rule
- [x] `git ls-files .playwright-mcp` is empty
- [x] `git status --short` no longer lists `.playwright-mcp/` as untracked
- [x] Diff is `.gitignore` only
- [ ] GitHub required checks on this PR


Made with [Cursor](https://cursor.com)