### PR TITLE
fix(ops): align flatten naked-px labels with quote-lock permit path

### DIFF
--- a/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/flatten_orchestration_contract_v1.py
+++ b/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/flatten_orchestration_contract_v1.py
@@ -22,6 +22,7 @@ from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.lifecycle_v1 import
 )
 from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.order_plan_v1 import (
     FLATTEN_LIMIT_PRICE_GATE_STATUS,
+    FLATTEN_NAKED_PX_FAIL_CLOSED_REASON,
     CanaryFlattenOrderPlanV1,
     LiveCanaryOrderPlanError,
     build_minimum_valid_canary_flatten_order_plan_v1,
@@ -35,9 +36,7 @@ from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.pre_submit_state_v1
 )
 
 FLATTEN_PERMIT_KIND = "FLATTEN_SUBMIT"
-FLATTEN_SUBMIT_UNREACHABLE_REASON = (
-    "FLATTEN_LIMIT_PRICE_POLICY_UNBOUND:" + FLATTEN_LIMIT_PRICE_GATE_STATUS
-)
+FLATTEN_SUBMIT_UNREACHABLE_REASON = FLATTEN_NAKED_PX_FAIL_CLOSED_REASON
 LIFECYCLE_FLATTEN_RUNTIME_REACHABLE = False
 LIVE_FLATTEN_PROVABILITY_STATUS = "UNPROVEN"
 NETWORK_EFFECT_NONE = "none"
@@ -349,7 +348,7 @@ def evaluate_canary_flatten_orchestration_contract_v1(
         market_fallback_used=False,
         submitted_entry_qty_used_as_authority=False,
         blocking_reasons=(FLATTEN_SUBMIT_UNREACHABLE_REASON,),
-        contract_state="FLATTEN_PERMIT_ISSUED_SUBMIT_BLOCKED_PRICE_POLICY",
+        contract_state="FLATTEN_PERMIT_ISSUED_NAKED_PX_FAIL_CLOSED",
     )
 
 

--- a/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/order_plan_v1.py
+++ b/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/order_plan_v1.py
@@ -264,7 +264,14 @@ def build_minimum_valid_canary_order_plan_v1(
     )
 
 
-FLATTEN_LIMIT_PRICE_GATE_STATUS = "FAIL_CLOSED_UNTIL_SEPARATE_OWNER_GO"
+# Quote-lock LIMIT policy is implemented (Z2AL). This status is only the
+# naked qty-plan / no-FlattenPricePermitV1 fail-closed gate. It is not a
+# claim that price policy awaits a separate Owner GO. Live wire remains
+# disabled. Freshness canonical default remains unbound.
+FLATTEN_LIMIT_PRICE_GATE_STATUS = "NAKED_PX_FAIL_CLOSED_PRICE_PERMIT_REQUIRED"
+FLATTEN_NAKED_PX_FAIL_CLOSED_REASON = (
+    "FLATTEN_NAKED_PX_FAIL_CLOSED:" + FLATTEN_LIMIT_PRICE_GATE_STATUS
+)
 
 
 def _format_flatten_qty(value: Decimal) -> str:
@@ -362,9 +369,7 @@ def serialize_canary_flatten_venue_native_payload_v1(
     """
     if price_permit is None:
         del px
-        raise LiveCanaryOrderPlanError(
-            "FLATTEN_LIMIT_PRICE_POLICY_UNBOUND:" + FLATTEN_LIMIT_PRICE_GATE_STATUS
-        )
+        raise LiveCanaryOrderPlanError(FLATTEN_NAKED_PX_FAIL_CLOSED_REASON)
     permit_side = str(getattr(price_permit, "flatten_side", "") or "").strip().upper()
     permit_px = str(getattr(price_permit, "limit_price", "") or "").strip()
     if permit_side != str(plan.side).upper():

--- a/tests/ops/test_section_11_13_5_dedicated_flatten_submit_transport_v1.py
+++ b/tests/ops/test_section_11_13_5_dedicated_flatten_submit_transport_v1.py
@@ -392,5 +392,5 @@ def test_global_invariants_unchanged() -> None:
 
 def test_serialize_without_permit_still_unbound() -> None:
     _permit, plan, _price, _payload = _flatten_bundle(pos="1")
-    with pytest.raises(Exception, match="FLATTEN_LIMIT_PRICE_POLICY_UNBOUND"):
+    with pytest.raises(Exception, match="FLATTEN_NAKED_PX_FAIL_CLOSED"):
         serialize_canary_flatten_venue_native_payload_v1(plan, px="64805.6")

--- a/tests/ops/test_section_11_13_5_live_flatten_offline_contract_core_v1.py
+++ b/tests/ops/test_section_11_13_5_live_flatten_offline_contract_core_v1.py
@@ -303,7 +303,7 @@ def test_flatten_plan_price_gate_fails_closed_and_is_not_wire_ready() -> None:
     assert plan.venue_native_payload is None
     assert plan.limit_price is None
     assert plan.price_gate_status == FLATTEN_LIMIT_PRICE_GATE_STATUS
-    with pytest.raises(LiveCanaryOrderPlanError, match="FLATTEN_LIMIT_PRICE_POLICY_UNBOUND"):
+    with pytest.raises(LiveCanaryOrderPlanError, match="FLATTEN_NAKED_PX_FAIL_CLOSED"):
         serialize_canary_flatten_venue_native_payload_v1(plan, px="63028.1")
 
 

--- a/tests/ops/test_section_11_13_5_live_flatten_offline_lifecycle_failure_matrix_v1.py
+++ b/tests/ops/test_section_11_13_5_live_flatten_offline_lifecycle_failure_matrix_v1.py
@@ -523,4 +523,5 @@ def test_lf04_offline_path_invokes_no_transport_and_is_not_wired() -> None:
     assert "post_flatten_order" in http_src
     assert "CanaryFlattenHttpPermitV1" in http_src
     assert "CanaryFlattenSubmitPermitV1" not in http_src
-    assert FLATTEN_LIMIT_PRICE_GATE_STATUS == "FAIL_CLOSED_UNTIL_SEPARATE_OWNER_GO"
+    assert FLATTEN_LIMIT_PRICE_GATE_STATUS == "NAKED_PX_FAIL_CLOSED_PRICE_PERMIT_REQUIRED"
+    assert FLATTEN_LIMIT_PRICE_GATE_STATUS != "FAIL_CLOSED_UNTIL_SEPARATE_OWNER_GO"

--- a/tests/ops/test_section_11_13_5_live_flatten_offline_limit_price_contract_v1.py
+++ b/tests/ops/test_section_11_13_5_live_flatten_offline_limit_price_contract_v1.py
@@ -256,7 +256,7 @@ def test_naked_px_without_permit_still_unbound() -> None:
         origin_main_sha=ORIGIN_SHA,
     )
     assert verdict.flatten_plan is not None
-    with pytest.raises(LiveCanaryOrderPlanError, match="FLATTEN_LIMIT_PRICE_POLICY_UNBOUND"):
+    with pytest.raises(LiveCanaryOrderPlanError, match="FLATTEN_NAKED_PX_FAIL_CLOSED"):
         serialize_canary_flatten_venue_native_payload_v1(verdict.flatten_plan, px="64805.6")
 
 
@@ -321,4 +321,6 @@ def test_lf05_offline_path_is_not_wired_into_entry_transport_or_runner() -> None
     ):
         assert banned not in transport_src
         assert banned not in runner_src
-    assert FLATTEN_LIMIT_PRICE_GATE_STATUS == "FAIL_CLOSED_UNTIL_SEPARATE_OWNER_GO"
+    assert FLATTEN_LIMIT_PRICE_GATE_STATUS == "NAKED_PX_FAIL_CLOSED_PRICE_PERMIT_REQUIRED"
+    assert FLATTEN_LIMIT_PRICE_GATE_STATUS != "FAIL_CLOSED_UNTIL_SEPARATE_OWNER_GO"
+    assert FLATTEN_LIMIT_PRICE_GATE_BOUND == "QUOTE_LOCKED_LIMIT_ISSUED"

--- a/tests/ops/test_section_11_13_5_live_flatten_offline_permit_orchestration_v1.py
+++ b/tests/ops/test_section_11_13_5_live_flatten_offline_permit_orchestration_v1.py
@@ -235,9 +235,7 @@ def test_missing_price_policy_blocks_submit_and_serialization() -> None:
     assert verdict.permit.submit_reachable is False
     assert verdict.permit.price_gate_status == FLATTEN_LIMIT_PRICE_GATE_STATUS
     assert FLATTEN_SUBMIT_UNREACHABLE_REASON in verdict.blocking_reasons
-    with pytest.raises(
-        LiveCanaryFlattenOrchestrationError, match="FLATTEN_LIMIT_PRICE_POLICY_UNBOUND"
-    ):
+    with pytest.raises(LiveCanaryFlattenOrchestrationError, match="FLATTEN_NAKED_PX_FAIL_CLOSED"):
         refuse_canary_flatten_submit_transport_v1(verdict.permit, px="63028.1")
     with pytest.raises(
         LiveCanaryFlattenOrchestrationError, match="FLATTEN_SUBMIT_REACHABLE_FORBIDDEN"

--- a/tests/ops/test_section_11_13_5_z2ai_lf10_read_only_adjudication_persist_v1.py
+++ b/tests/ops/test_section_11_13_5_z2ai_lf10_read_only_adjudication_persist_v1.py
@@ -322,6 +322,7 @@ def test_z2ai_map_of_truth_navigation_pointer_matches_runbook() -> None:
     assert "LF10_COMPLETE_NO_NEW_PROVEN_CLOSURE" not in current_pointer
     assert "Z2AH_API_EXECUTION_DENOMINATION_PROVEN" not in current_pointer
     assert "Z2AJ_PUBLIC_CONVERSION_CANDIDATE" not in current_pointer
-    assert "Z2AL_STATIC_FLATTEN_PREREQUISITES" in current_pointer
+    assert "Z2AL_STATIC_FLATTEN_PREREQUISITES" not in current_pointer
+    assert "Z2AM_FRESHNESS_BINDING_OWNER_RATIFICATION_REQUIRED" in current_pointer
     assert "NO_ORDER_COUNT_LIMIT_RAISE_TO_2" in current_pointer
     assert "NO_PRODUCTIVE_FLATTEN" in current_pointer

--- a/tests/ops/test_section_11_13_5_z2aj_usd_usdc_public_get_adjudication_persist_v1.py
+++ b/tests/ops/test_section_11_13_5_z2aj_usd_usdc_public_get_adjudication_persist_v1.py
@@ -294,6 +294,7 @@ def test_z2aj_map_of_truth_navigation_pointer_matches_runbook() -> None:
     assert "LF10_COMPLETE_NO_NEW_PROVEN_CLOSURE" not in current_pointer
     assert "Z2AH_API_EXECUTION_DENOMINATION_PROVEN" not in current_pointer
     assert "Z2AJ_PUBLIC_CONVERSION_CANDIDATE" not in current_pointer
-    assert "Z2AL_STATIC_FLATTEN_PREREQUISITES" in current_pointer
+    assert "Z2AL_STATIC_FLATTEN_PREREQUISITES" not in current_pointer
+    assert "Z2AM_FRESHNESS_BINDING_OWNER_RATIFICATION_REQUIRED" in current_pointer
     assert "NO_ORDER_COUNT_LIMIT_RAISE_TO_2" in current_pointer
     assert "NO_PRODUCTIVE_FLATTEN" in current_pointer

--- a/tests/ops/test_section_11_13_5_z2ak_lf11_lf12_adjudication_persist_v1.py
+++ b/tests/ops/test_section_11_13_5_z2ak_lf11_lf12_adjudication_persist_v1.py
@@ -233,7 +233,8 @@ def test_z2ak_map_of_truth_navigation_pointer_matches_runbook() -> None:
     current_pointer = snapshot_pointer_lines[-1].split("=", 1)[1]
     assert "Z2AJ_PUBLIC_CONVERSION_CANDIDATE" not in current_pointer
     assert "NO_LF11" not in current_pointer
-    assert "Z2AL_STATIC_FLATTEN_PREREQUISITES" in current_pointer
+    assert "Z2AL_STATIC_FLATTEN_PREREQUISITES" not in current_pointer
+    assert "Z2AM_FRESHNESS_BINDING_OWNER_RATIFICATION_REQUIRED" in current_pointer
     assert "NO_LIVE_WIRE" in current_pointer
     assert "NO_ORDER_COUNT_LIMIT_RAISE_TO_2" in current_pointer
     assert "NO_PRODUCTIVE_FLATTEN" in current_pointer

--- a/tests/ops/test_section_11_13_5_z2al_static_flatten_prerequisites_persist_v1.py
+++ b/tests/ops/test_section_11_13_5_z2al_static_flatten_prerequisites_persist_v1.py
@@ -112,6 +112,7 @@ def test_z2al_map_of_truth_navigation_pointer_matches_runbook() -> None:
     assert "THIS_DOCUMENT_DEFINES_NO_SEMANTICS=true" in mot
     assert "§11.13.5.Z2AL |" in mot
     assert "historical next pointer superseded by §11.13.5.Z2AL" in mot
+    assert "historical next pointer superseded by §11.13.5.Z2AM" in mot
     assert "FLATTEN_PRICE_POLICY_IMPLEMENTED=true" in mot
     assert "DEDICATED_FLATTEN_TRANSPORT_IMPLEMENTED=true" in mot
     assert "STATIC_FLATTEN_PREREQUISITES_STATUS=PASS_OFFLINE" in mot
@@ -121,4 +122,10 @@ def test_z2al_map_of_truth_navigation_pointer_matches_runbook() -> None:
     snapshot_pointer_lines = [
         ln for ln in mot.splitlines() if ln.startswith("NEXT_CANONICAL_STEP_POINTER=")
     ]
-    assert snapshot_pointer_lines[-1] == f"NEXT_CANONICAL_STEP_POINTER={NEXT_POINTER}"
+    assert snapshot_pointer_lines[-1] != f"NEXT_CANONICAL_STEP_POINTER={NEXT_POINTER}"
+    current_pointer = snapshot_pointer_lines[-1].split("=", 1)[1]
+    assert "Z2AL_STATIC_FLATTEN_PREREQUISITES" not in current_pointer
+    assert "Z2AM_FRESHNESS_BINDING_OWNER_RATIFICATION_REQUIRED" in current_pointer
+    assert "NO_CANONICAL_FRESHNESS_DEFAULT" in current_pointer
+    assert "NO_LIVE_WIRE" in current_pointer
+    assert "NO_ORDER_COUNT_LIMIT_RAISE_TO_2" in current_pointer


### PR DESCRIPTION
## Summary
- Align leftover flatten contract labels so naked/unbound px stays fail-closed without claiming the quote-locked LIMIT policy still awaits a separate Owner GO (Z2AL already implemented that path).
- Repair Z2AI–Z2AL Mot last-pointer persist tests to follow the current canonical Z2AM pointer.
- Reuse existing quote-lock, tick rounding, reduceOnly, full-size flatten, and dedicated fake transport. No live wire, no freshness default, no ORDER_COUNT_LIMIT change, no GET/POST.

## Test plan
- [x] Offline flatten contract tests (limit-price, core, permit/orchestration, lifecycle matrix, dedicated transport)
- [x] Z2AI–Z2AL persist Mot-pointer tests
- [x] Selector `PR_BOUNDED_FULL` local targets
- [ ] GitHub required checks on this PR (no merge without separate `OWNER_MERGE_GO`)


Made with [Cursor](https://cursor.com)