### PR TITLE
feat(ops): offline live-flatten contract core + LF-03 permit/orchestration

### DIFF
--- a/src/ops/section_11_12_8_actual_productive_testnet_campaign_run_start_v1/okx_response_mapper_v1.py
+++ b/src/ops/section_11_12_8_actual_productive_testnet_campaign_run_start_v1/okx_response_mapper_v1.py
@@ -53,6 +53,9 @@ class OkxOrderResponseV1:
         }
 
 
+# Offline JSON presence only. Venue acceptance of boolean vs string is UNPROVEN.
+REDUCE_ONLY_WIRE_TYPE_STATUS = "UNPROVEN"
+
 # OKX Place Order: Conditional px required for these ordType values.
 _OKX_ORD_TYPES_REQUIRING_PX: frozenset[str] = frozenset(
     {
@@ -78,12 +81,20 @@ def build_venue_native_order_body_v1(
     quantity: str,
     td_mode: str = "cross",
     px: str | None = None,
+    reduce_only: bool = False,
 ) -> dict[str, Any]:
     """Cap 11.4 venue-native field mapping (productive; dry_run omitted).
 
     For LIMIT-class ordType, OKX Conditional ``px`` MUST be present in the
     final request body. Missing/blank px fails closed before wire.
+
+    ``reduceOnly`` is opt-in and omitted unless ``reduce_only is True``.
+    Entry/Testnet callers must keep the default so ordinary payloads omit
+    the field. Emitting the key does not prove venue acceptance; wire type
+    remains ``REDUCE_ONLY_WIRE_TYPE_STATUS``.
     """
+    if not isinstance(reduce_only, bool):
+        raise OkxResponseMapperError("REDUCE_ONLY_FLAG_INVALID")
     ord_type = order_type.lower()
     body: dict[str, Any] = {
         "clOrdId": client_order_id,
@@ -98,6 +109,9 @@ def build_venue_native_order_body_v1(
         if not px_text:
             raise OkxResponseMapperError("LIMIT_ORDER_PX_REQUIRED_BEFORE_WIRE")
         body["px"] = px_text
+    if reduce_only is True:
+        # Local JSON boolean. Venue string-vs-boolean wire type is UNPROVEN.
+        body["reduceOnly"] = True
     return body
 
 

--- a/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/flatten_orchestration_contract_v1.py
+++ b/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/flatten_orchestration_contract_v1.py
@@ -1,0 +1,328 @@
+"""Offline flatten permit and orchestration contract for §11.13.5 LF-03.
+
+Not runtime-reachable. Does not POST, invent a LIMIT price, or activate lifecycle.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Mapping
+
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.constants_v1 import (
+    DEFAULT_INSTRUMENT_ID,
+    DEFAULT_ORDER_TYPE,
+    LiveCanaryInstrumentBindingError,
+    assert_live_canary_instrument_binding_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.order_plan_v1 import (
+    FLATTEN_LIMIT_PRICE_GATE_STATUS,
+    CanaryFlattenOrderPlanV1,
+    LiveCanaryOrderPlanError,
+    build_minimum_valid_canary_flatten_order_plan_v1,
+    serialize_canary_clordid_v1,
+    serialize_canary_flatten_venue_native_payload_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.pre_submit_state_v1 import (
+    LiveCanaryPositionObservationError,
+    observe_target_position_flatten_candidate_v1,
+)
+
+FLATTEN_PERMIT_KIND = "FLATTEN_SUBMIT"
+FLATTEN_SUBMIT_UNREACHABLE_REASON = (
+    "FLATTEN_LIMIT_PRICE_POLICY_UNBOUND:" + FLATTEN_LIMIT_PRICE_GATE_STATUS
+)
+
+
+class LiveCanaryFlattenOrchestrationError(RuntimeError):
+    """Fail-closed offline flatten permit/orchestration violation."""
+
+
+@dataclass(frozen=True)
+class CanaryFlattenSubmitPermitV1:
+    """Typed flatten permit. Does not authorize Entry POST or flatten transport."""
+
+    owner_go: str
+    clordid: str
+    permit_id: str
+    instrument_id: str
+    side: str
+    quantity: str
+    reduce_only: bool
+    price_gate_status: str
+    submitted_entry_sz_used: bool
+    submit_reachable: bool = False
+    kind: str = FLATTEN_PERMIT_KIND
+
+    def __post_init__(self) -> None:
+        if self.kind != FLATTEN_PERMIT_KIND:
+            raise LiveCanaryFlattenOrchestrationError("FLATTEN_PERMIT_KIND_INVALID")
+        if self.submit_reachable is not False:
+            raise LiveCanaryFlattenOrchestrationError("FLATTEN_SUBMIT_REACHABLE_FORBIDDEN")
+        if self.reduce_only is not True:
+            raise LiveCanaryFlattenOrchestrationError("FLATTEN_PERMIT_REDUCE_ONLY_REQUIRED")
+        if self.price_gate_status != FLATTEN_LIMIT_PRICE_GATE_STATUS:
+            raise LiveCanaryFlattenOrchestrationError("FLATTEN_PRICE_GATE_STATUS_INVALID")
+        if self.submitted_entry_sz_used is not False:
+            raise LiveCanaryFlattenOrchestrationError("SUBMITTED_ENTRY_SZ_CANNOT_AUTHORIZE_FLATTEN")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "owner_go": self.owner_go,
+            "clordid": self.clordid,
+            "permit_id": self.permit_id,
+            "instrument_id": self.instrument_id,
+            "side": self.side,
+            "quantity": self.quantity,
+            "reduce_only": self.reduce_only,
+            "price_gate_status": self.price_gate_status,
+            "submitted_entry_sz_used": self.submitted_entry_sz_used,
+            "submit_reachable": self.submit_reachable,
+            "kind": self.kind,
+        }
+
+
+@dataclass(frozen=True)
+class CanaryFlattenOrchestrationVerdictV1:
+    """Offline orchestration result. Never a transport or execute authorization."""
+
+    entry_lifecycle_context: str
+    observation_status: str
+    flatten_plan_derivable: bool
+    permit_issued: bool
+    permit: CanaryFlattenSubmitPermitV1 | None
+    flatten_plan: CanaryFlattenOrderPlanV1 | None
+    submit_reachable: bool
+    serialization_reachable: bool
+    transport_invoked: bool
+    market_fallback_used: bool
+    submitted_entry_qty_used_as_authority: bool
+    blocking_reasons: tuple[str, ...]
+    contract_state: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "entry_lifecycle_context": self.entry_lifecycle_context,
+            "observation_status": self.observation_status,
+            "flatten_plan_derivable": self.flatten_plan_derivable,
+            "permit_issued": self.permit_issued,
+            "permit": None if self.permit is None else self.permit.to_dict(),
+            "flatten_plan": None if self.flatten_plan is None else self.flatten_plan.to_dict(),
+            "submit_reachable": self.submit_reachable,
+            "serialization_reachable": self.serialization_reachable,
+            "transport_invoked": self.transport_invoked,
+            "market_fallback_used": self.market_fallback_used,
+            "submitted_entry_qty_used_as_authority": self.submitted_entry_qty_used_as_authority,
+            "blocking_reasons": list(self.blocking_reasons),
+            "contract_state": self.contract_state,
+        }
+
+
+def _flatten_permit_id(*, owner_go: str, clordid: str) -> str:
+    material = f"FLATTEN_PERMIT:{owner_go}:{clordid}".encode("utf-8")
+    return hashlib.sha256(material).hexdigest()[:32]
+
+
+def _blocked_verdict(
+    *,
+    entry_lifecycle_context: str,
+    observation_status: str,
+    blocking_reasons: tuple[str, ...],
+    contract_state: str,
+) -> CanaryFlattenOrchestrationVerdictV1:
+    return CanaryFlattenOrchestrationVerdictV1(
+        entry_lifecycle_context=entry_lifecycle_context,
+        observation_status=observation_status,
+        flatten_plan_derivable=False,
+        permit_issued=False,
+        permit=None,
+        flatten_plan=None,
+        submit_reachable=False,
+        serialization_reachable=False,
+        transport_invoked=False,
+        market_fallback_used=False,
+        submitted_entry_qty_used_as_authority=False,
+        blocking_reasons=blocking_reasons,
+        contract_state=contract_state,
+    )
+
+
+def _assert_plan_is_offline_flatten(plan: CanaryFlattenOrderPlanV1) -> None:
+    if plan.reduce_only is not True:
+        raise LiveCanaryFlattenOrchestrationError("FLATTEN_PLAN_REDUCE_ONLY_REQUIRED")
+    if str(plan.order_type).upper() != "LIMIT":
+        raise LiveCanaryFlattenOrchestrationError("FLATTEN_MARKET_FALLBACK_FORBIDDEN")
+    if str(DEFAULT_ORDER_TYPE).upper() != "LIMIT":
+        raise LiveCanaryFlattenOrchestrationError("ENTRY_ORDER_TYPE_NOT_LIMIT")
+    if plan.limit_price is not None or plan.venue_native_payload is not None:
+        raise LiveCanaryFlattenOrchestrationError("FLATTEN_LIMIT_PRICE_POLICY_BOUND_FORBIDDEN")
+    if plan.price_gate_status != FLATTEN_LIMIT_PRICE_GATE_STATUS:
+        raise LiveCanaryFlattenOrchestrationError("FLATTEN_PRICE_GATE_STATUS_INVALID")
+    if plan.submitted_entry_sz_used is not False:
+        raise LiveCanaryFlattenOrchestrationError("SUBMITTED_ENTRY_SZ_CANNOT_AUTHORIZE_FLATTEN")
+
+
+def issue_canary_flatten_submit_permit_v1(
+    *,
+    positions_payload: Mapping[str, Any],
+    owner_go: str,
+    origin_main_sha: str,
+    instrument_id: str = DEFAULT_INSTRUMENT_ID,
+    submitted_entry_sz: str | None = None,
+    entry_clordid: str | None = None,
+) -> CanaryFlattenSubmitPermitV1:
+    """Issue an inert flatten permit from observed position. Submit remains unreachable."""
+    try:
+        assert_live_canary_instrument_binding_v1(instrument_id=instrument_id)
+    except LiveCanaryInstrumentBindingError as exc:
+        raise LiveCanaryFlattenOrchestrationError(f"INSTRUMENT_BINDING:{exc}") from exc
+    try:
+        plan = build_minimum_valid_canary_flatten_order_plan_v1(
+            positions_payload=positions_payload,
+            owner_go=owner_go,
+            origin_main_sha=origin_main_sha,
+            instrument_id=instrument_id,
+            submitted_entry_sz=submitted_entry_sz,
+        )
+    except LiveCanaryOrderPlanError as exc:
+        raise LiveCanaryFlattenOrchestrationError(f"FLATTEN_PERMIT_BLOCKED:{exc}") from exc
+    _assert_plan_is_offline_flatten(plan)
+    if entry_clordid is not None and plan.clordid == entry_clordid:
+        raise LiveCanaryFlattenOrchestrationError("FLATTEN_CLORDID_ALIASES_ENTRY")
+    return CanaryFlattenSubmitPermitV1(
+        owner_go=owner_go,
+        clordid=plan.clordid,
+        permit_id=_flatten_permit_id(owner_go=owner_go, clordid=plan.clordid),
+        instrument_id=plan.instrument_id,
+        side=plan.side,
+        quantity=plan.quantity,
+        reduce_only=True,
+        price_gate_status=FLATTEN_LIMIT_PRICE_GATE_STATUS,
+        submitted_entry_sz_used=False,
+        submit_reachable=False,
+        kind=FLATTEN_PERMIT_KIND,
+    )
+
+
+def refuse_canary_flatten_submit_transport_v1(
+    permit: CanaryFlattenSubmitPermitV1,
+    *,
+    px: str | None = None,
+) -> None:
+    """Refuse flatten POST/serialization. Never calls a transport."""
+    del px
+    if permit.kind != FLATTEN_PERMIT_KIND:
+        raise LiveCanaryFlattenOrchestrationError("FLATTEN_PERMIT_KIND_INVALID")
+    if permit.submit_reachable is not False:
+        raise LiveCanaryFlattenOrchestrationError("FLATTEN_SUBMIT_REACHABLE_FORBIDDEN")
+    raise LiveCanaryFlattenOrchestrationError(FLATTEN_SUBMIT_UNREACHABLE_REASON)
+
+
+def evaluate_canary_flatten_orchestration_contract_v1(
+    *,
+    positions_payload: Mapping[str, Any],
+    owner_go: str,
+    origin_main_sha: str,
+    instrument_id: str = DEFAULT_INSTRUMENT_ID,
+    submitted_entry_sz: str | None = None,
+    entry_lifecycle_context: str = "ENTRY_LIFECYCLE_CONTEXT",
+) -> CanaryFlattenOrchestrationVerdictV1:
+    """ENTRY context → observe → optional permit. Submit/serialization stay unreachable."""
+    try:
+        assert_live_canary_instrument_binding_v1(instrument_id=instrument_id)
+    except LiveCanaryInstrumentBindingError as exc:
+        return _blocked_verdict(
+            entry_lifecycle_context=entry_lifecycle_context,
+            observation_status="INSTRUMENT_BINDING_FAILED",
+            blocking_reasons=(f"INSTRUMENT_BINDING:{exc}",),
+            contract_state="FLATTEN_FAIL_CLOSED",
+        )
+    try:
+        observed = observe_target_position_flatten_candidate_v1(
+            positions_payload=positions_payload,
+            instrument_id=instrument_id,
+        )
+    except LiveCanaryPositionObservationError as exc:
+        code = str(exc)
+        if "ZERO_POSITION_NO_FLATTEN_ORDER" in code:
+            status = "ZERO_POSITION"
+            state = "NO_FLATTEN_ZERO_POSITION"
+        elif "TARGET_INSTRUMENT_NOT_OBSERVED" in code:
+            status = "TARGET_INSTRUMENT_NOT_OBSERVED"
+            state = "FLATTEN_FAIL_CLOSED"
+        elif "AMBIGUOUS_TARGET_POSITION_ROWS" in code:
+            status = "AMBIGUOUS_TARGET_POSITION_ROWS"
+            state = "FLATTEN_FAIL_CLOSED"
+        elif "POSITION_SIZE_" in code:
+            status = "MALFORMED_POSITION"
+            state = "FLATTEN_FAIL_CLOSED"
+        else:
+            status = "OBSERVATION_FAIL_CLOSED"
+            state = "FLATTEN_FAIL_CLOSED"
+        return _blocked_verdict(
+            entry_lifecycle_context=entry_lifecycle_context,
+            observation_status=status,
+            blocking_reasons=(code,),
+            contract_state=state,
+        )
+    try:
+        plan = build_minimum_valid_canary_flatten_order_plan_v1(
+            positions_payload=positions_payload,
+            owner_go=owner_go,
+            origin_main_sha=origin_main_sha,
+            instrument_id=instrument_id,
+            submitted_entry_sz=submitted_entry_sz,
+        )
+    except LiveCanaryOrderPlanError as exc:
+        return _blocked_verdict(
+            entry_lifecycle_context=entry_lifecycle_context,
+            observation_status="OBSERVED_NONZERO",
+            blocking_reasons=(f"FLATTEN_PLAN:{exc}",),
+            contract_state="FLATTEN_FAIL_CLOSED",
+        )
+    _assert_plan_is_offline_flatten(plan)
+    if observed.candidate_flatten_qty != abs(observed.signed_pos):
+        raise LiveCanaryFlattenOrchestrationError("FLATTEN_QTY_NOT_ABS_OBSERVED_POS")
+    if Decimal(plan.quantity) != observed.candidate_flatten_qty:
+        raise LiveCanaryFlattenOrchestrationError("FLATTEN_QTY_NOT_ABS_OBSERVED_POS")
+    if plan.side != observed.candidate_flatten_side:
+        raise LiveCanaryFlattenOrchestrationError("FLATTEN_SIDE_NOT_FROM_OBSERVED_SIGN")
+    entry_clordid = serialize_canary_clordid_v1(owner_go=owner_go, origin_main_sha=origin_main_sha)
+    if plan.clordid == entry_clordid:
+        raise LiveCanaryFlattenOrchestrationError("FLATTEN_CLORDID_ALIASES_ENTRY")
+    permit = CanaryFlattenSubmitPermitV1(
+        owner_go=owner_go,
+        clordid=plan.clordid,
+        permit_id=_flatten_permit_id(owner_go=owner_go, clordid=plan.clordid),
+        instrument_id=plan.instrument_id,
+        side=plan.side,
+        quantity=plan.quantity,
+        reduce_only=True,
+        price_gate_status=FLATTEN_LIMIT_PRICE_GATE_STATUS,
+        submitted_entry_sz_used=False,
+        submit_reachable=False,
+        kind=FLATTEN_PERMIT_KIND,
+    )
+    serialization_blocked = False
+    try:
+        serialize_canary_flatten_venue_native_payload_v1(plan, px=None)
+    except LiveCanaryOrderPlanError:
+        serialization_blocked = True
+    if not serialization_blocked:
+        raise LiveCanaryFlattenOrchestrationError("FLATTEN_SERIALIZATION_UNEXPECTEDLY_REACHABLE")
+    return CanaryFlattenOrchestrationVerdictV1(
+        entry_lifecycle_context=entry_lifecycle_context,
+        observation_status="OBSERVED_NONZERO",
+        flatten_plan_derivable=True,
+        permit_issued=True,
+        permit=permit,
+        flatten_plan=plan,
+        submit_reachable=False,
+        serialization_reachable=False,
+        transport_invoked=False,
+        market_fallback_used=False,
+        submitted_entry_qty_used_as_authority=False,
+        blocking_reasons=(FLATTEN_SUBMIT_UNREACHABLE_REASON,),
+        contract_state="FLATTEN_PERMIT_ISSUED_SUBMIT_BLOCKED_PRICE_POLICY",
+    )

--- a/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/order_plan_v1.py
+++ b/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/order_plan_v1.py
@@ -32,6 +32,10 @@ from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.exposure_v1 import 
     LiveCanaryExposureError,
     build_canary_exposure_binding_v1,
 )
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.pre_submit_state_v1 import (
+    LiveCanaryPositionObservationError,
+    observe_target_position_flatten_candidate_v1,
+)
 
 
 class LiveCanaryOrderPlanError(RuntimeError):
@@ -141,6 +145,23 @@ def serialize_canary_clordid_v1(*, owner_go: str, origin_main_sha: str) -> str:
     return coid
 
 
+def serialize_canary_flatten_clordid_v1(*, owner_go: str, origin_main_sha: str) -> str:
+    material = hashlib.sha256(f"{owner_go}:{origin_main_sha}:FLATTEN".encode("utf-8")).hexdigest()
+    coid = build_client_order_id(
+        run_id=material,
+        session_id=material,
+        intent_id=material,
+        environment="LIVE",
+        instrument_id=DEFAULT_INSTRUMENT_ID,
+        sequence=1,
+    )
+    if not coid or len(coid) > CLIENT_ORDER_ID_MAX_LENGTH:
+        raise LiveCanaryOrderPlanError("FLATTEN_CLORDID_LENGTH_VIOLATION")
+    if not CLIENT_ORDER_ID_ALLOWED_PATTERN.fullmatch(coid):
+        raise LiveCanaryOrderPlanError("FLATTEN_CLORDID_ALPHANUMERIC_VIOLATION")
+    return coid
+
+
 @dataclass(frozen=True)
 class CanaryOrderPlanV1:
     instrument_id: str
@@ -240,4 +261,101 @@ def build_minimum_valid_canary_order_plan_v1(
         max_notional=exposure.max_notional,
         clordid=clordid,
         venue_native_payload=payload,
+    )
+
+
+FLATTEN_LIMIT_PRICE_GATE_STATUS = "FAIL_CLOSED_UNTIL_SEPARATE_OWNER_GO"
+
+
+def _format_flatten_qty(value: Decimal) -> str:
+    if value <= 0:
+        raise LiveCanaryOrderPlanError("ZERO_POSITION_NO_FLATTEN_ORDER")
+    integral = value.to_integral_value()
+    if value == integral:
+        return format(integral, "f")
+    return format(value, "f")
+
+
+@dataclass(frozen=True)
+class CanaryFlattenOrderPlanV1:
+    """Offline flatten plan. Not runtime-reachable and not price-authorized."""
+
+    instrument_id: str
+    side: str
+    order_type: str
+    td_mode: str
+    quantity: str
+    reduce_only: bool
+    clordid: str
+    limit_price: None
+    price_gate_status: str
+    venue_native_payload: None
+    submitted_entry_sz_used: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "instrument_id": self.instrument_id,
+            "side": self.side,
+            "order_type": self.order_type,
+            "td_mode": self.td_mode,
+            "quantity": self.quantity,
+            "reduce_only": self.reduce_only,
+            "clordid": self.clordid,
+            "limit_price": self.limit_price,
+            "price_gate_status": self.price_gate_status,
+            "venue_native_payload": self.venue_native_payload,
+            "submitted_entry_sz_used": self.submitted_entry_sz_used,
+        }
+
+
+def build_minimum_valid_canary_flatten_order_plan_v1(
+    *,
+    positions_payload: Mapping[str, Any],
+    owner_go: str,
+    origin_main_sha: str,
+    instrument_id: str = DEFAULT_INSTRUMENT_ID,
+    td_mode: str = DEFAULT_TD_MODE,
+    submitted_entry_sz: str | None = None,
+) -> CanaryFlattenOrderPlanV1:
+    """Build an Entry-separated flatten plan from observed position only.
+
+    ``submitted_entry_sz`` is accepted only so tests can prove it is ignored.
+    No LIMIT price is bound. No venue-native payload is produced.
+    """
+    del submitted_entry_sz
+    try:
+        observed = observe_target_position_flatten_candidate_v1(
+            positions_payload=positions_payload,
+            instrument_id=instrument_id,
+        )
+    except LiveCanaryPositionObservationError as exc:
+        raise LiveCanaryOrderPlanError(f"FLATTEN_OBSERVATION:{exc}") from exc
+    clordid = serialize_canary_flatten_clordid_v1(
+        owner_go=owner_go,
+        origin_main_sha=origin_main_sha,
+    )
+    return CanaryFlattenOrderPlanV1(
+        instrument_id=observed.instrument_id,
+        side=observed.candidate_flatten_side,
+        order_type="LIMIT",
+        td_mode=td_mode,
+        quantity=_format_flatten_qty(observed.candidate_flatten_qty),
+        reduce_only=True,
+        clordid=clordid,
+        limit_price=None,
+        price_gate_status=FLATTEN_LIMIT_PRICE_GATE_STATUS,
+        venue_native_payload=None,
+        submitted_entry_sz_used=False,
+    )
+
+
+def serialize_canary_flatten_venue_native_payload_v1(
+    plan: CanaryFlattenOrderPlanV1,
+    *,
+    px: str | None = None,
+) -> dict[str, Any]:
+    """Refuse a wire-ready flatten LIMIT body until a separate price-policy GO."""
+    del plan, px
+    raise LiveCanaryOrderPlanError(
+        "FLATTEN_LIMIT_PRICE_POLICY_UNBOUND:" + FLATTEN_LIMIT_PRICE_GATE_STATUS
     )

--- a/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/pre_submit_state_v1.py
+++ b/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/pre_submit_state_v1.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation
 from typing import Any, Mapping
 
@@ -12,6 +13,28 @@ from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.constants_v1 import
 
 class LiveCanaryPreSubmitStateError(RuntimeError):
     """Fail-closed pre-submit exchange-state violation."""
+
+
+class LiveCanaryPositionObservationError(RuntimeError):
+    """Fail-closed observed-position flatten-candidate violation."""
+
+
+@dataclass(frozen=True)
+class ObservedTargetPositionFlattenCandidateV1:
+    """Offline observation only. Not productive flatten authorization."""
+
+    instrument_id: str
+    signed_pos: Decimal
+    candidate_flatten_qty: Decimal
+    candidate_flatten_side: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "instrument_id": self.instrument_id,
+            "signed_pos": format(self.signed_pos, "f"),
+            "candidate_flatten_qty": format(self.candidate_flatten_qty, "f"),
+            "candidate_flatten_side": self.candidate_flatten_side,
+        }
 
 
 def _rows(payload: Mapping[str, Any]) -> list[Mapping[str, Any]]:
@@ -31,6 +54,58 @@ def _pos_size(row: Mapping[str, Any]) -> Decimal:
         return Decimal(str(raw))
     except (InvalidOperation, TypeError, ValueError) as exc:
         raise LiveCanaryPreSubmitStateError("POSITION_SIZE_UNPARSEABLE") from exc
+
+
+def _signed_observed_pos(row: Mapping[str, Any]) -> Decimal:
+    if "pos" in row and row["pos"] is not None:
+        raw = row["pos"]
+    elif "posSize" in row and row["posSize"] is not None:
+        raw = row["posSize"]
+    else:
+        raise LiveCanaryPositionObservationError("POSITION_SIZE_MISSING")
+    text = str(raw).strip()
+    if not text:
+        raise LiveCanaryPositionObservationError("POSITION_SIZE_MISSING")
+    try:
+        return Decimal(text)
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise LiveCanaryPositionObservationError("POSITION_SIZE_UNPARSEABLE") from exc
+
+
+def observe_target_position_flatten_candidate_v1(
+    *,
+    positions_payload: Mapping[str, Any],
+    instrument_id: str = DEFAULT_INSTRUMENT_ID,
+) -> ObservedTargetPositionFlattenCandidateV1:
+    """Derive flatten qty/side from a unique observed target position.
+
+    Submitted Entry quantity is not an input and cannot be authority.
+    Zero, missing, malformed, or ambiguous rows fail closed. This result
+    is not productive flatten authorization.
+    """
+    target = str(instrument_id or "").strip()
+    if not target:
+        raise LiveCanaryPositionObservationError("TARGET_INSTRUMENT_REQUIRED")
+    try:
+        rows = _rows(positions_payload)
+    except LiveCanaryPreSubmitStateError as exc:
+        raise LiveCanaryPositionObservationError(str(exc)) from exc
+    matching = [row for row in rows if str(row.get("instId") or "") == target]
+    if not matching:
+        raise LiveCanaryPositionObservationError("TARGET_INSTRUMENT_NOT_OBSERVED")
+    if len(matching) != 1:
+        raise LiveCanaryPositionObservationError("AMBIGUOUS_TARGET_POSITION_ROWS")
+    signed = _signed_observed_pos(matching[0])
+    if signed == 0:
+        raise LiveCanaryPositionObservationError("ZERO_POSITION_NO_FLATTEN_ORDER")
+    abs_qty = abs(signed)
+    side = "SELL" if signed > 0 else "BUY"
+    return ObservedTargetPositionFlattenCandidateV1(
+        instrument_id=target,
+        signed_pos=signed,
+        candidate_flatten_qty=abs_qty,
+        candidate_flatten_side=side,
+    )
 
 
 def evaluate_pre_submit_exchange_state_v1(

--- a/tests/ops/test_section_11_13_5_live_flatten_offline_contract_core_v1.py
+++ b/tests/ops/test_section_11_13_5_live_flatten_offline_contract_core_v1.py
@@ -317,6 +317,8 @@ def test_flatten_contract_is_not_wired_into_execute_or_lifecycle() -> None:
     transport_src = inspect.getsource(run_canary_submit_transport_v1)
     assert "build_minimum_valid_canary_flatten_order_plan_v1" not in transport_src
     assert "post_flatten_order" not in transport_src
+    assert "issue_canary_flatten_submit_permit_v1" not in transport_src
+    assert "evaluate_canary_flatten_orchestration_contract_v1" not in transport_src
     http_src = inspect.getsource(http_client_v1)
     assert "post_flatten_order" not in http_src
     assert "CanaryFlattenSubmitPermitV1" not in http_src

--- a/tests/ops/test_section_11_13_5_live_flatten_offline_contract_core_v1.py
+++ b/tests/ops/test_section_11_13_5_live_flatten_offline_contract_core_v1.py
@@ -1,0 +1,323 @@
+"""LF-01/LF-02 offline flatten contract-core tests. No network, no submit."""
+
+from __future__ import annotations
+
+import inspect
+import json
+from typing import Any, Mapping
+
+import pytest
+
+from src.ops.section_11_12_8_actual_productive_testnet_campaign_run_start_v1.okx_response_mapper_v1 import (
+    REDUCE_ONLY_WIRE_TYPE_STATUS,
+    OkxResponseMapperError,
+    build_venue_native_order_body_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.constants_v1 import (
+    DEFAULT_INSTRUMENT_ID,
+    ENDPOINT_CANCEL,
+    ENDPOINT_SUBMIT,
+    ORDER_COUNT_LIMIT,
+    POST_ENDPOINTS_GATED,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.lifecycle_v1 import (
+    build_lifecycle_and_closeout_contract_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.order_plan_v1 import (
+    FLATTEN_LIMIT_PRICE_GATE_STATUS,
+    LiveCanaryOrderPlanError,
+    build_minimum_valid_canary_flatten_order_plan_v1,
+    build_minimum_valid_canary_order_plan_v1,
+    serialize_canary_clordid_v1,
+    serialize_canary_flatten_clordid_v1,
+    serialize_canary_flatten_venue_native_payload_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.pre_submit_state_v1 import (
+    LiveCanaryPositionObservationError,
+    observe_target_position_flatten_candidate_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.submit_transport_v1 import (
+    run_canary_submit_transport_v1,
+)
+
+OWNER_GO = "OWNER_GO_LIVE_CANARY_MINIMUM_EXPOSURE"
+ORIGIN_SHA = "aa421d84cd0223146ab63f94405e81ed813d40c3"
+TARGET = DEFAULT_INSTRUMENT_ID
+INSTRUMENTS = {
+    "code": "0",
+    "data": [
+        {
+            "instId": TARGET,
+            "instType": "FUTURES",
+            "ruleType": "xperp",
+            "minSz": "1",
+            "lotSz": "1",
+            "tickSz": "0.1",
+            "ctVal": "0.0001",
+            "ctValCcy": "BTC",
+        }
+    ],
+}
+TICKER = {"code": "0", "data": [{"instId": TARGET, "last": "63028.1"}]}
+ENTRY_BODY_KEYS = {
+    "instId",
+    "tdMode",
+    "side",
+    "ordType",
+    "sz",
+    "px",
+    "clOrdId",
+}
+
+
+def _positions(*rows: Mapping[str, Any]) -> dict[str, Any]:
+    return {"code": "0", "data": list(rows)}
+
+
+def _entry_body(**overrides: Any) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "client_order_id": "c1",
+        "instrument": TARGET,
+        "order_type": "LIMIT",
+        "side": "buy",
+        "quantity": "1",
+        "px": "10000",
+    }
+    kwargs.update(overrides)
+    return build_venue_native_order_body_v1(**kwargs)
+
+
+def test_entry_payload_omits_reduce_only_by_default() -> None:
+    body = _entry_body()
+    assert "reduceOnly" not in body
+    assert set(body) == ENTRY_BODY_KEYS
+    assert REDUCE_ONLY_WIRE_TYPE_STATUS == "UNPROVEN"
+
+
+def test_entry_payload_omits_reduce_only_when_explicitly_false() -> None:
+    body = _entry_body(reduce_only=False)
+    assert "reduceOnly" not in body
+    assert set(body) == ENTRY_BODY_KEYS
+
+
+def test_existing_entry_body_contract_unchanged() -> None:
+    body = _entry_body()
+    assert body["clOrdId"] == "c1"
+    assert body["instId"] == TARGET
+    assert body["tdMode"] == "cross"
+    assert body["side"] == "buy"
+    assert body["ordType"] == "limit"
+    assert body["sz"] == "1"
+    assert body["px"] == "10000"
+    assert "posSide" not in body
+    assert "client_order_id" not in body
+
+
+def test_explicit_flatten_serialization_contains_reduce_only_only_when_requested() -> None:
+    omitted = _entry_body()
+    requested = _entry_body(reduce_only=True)
+    assert "reduceOnly" not in omitted
+    assert requested["reduceOnly"] is True
+    assert set(requested) == ENTRY_BODY_KEYS | {"reduceOnly"}
+    assert requested["ordType"] == "limit"
+    assert "posSide" not in requested
+    wire = json.dumps(requested, separators=(",", ":"), ensure_ascii=True)
+    assert '"reduceOnly":true' in wire
+    assert REDUCE_ONLY_WIRE_TYPE_STATUS == "UNPROVEN"
+
+
+def test_reduce_only_flag_rejects_non_bool() -> None:
+    with pytest.raises(OkxResponseMapperError, match="REDUCE_ONLY_FLAG_INVALID"):
+        _entry_body(reduce_only=1)  # type: ignore[arg-type]
+
+
+def test_observed_positive_position_derives_sell() -> None:
+    observed = observe_target_position_flatten_candidate_v1(
+        positions_payload=_positions({"instId": TARGET, "pos": "2"}),
+    )
+    assert observed.candidate_flatten_side == "SELL"
+    assert observed.candidate_flatten_qty == observed.signed_pos == 2
+    plan = build_minimum_valid_canary_flatten_order_plan_v1(
+        positions_payload=_positions({"instId": TARGET, "pos": "2"}),
+        owner_go=OWNER_GO,
+        origin_main_sha=ORIGIN_SHA,
+        submitted_entry_sz="1",
+    )
+    assert plan.side == "SELL"
+    assert plan.quantity == "2"
+    assert plan.reduce_only is True
+    assert plan.submitted_entry_sz_used is False
+
+
+def test_observed_negative_position_derives_buy() -> None:
+    observed = observe_target_position_flatten_candidate_v1(
+        positions_payload=_positions({"instId": TARGET, "pos": "-3"}),
+    )
+    assert observed.candidate_flatten_side == "BUY"
+    assert observed.signed_pos == -3
+    assert observed.candidate_flatten_qty == 3
+    plan = build_minimum_valid_canary_flatten_order_plan_v1(
+        positions_payload=_positions({"instId": TARGET, "pos": "-3"}),
+        owner_go=OWNER_GO,
+        origin_main_sha=ORIGIN_SHA,
+        submitted_entry_sz="1",
+    )
+    assert plan.side == "BUY"
+    assert plan.quantity == "3"
+    assert plan.reduce_only is True
+
+
+def test_observed_zero_cannot_create_flatten_order() -> None:
+    with pytest.raises(LiveCanaryPositionObservationError, match="ZERO_POSITION_NO_FLATTEN_ORDER"):
+        observe_target_position_flatten_candidate_v1(
+            positions_payload=_positions({"instId": TARGET, "pos": "0"}),
+        )
+    with pytest.raises(LiveCanaryOrderPlanError, match="ZERO_POSITION_NO_FLATTEN_ORDER"):
+        build_minimum_valid_canary_flatten_order_plan_v1(
+            positions_payload=_positions({"instId": TARGET, "pos": "0"}),
+            owner_go=OWNER_GO,
+            origin_main_sha=ORIGIN_SHA,
+        )
+
+
+def test_flatten_qty_derives_from_observed_position_not_submitted_entry_sz() -> None:
+    plan = build_minimum_valid_canary_flatten_order_plan_v1(
+        positions_payload=_positions({"instId": TARGET, "pos": "4"}),
+        owner_go=OWNER_GO,
+        origin_main_sha=ORIGIN_SHA,
+        submitted_entry_sz="1",
+    )
+    assert plan.quantity == "4"
+    assert plan.quantity != "1"
+    assert plan.submitted_entry_sz_used is False
+    source = inspect.getsource(build_minimum_valid_canary_flatten_order_plan_v1)
+    assert "submitted_entry_sz" in source
+    assert "del submitted_entry_sz" in source
+
+
+def test_malformed_position_cannot_authorize_flatten() -> None:
+    with pytest.raises(LiveCanaryPositionObservationError, match="POSITION_SIZE_UNPARSEABLE"):
+        observe_target_position_flatten_candidate_v1(
+            positions_payload=_positions({"instId": TARGET, "pos": "not-a-number"}),
+        )
+    with pytest.raises(LiveCanaryPositionObservationError, match="POSITION_SIZE_MISSING"):
+        observe_target_position_flatten_candidate_v1(
+            positions_payload=_positions({"instId": TARGET}),
+        )
+    with pytest.raises(LiveCanaryOrderPlanError, match="POSITION_SIZE_MISSING"):
+        build_minimum_valid_canary_flatten_order_plan_v1(
+            positions_payload=_positions({"instId": TARGET, "pos": ""}),
+            owner_go=OWNER_GO,
+            origin_main_sha=ORIGIN_SHA,
+        )
+
+
+def test_missing_target_instrument_cannot_authorize_flatten() -> None:
+    with pytest.raises(LiveCanaryPositionObservationError, match="TARGET_INSTRUMENT_NOT_OBSERVED"):
+        observe_target_position_flatten_candidate_v1(
+            positions_payload=_positions({"instId": "BTC-USDT-SWAP", "pos": "1"}),
+        )
+    with pytest.raises(LiveCanaryOrderPlanError, match="TARGET_INSTRUMENT_NOT_OBSERVED"):
+        build_minimum_valid_canary_flatten_order_plan_v1(
+            positions_payload={"code": "0", "data": []},
+            owner_go=OWNER_GO,
+            origin_main_sha=ORIGIN_SHA,
+        )
+
+
+def test_ambiguous_multiple_authoritative_target_rows_cannot_authorize_flatten() -> None:
+    payload = _positions(
+        {"instId": TARGET, "pos": "1"},
+        {"instId": TARGET, "pos": "1"},
+    )
+    with pytest.raises(LiveCanaryPositionObservationError, match="AMBIGUOUS_TARGET_POSITION_ROWS"):
+        observe_target_position_flatten_candidate_v1(positions_payload=payload)
+    with pytest.raises(LiveCanaryOrderPlanError, match="AMBIGUOUS_TARGET_POSITION_ROWS"):
+        build_minimum_valid_canary_flatten_order_plan_v1(
+            positions_payload=payload,
+            owner_go=OWNER_GO,
+            origin_main_sha=ORIGIN_SHA,
+        )
+
+
+def test_entry_and_flatten_clordid_identities_do_not_alias() -> None:
+    entry = serialize_canary_clordid_v1(owner_go=OWNER_GO, origin_main_sha=ORIGIN_SHA)
+    flatten = serialize_canary_flatten_clordid_v1(owner_go=OWNER_GO, origin_main_sha=ORIGIN_SHA)
+    assert entry != flatten
+    plan = build_minimum_valid_canary_flatten_order_plan_v1(
+        positions_payload=_positions({"instId": TARGET, "pos": "1"}),
+        owner_go=OWNER_GO,
+        origin_main_sha=ORIGIN_SHA,
+    )
+    assert plan.clordid == flatten
+    assert plan.clordid != entry
+
+
+def test_post_endpoints_gated_and_entry_order_count_limit_unchanged() -> None:
+    assert POST_ENDPOINTS_GATED == (
+        "/api/v5/trade/order",
+        "/api/v5/trade/cancel-order",
+    )
+    assert ENDPOINT_SUBMIT == "/api/v5/trade/order"
+    assert ENDPOINT_CANCEL == "/api/v5/trade/cancel-order"
+    assert "/api/v5/trade/close-position" not in POST_ENDPOINTS_GATED
+    assert ORDER_COUNT_LIMIT == 1
+
+
+def test_entry_plan_remains_entry_only_and_omits_reduce_only() -> None:
+    plan = build_minimum_valid_canary_order_plan_v1(
+        instruments_payload=INSTRUMENTS,
+        ticker_payload=TICKER,
+        owner_go=OWNER_GO,
+        origin_main_sha=ORIGIN_SHA,
+    )
+    assert plan.side == "BUY"
+    assert plan.quantity == "1"
+    assert "reduceOnly" not in plan.venue_native_payload
+    assert set(plan.venue_native_payload) == ENTRY_BODY_KEYS
+    source = inspect.getsource(build_minimum_valid_canary_order_plan_v1)
+    assert "reduce_only" not in source
+
+
+def test_testnet_and_entry_bodies_backward_compatible_without_explicit_reduce_only() -> None:
+    testnet = build_venue_native_order_body_v1(
+        client_order_id="c1",
+        instrument="BTC-USD_UM_XPERP-310328",
+        order_type="LIMIT",
+        side="buy",
+        quantity="1",
+        px="10000",
+    )
+    assert "reduceOnly" not in testnet
+    assert testnet["ordType"] == "limit"
+    assert set(testnet) == ENTRY_BODY_KEYS
+
+
+def test_flatten_plan_price_gate_fails_closed_and_is_not_wire_ready() -> None:
+    plan = build_minimum_valid_canary_flatten_order_plan_v1(
+        positions_payload=_positions({"instId": TARGET, "pos": "1"}),
+        owner_go=OWNER_GO,
+        origin_main_sha=ORIGIN_SHA,
+    )
+    assert plan.order_type == "LIMIT"
+    assert plan.venue_native_payload is None
+    assert plan.limit_price is None
+    assert plan.price_gate_status == FLATTEN_LIMIT_PRICE_GATE_STATUS
+    with pytest.raises(LiveCanaryOrderPlanError, match="FLATTEN_LIMIT_PRICE_POLICY_UNBOUND"):
+        serialize_canary_flatten_venue_native_payload_v1(plan, px="63028.1")
+
+
+def test_flatten_contract_is_not_wired_into_execute_or_lifecycle() -> None:
+    from src.ops.section_11_13_5_live_canary_minimum_exposure_v1 import http_client_v1
+
+    lifecycle = build_lifecycle_and_closeout_contract_v1()
+    assert lifecycle["ACTIVATED"] is False
+    assert lifecycle["order_count_limit"] == 1
+    assert lifecycle["order_type_semantics"] == "LIMIT_ONLY_NO_MARKET"
+    transport_src = inspect.getsource(run_canary_submit_transport_v1)
+    assert "build_minimum_valid_canary_flatten_order_plan_v1" not in transport_src
+    assert "post_flatten_order" not in transport_src
+    http_src = inspect.getsource(http_client_v1)
+    assert "post_flatten_order" not in http_src
+    assert "CanaryFlattenSubmitPermitV1" not in http_src
+    assert "FLATTEN_SUBMIT" not in http_src

--- a/tests/ops/test_section_11_13_5_live_flatten_offline_permit_orchestration_v1.py
+++ b/tests/ops/test_section_11_13_5_live_flatten_offline_permit_orchestration_v1.py
@@ -1,0 +1,318 @@
+"""LF-03 offline flatten permit and orchestration contract tests. No network."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Mapping
+
+import pytest
+
+from src.ops.section_11_12_8_actual_productive_testnet_campaign_run_start_v1.okx_response_mapper_v1 import (
+    REDUCE_ONLY_WIRE_TYPE_STATUS,
+    build_venue_native_order_body_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.constants_v1 import (
+    DEFAULT_INSTRUMENT_ID,
+    DEFAULT_ORDER_TYPE,
+    ENDPOINT_CANCEL,
+    ENDPOINT_SUBMIT,
+    ORDER_COUNT_LIMIT,
+    POST_ENDPOINTS_GATED,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.flatten_orchestration_contract_v1 import (
+    FLATTEN_PERMIT_KIND,
+    FLATTEN_SUBMIT_UNREACHABLE_REASON,
+    CanaryFlattenSubmitPermitV1,
+    LiveCanaryFlattenOrchestrationError,
+    evaluate_canary_flatten_orchestration_contract_v1,
+    issue_canary_flatten_submit_permit_v1,
+    refuse_canary_flatten_submit_transport_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.http_client_v1 import (
+    CanaryEntrySubmitPermitV1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.lifecycle_v1 import (
+    build_lifecycle_and_closeout_contract_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.order_plan_v1 import (
+    FLATTEN_LIMIT_PRICE_GATE_STATUS,
+    serialize_canary_clordid_v1,
+    serialize_canary_flatten_clordid_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.submit_transport_v1 import (
+    run_canary_submit_transport_v1,
+)
+
+OWNER_GO = "OWNER_GO_LIVE_CANARY_MINIMUM_EXPOSURE"
+ORIGIN_SHA = "aa421d84cd0223146ab63f94405e81ed813d40c3"
+TARGET = DEFAULT_INSTRUMENT_ID
+
+
+def _positions(*rows: Mapping[str, Any]) -> dict[str, Any]:
+    return {"code": "0", "data": list(rows)}
+
+
+def test_long_observed_position_issues_sell_flatten_permit() -> None:
+    verdict = evaluate_canary_flatten_orchestration_contract_v1(
+        positions_payload=_positions({"instId": TARGET, "pos": "2"}),
+        owner_go=OWNER_GO,
+        origin_main_sha=ORIGIN_SHA,
+        submitted_entry_sz="1",
+        entry_lifecycle_context="ENTRY_FILLED_CONTEXT",
+    )
+    assert verdict.permit_issued is True
+    assert verdict.permit is not None
+    assert verdict.permit.side == "SELL"
+    assert verdict.permit.quantity == "2"
+    assert verdict.permit.kind == FLATTEN_PERMIT_KIND
+    assert verdict.flatten_plan is not None
+    assert verdict.flatten_plan.side == "SELL"
+
+
+def test_short_observed_position_issues_buy_flatten_permit() -> None:
+    permit = issue_canary_flatten_submit_permit_v1(
+        positions_payload=_positions({"instId": TARGET, "pos": "-3"}),
+        owner_go=OWNER_GO,
+        origin_main_sha=ORIGIN_SHA,
+        submitted_entry_sz="1",
+    )
+    assert permit.side == "BUY"
+    assert permit.quantity == "3"
+    assert permit.reduce_only is True
+
+
+def test_flatten_qty_equals_abs_observed_pos_not_submitted_entry_sz() -> None:
+    permit = issue_canary_flatten_submit_permit_v1(
+        positions_payload=_positions({"instId": TARGET, "pos": "-4"}),
+        owner_go=OWNER_GO,
+        origin_main_sha=ORIGIN_SHA,
+        submitted_entry_sz="1",
+    )
+    assert permit.quantity == "4"
+    assert permit.quantity != "1"
+    assert permit.submitted_entry_sz_used is False
+    verdict = evaluate_canary_flatten_orchestration_contract_v1(
+        positions_payload=_positions({"instId": TARGET, "pos": "5"}),
+        owner_go=OWNER_GO,
+        origin_main_sha=ORIGIN_SHA,
+        submitted_entry_sz="1",
+    )
+    assert verdict.submitted_entry_qty_used_as_authority is False
+    assert verdict.permit is not None
+    assert verdict.permit.quantity == "5"
+
+
+def test_zero_position_issues_no_permit_and_no_submit() -> None:
+    verdict = evaluate_canary_flatten_orchestration_contract_v1(
+        positions_payload=_positions({"instId": TARGET, "pos": "0"}),
+        owner_go=OWNER_GO,
+        origin_main_sha=ORIGIN_SHA,
+    )
+    assert verdict.permit_issued is False
+    assert verdict.permit is None
+    assert verdict.submit_reachable is False
+    assert verdict.observation_status == "ZERO_POSITION"
+    with pytest.raises(LiveCanaryFlattenOrchestrationError, match="ZERO_POSITION_NO_FLATTEN_ORDER"):
+        issue_canary_flatten_submit_permit_v1(
+            positions_payload=_positions({"instId": TARGET, "pos": "0"}),
+            owner_go=OWNER_GO,
+            origin_main_sha=ORIGIN_SHA,
+        )
+
+
+def test_missing_target_position_fail_closed() -> None:
+    verdict = evaluate_canary_flatten_orchestration_contract_v1(
+        positions_payload=_positions({"instId": "BTC-USDT-SWAP", "pos": "1"}),
+        owner_go=OWNER_GO,
+        origin_main_sha=ORIGIN_SHA,
+    )
+    assert verdict.permit_issued is False
+    assert verdict.observation_status == "TARGET_INSTRUMENT_NOT_OBSERVED"
+    with pytest.raises(LiveCanaryFlattenOrchestrationError, match="TARGET_INSTRUMENT_NOT_OBSERVED"):
+        issue_canary_flatten_submit_permit_v1(
+            positions_payload={"code": "0", "data": []},
+            owner_go=OWNER_GO,
+            origin_main_sha=ORIGIN_SHA,
+        )
+
+
+def test_malformed_pos_fail_closed() -> None:
+    verdict = evaluate_canary_flatten_orchestration_contract_v1(
+        positions_payload=_positions({"instId": TARGET, "pos": "not-a-number"}),
+        owner_go=OWNER_GO,
+        origin_main_sha=ORIGIN_SHA,
+    )
+    assert verdict.permit_issued is False
+    assert verdict.observation_status == "MALFORMED_POSITION"
+    with pytest.raises(LiveCanaryFlattenOrchestrationError, match="POSITION_SIZE_MISSING"):
+        issue_canary_flatten_submit_permit_v1(
+            positions_payload=_positions({"instId": TARGET}),
+            owner_go=OWNER_GO,
+            origin_main_sha=ORIGIN_SHA,
+        )
+
+
+def test_duplicate_target_rows_fail_closed() -> None:
+    payload = _positions(
+        {"instId": TARGET, "pos": "1"},
+        {"instId": TARGET, "pos": "1"},
+    )
+    verdict = evaluate_canary_flatten_orchestration_contract_v1(
+        positions_payload=payload,
+        owner_go=OWNER_GO,
+        origin_main_sha=ORIGIN_SHA,
+    )
+    assert verdict.permit_issued is False
+    assert verdict.observation_status == "AMBIGUOUS_TARGET_POSITION_ROWS"
+    with pytest.raises(LiveCanaryFlattenOrchestrationError, match="AMBIGUOUS_TARGET_POSITION_ROWS"):
+        issue_canary_flatten_submit_permit_v1(
+            positions_payload=payload,
+            owner_go=OWNER_GO,
+            origin_main_sha=ORIGIN_SHA,
+        )
+
+
+def test_flatten_clordid_distinct_from_entry() -> None:
+    entry = serialize_canary_clordid_v1(owner_go=OWNER_GO, origin_main_sha=ORIGIN_SHA)
+    flatten = serialize_canary_flatten_clordid_v1(owner_go=OWNER_GO, origin_main_sha=ORIGIN_SHA)
+    permit = issue_canary_flatten_submit_permit_v1(
+        positions_payload=_positions({"instId": TARGET, "pos": "1"}),
+        owner_go=OWNER_GO,
+        origin_main_sha=ORIGIN_SHA,
+        entry_clordid=entry,
+    )
+    assert permit.clordid == flatten
+    assert permit.clordid != entry
+    assert (
+        permit.kind
+        != CanaryEntrySubmitPermitV1(owner_go=OWNER_GO, clordid=entry, permit_id="x").kind
+    )
+
+
+def test_flatten_requires_reduce_only_true_and_entry_omits_reduce_only() -> None:
+    permit = issue_canary_flatten_submit_permit_v1(
+        positions_payload=_positions({"instId": TARGET, "pos": "1"}),
+        owner_go=OWNER_GO,
+        origin_main_sha=ORIGIN_SHA,
+    )
+    assert permit.reduce_only is True
+    entry_body = build_venue_native_order_body_v1(
+        client_order_id="c1",
+        instrument=TARGET,
+        order_type="LIMIT",
+        side="buy",
+        quantity="1",
+        px="10000",
+    )
+    assert "reduceOnly" not in entry_body
+    assert REDUCE_ONLY_WIRE_TYPE_STATUS == "UNPROVEN"
+    with pytest.raises(
+        LiveCanaryFlattenOrchestrationError, match="FLATTEN_PERMIT_REDUCE_ONLY_REQUIRED"
+    ):
+        CanaryFlattenSubmitPermitV1(
+            owner_go=OWNER_GO,
+            clordid=permit.clordid,
+            permit_id=permit.permit_id,
+            instrument_id=TARGET,
+            side="SELL",
+            quantity="1",
+            reduce_only=False,
+            price_gate_status=FLATTEN_LIMIT_PRICE_GATE_STATUS,
+            submitted_entry_sz_used=False,
+        )
+
+
+def test_missing_price_policy_blocks_submit_and_serialization() -> None:
+    verdict = evaluate_canary_flatten_orchestration_contract_v1(
+        positions_payload=_positions({"instId": TARGET, "pos": "1"}),
+        owner_go=OWNER_GO,
+        origin_main_sha=ORIGIN_SHA,
+    )
+    assert verdict.permit_issued is True
+    assert verdict.submit_reachable is False
+    assert verdict.serialization_reachable is False
+    assert verdict.permit is not None
+    assert verdict.permit.submit_reachable is False
+    assert verdict.permit.price_gate_status == FLATTEN_LIMIT_PRICE_GATE_STATUS
+    assert FLATTEN_SUBMIT_UNREACHABLE_REASON in verdict.blocking_reasons
+    with pytest.raises(
+        LiveCanaryFlattenOrchestrationError, match="FLATTEN_LIMIT_PRICE_POLICY_UNBOUND"
+    ):
+        refuse_canary_flatten_submit_transport_v1(verdict.permit, px="63028.1")
+    with pytest.raises(
+        LiveCanaryFlattenOrchestrationError, match="FLATTEN_SUBMIT_REACHABLE_FORBIDDEN"
+    ):
+        CanaryFlattenSubmitPermitV1(
+            owner_go=OWNER_GO,
+            clordid=verdict.permit.clordid,
+            permit_id=verdict.permit.permit_id,
+            instrument_id=TARGET,
+            side="SELL",
+            quantity="1",
+            reduce_only=True,
+            price_gate_status=FLATTEN_LIMIT_PRICE_GATE_STATUS,
+            submitted_entry_sz_used=False,
+            submit_reachable=True,
+        )
+
+
+def test_no_market_fallback_and_limit_only_preserved() -> None:
+    verdict = evaluate_canary_flatten_orchestration_contract_v1(
+        positions_payload=_positions({"instId": TARGET, "pos": "1"}),
+        owner_go=OWNER_GO,
+        origin_main_sha=ORIGIN_SHA,
+    )
+    assert verdict.market_fallback_used is False
+    assert verdict.flatten_plan is not None
+    assert verdict.flatten_plan.order_type == "LIMIT"
+    assert DEFAULT_ORDER_TYPE == "LIMIT"
+    lifecycle = build_lifecycle_and_closeout_contract_v1()
+    assert lifecycle["order_type_semantics"] == "LIMIT_ONLY_NO_MARKET"
+    assert lifecycle["ACTIVATED"] is False
+
+
+def test_no_second_entry_allowance_and_allowlist_unchanged() -> None:
+    assert ORDER_COUNT_LIMIT == 1
+    assert POST_ENDPOINTS_GATED == (
+        "/api/v5/trade/order",
+        "/api/v5/trade/cancel-order",
+    )
+    assert ENDPOINT_SUBMIT == "/api/v5/trade/order"
+    assert ENDPOINT_CANCEL == "/api/v5/trade/cancel-order"
+    assert "/api/v5/trade/close-position" not in POST_ENDPOINTS_GATED
+    lifecycle = build_lifecycle_and_closeout_contract_v1()
+    assert lifecycle["order_count_limit"] == 1
+    entry = CanaryEntrySubmitPermitV1(owner_go=OWNER_GO, clordid="entry", permit_id="e1")
+    assert entry.kind == "ENTRY_SUBMIT"
+    flatten = issue_canary_flatten_submit_permit_v1(
+        positions_payload=_positions({"instId": TARGET, "pos": "1"}),
+        owner_go=OWNER_GO,
+        origin_main_sha=ORIGIN_SHA,
+    )
+    assert flatten.kind == FLATTEN_PERMIT_KIND
+    assert flatten.kind != entry.kind
+
+
+def test_lf03_offline_path_invokes_no_transport() -> None:
+    from src.ops.section_11_13_5_live_canary_minimum_exposure_v1 import (
+        flatten_orchestration_contract_v1,
+        http_client_v1,
+    )
+
+    verdict = evaluate_canary_flatten_orchestration_contract_v1(
+        positions_payload=_positions({"instId": TARGET, "pos": "1"}),
+        owner_go=OWNER_GO,
+        origin_main_sha=ORIGIN_SHA,
+    )
+    assert verdict.transport_invoked is False
+    orch_src = inspect.getsource(flatten_orchestration_contract_v1)
+    assert "transport.send" not in orch_src
+    assert "post_flatten_order" not in orch_src
+    assert "post_entry_order" not in orch_src
+    assert "urllib" not in orch_src
+    transport_src = inspect.getsource(run_canary_submit_transport_v1)
+    assert "issue_canary_flatten_submit_permit_v1" not in transport_src
+    assert "evaluate_canary_flatten_orchestration_contract_v1" not in transport_src
+    http_src = inspect.getsource(http_client_v1)
+    assert "post_flatten_order" not in http_src
+    assert "CanaryFlattenSubmitPermitV1" not in http_src


### PR DESCRIPTION
## Summary
- LF-01/LF-02: opt-in `reduceOnly` on the shared venue body builder, structured observed-position flatten candidate, and an Entry-separated flatten plan that cannot reuse submitted Entry `sz`.
- LF-03: typed offline `CanaryFlattenSubmitPermitV1` plus orchestration contract. Permit issues only from unique nonzero observed position; submit and LIMIT serialization remain unreachable because flatten price policy is unbound.
- Entry/Testnet payloads still omit `reduceOnly` by default. No productive flatten payload, no `post_flatten_order`, no execute wiring, no allowlist change, no canonical pointer advancement.
- `LIVE_FLATTEN_PROVABILITY` remains `UNPROVEN`. `REDUCE_ONLY_WIRE_TYPE_STATUS=UNPROVEN`. Flatten permit is not runtime-reachable.

## Test plan
- [x] LF-01/LF-02 offline tests — 18 passed
- [x] LF-03 offline permit/orchestration tests — 13 passed
- [x] Combined flatten offline — 31 passed
- [x] Affected Canary/body/Z2AA/Z2AB modules — 109 passed
- [x] Ruff format/check on touched files — passed
- [x] Path-equivalent PR_BOUNDED_FULL selector targets — 729 passed in 37s
- [ ] GitHub required checks on this PR (confirmation only; do not merge)

Do not merge. No runtime follow-up. No flatten LIMIT price policy under this GO.