### PR TITLE
fix(ops): retain OKX canary submit data[] and venue-native request evidence

### DIFF
--- a/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/http_client_v1.py
+++ b/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/http_client_v1.py
@@ -80,6 +80,27 @@ _FORBIDDEN_HEADER_NAME_MARKERS = (
 )
 _OKX_MSG_MAX_LEN = 200
 _OKX_CODE_MAX_LEN = 64
+_OKX_SMSG_MAX_LEN = 512
+_OKX_ID_FIELD_MAX_LEN = 128
+_VENUE_NATIVE_SCALAR_MAX_LEN = 128
+
+CANARY_VENUE_NATIVE_REQUEST_FIELDS_V1 = (
+    "instId",
+    "tdMode",
+    "side",
+    "ordType",
+    "sz",
+    "px",
+    "posSide",
+    "reduceOnly",
+    "ccy",
+    "tgtCcy",
+    "banAmend",
+    "stpMode",
+    "tag",
+    "clOrdId",
+)
+OKX_ORDER_DATA_ENTRY_FIELDS_V1 = ("sCode", "sMsg", "ordId", "clOrdId", "tag")
 _CONTENT_TYPE_MAX_LEN = 128
 _LOCATION_MAX_LEN = 512
 
@@ -142,6 +163,106 @@ def signed_wire_body_evidence_v1(
     }
 
 
+def _copy_allowlisted_scalar_fields_v1(
+    source: Mapping[str, Any],
+    allowlist: tuple[str, ...],
+    *,
+    max_len: int,
+) -> dict[str, Any]:
+    """Copy present allowlisted scalars only. Absent keys stay omitted."""
+    out: dict[str, Any] = {}
+    for key in allowlist:
+        if key not in source:
+            continue
+        raw = source[key]
+        if isinstance(raw, (dict, list)):
+            continue
+        if isinstance(raw, (bool, int, float)) or raw is None:
+            out[key] = raw
+            continue
+        out[key] = str(raw)[:max_len]
+    return out
+
+
+def _extract_okx_order_data_entry_v1(item: Any) -> dict[str, Any]:
+    if not isinstance(item, Mapping):
+        return {"_entry_not_object": True}
+    copied = _copy_allowlisted_scalar_fields_v1(
+        item,
+        OKX_ORDER_DATA_ENTRY_FIELDS_V1,
+        max_len=_OKX_SMSG_MAX_LEN,
+    )
+    for key in ("sCode", "ordId", "clOrdId", "tag"):
+        if key in copied and copied[key] is not None and not isinstance(copied[key], bool):
+            copied[key] = str(copied[key])[:_OKX_ID_FIELD_MAX_LEN]
+    if "sMsg" in copied and copied["sMsg"] is not None and not isinstance(copied["sMsg"], bool):
+        copied["sMsg"] = str(copied["sMsg"])[:_OKX_SMSG_MAX_LEN]
+    return copied
+
+
+def extract_canary_venue_native_request_evidence_v1(*, body_text: str) -> dict[str, Any]:
+    """Secret-safe venue-native POST body fields after final serialization."""
+    parse_error: str | None = None
+    payload: Any = None
+    try:
+        payload = json.loads(body_text)
+    except (TypeError, json.JSONDecodeError, UnicodeDecodeError):
+        parse_error = "REQUEST_BODY_NOT_JSON"
+        payload = None
+    if payload is not None and not isinstance(payload, dict):
+        parse_error = "REQUEST_BODY_NOT_JSON_OBJECT"
+        payload = None
+    present_keys: list[str] = []
+    absent_keys: list[str] = []
+    fields: dict[str, Any] = {}
+    if isinstance(payload, dict):
+        fields = _copy_allowlisted_scalar_fields_v1(
+            payload,
+            CANARY_VENUE_NATIVE_REQUEST_FIELDS_V1,
+            max_len=_VENUE_NATIVE_SCALAR_MAX_LEN,
+        )
+        for key in CANARY_VENUE_NATIVE_REQUEST_FIELDS_V1:
+            if key in payload:
+                present_keys.append(key)
+            else:
+                absent_keys.append(key)
+    else:
+        absent_keys = list(CANARY_VENUE_NATIVE_REQUEST_FIELDS_V1)
+    return {
+        "fields": fields,
+        "present_keys": present_keys,
+        "absent_keys": absent_keys,
+        "parse_error": parse_error,
+        "SECRET_VALUES_INCLUDED": False,
+    }
+
+
+def build_canary_submit_adjudication_evidence_v1(
+    *,
+    http_evidence: Mapping[str, Any],
+    venue_native_request: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Compact durable adjudication block. Survives result mapping without stdout."""
+    request_fields = dict(venue_native_request.get("fields") or {})
+    if not request_fields and "fields" not in venue_native_request:
+        request_fields = {
+            key: venue_native_request[key]
+            for key in CANARY_VENUE_NATIVE_REQUEST_FIELDS_V1
+            if key in venue_native_request
+        }
+    return {
+        "HTTP_STATUS": http_evidence.get("http_status"),
+        "TOP_LEVEL_OKX_CODE": http_evidence.get("okx_code"),
+        "TOP_LEVEL_OKX_MSG": http_evidence.get("okx_msg"),
+        "OKX_DATA_COUNT": http_evidence.get("okx_data_count"),
+        "okx_data": list(http_evidence.get("okx_data") or []),
+        "venue_native_request": request_fields,
+        "VENUE_NATIVE_PRESENT_KEYS": list(venue_native_request.get("present_keys") or []),
+        "VENUE_NATIVE_ABSENT_KEYS": list(venue_native_request.get("absent_keys") or []),
+        "SECRET_VALUES_INCLUDED": False,
+    }
+
+
 def extract_canary_http_response_evidence_v1(
     *,
     status_code: int,
@@ -163,6 +284,8 @@ def extract_canary_http_response_evidence_v1(
     okx_code: str | None = None
     okx_msg: str | None = None
     parse_error: str | None = None
+    okx_data: list[dict[str, Any]] = []
+    okx_data_count: int | None = None
     try:
         payload = json.loads(raw.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError):
@@ -177,6 +300,15 @@ def extract_canary_http_response_evidence_v1(
             okx_code = str(payload.get("code"))[:_OKX_CODE_MAX_LEN]
         if payload.get("msg") is not None:
             okx_msg = str(payload.get("msg"))[:_OKX_MSG_MAX_LEN]
+        if "data" not in payload:
+            okx_data_count = None
+        elif not isinstance(payload.get("data"), list):
+            parse_error = parse_error or "OKX_DATA_NOT_ARRAY"
+            okx_data_count = None
+        else:
+            data_rows = payload.get("data")
+            okx_data_count = len(data_rows)
+            okx_data = [_extract_okx_order_data_entry_v1(item) for item in data_rows]
     location = sanitize_redirect_location_v1(
         redirect_location or headers_safe.get("Location") or headers_safe.get("location")
     )
@@ -184,6 +316,8 @@ def extract_canary_http_response_evidence_v1(
         "http_status": int(status_code),
         "okx_code": okx_code,
         "okx_msg": okx_msg,
+        "okx_data_count": okx_data_count,
+        "okx_data": okx_data,
         "content_type": content_type[:_CONTENT_TYPE_MAX_LEN] if content_type else None,
         "response_headers_safe": headers_safe,
         "json_parse_ok": json_parse_ok,

--- a/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/submit_transport_v1.py
+++ b/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/submit_transport_v1.py
@@ -41,7 +41,9 @@ from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.http_client_v1 impo
     LiveCanaryHttpResponseV1,
     LiveCanaryTransportV1,
     UrllibLiveCanaryTransportV1,
+    build_canary_submit_adjudication_evidence_v1,
     extract_canary_http_response_evidence_v1,
+    extract_canary_venue_native_request_evidence_v1,
     parse_json_object_v1,
     signed_wire_body_evidence_v1,
 )
@@ -140,6 +142,7 @@ def _entry_submit_returned_payload_v1(
     client: LiveCanaryHttpClientV1,
     signed_wire: Mapping[str, Any],
     http_evidence: Mapping[str, Any],
+    venue_native_request: Mapping[str, Any],
 ) -> dict[str, Any]:
     status = int(http_evidence.get("http_status") or response.status_code)
     redirectish = bool(http_evidence.get("redirect_status")) or (300 <= status < 400)
@@ -158,6 +161,10 @@ def _entry_submit_returned_payload_v1(
         canary_result = "ENTRY_SUBMIT_POST_REDIRECT_FAIL_CLOSED"
     else:
         canary_result = "ENTRY_SUBMIT_TRANSPORT_RETURNED"
+    adjudication = build_canary_submit_adjudication_evidence_v1(
+        http_evidence=http_evidence,
+        venue_native_request=venue_native_request,
+    )
     payload = {
         "ok": ok,
         "mode": "execute",
@@ -175,6 +182,8 @@ def _entry_submit_returned_payload_v1(
         "counters": client.counters.to_dict(),
         "http_status": status,
         "http_error_evidence": dict(http_evidence),
+        "venue_native_request_evidence": dict(venue_native_request),
+        "submit_adjudication_evidence": adjudication,
         "signed_wire_body_evidence": dict(signed_wire),
         "SIGNED_BODY_EQUALS_WIRE_BODY": bool(signed_wire.get("SIGNED_BODY_EQUALS_WIRE_BODY")),
         "OWNER_GO_CONSUMED": False,
@@ -345,6 +354,7 @@ def run_canary_submit_transport_v1(
         refuse_submit_unless_gates_pass_v1(submit_gate)
 
         body_text = serialize_signed_post_body_v1(plan.venue_native_payload)
+        venue_native_request = extract_canary_venue_native_request_evidence_v1(body_text=body_text)
         url = f"{client.rest_base.rstrip('/')}{ENDPOINT_SUBMIT}"
         headers = build_okx_live_canary_auth_headers_v1(
             handle=handle,
@@ -394,6 +404,17 @@ def run_canary_submit_transport_v1(
                     "BLIND_RETRY": False,
                     "plan": plan.to_dict(),
                     "counters": client.counters.to_dict(),
+                    "venue_native_request_evidence": dict(venue_native_request),
+                    "submit_adjudication_evidence": build_canary_submit_adjudication_evidence_v1(
+                        http_evidence={
+                            "http_status": None,
+                            "okx_code": None,
+                            "okx_msg": None,
+                            "okx_data_count": None,
+                            "okx_data": [],
+                        },
+                        venue_native_request=venue_native_request,
+                    ),
                     "OWNER_GO_CONSUMED": False,
                     "error": str(exc),
                 }
@@ -426,6 +447,7 @@ def run_canary_submit_transport_v1(
             client=client,
             signed_wire=signed_wire,
             http_evidence=http_evidence,
+            venue_native_request=venue_native_request,
         )
     finally:
         if created_handle and handle is not None:

--- a/tests/ops/test_section_11_13_5_canary_submit_transport_observability_v1.py
+++ b/tests/ops/test_section_11_13_5_canary_submit_transport_observability_v1.py
@@ -1,0 +1,299 @@
+"""Focused tests for §11.13.5 canary order-submit transport observability (offline only)."""
+
+from __future__ import annotations
+
+import json
+
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.constants_v1 import (
+    GENERAL_LIVE_SUBMIT_UNLOCKED,
+    LIVE_AUTHORIZED,
+    OWNER_GO_AUTHORING,
+    SUBMIT_UNLOCKED,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.http_client_v1 import (
+    CANARY_VENUE_NATIVE_REQUEST_FIELDS_V1,
+    extract_canary_http_response_evidence_v1,
+    extract_canary_venue_native_request_evidence_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.submit_transport_v1 import (
+    LiveCanarySubmitTransportError,
+    run_canary_submit_transport_v1,
+)
+from tests.ops.test_section_11_13_5_canary_submit_transport_v1 import (
+    FIXTURE_MATERIAL,
+    _fake_transport,
+    _transport_kwargs,
+)
+
+_SECRET_MARKERS = (
+    "must-not-leak",
+    "session=secret",
+    "Bearer leaked-token",
+    "A" * 36,
+    "B" * 32,
+    "C" * 14,
+    "ok-access-sign-value",
+)
+
+
+def _dumped(payload: object) -> str:
+    return json.dumps(payload, default=str)
+
+
+def test_http_200_top_level_code_1_retains_single_data_failure() -> None:
+    transport = _fake_transport()
+    transport.post_status_code = 200
+    transport.post_body = json.dumps(
+        {
+            "code": "1",
+            "msg": "All operations failed",
+            "data": [
+                {
+                    "sCode": "51008",
+                    "sMsg": "Order failed. Insufficient USDC balance in account.",
+                    "ordId": "",
+                    "clOrdId": "canary-cl-1",
+                    "tag": "pt",
+                }
+            ],
+        }
+    ).encode("utf-8")
+    result = run_canary_submit_transport_v1(**_transport_kwargs(transport=transport))
+    assert result["ok"] is False
+    assert result["CANARY_RESULT"] == "ENTRY_SUBMIT_TRANSPORT_RETURNED"
+    evidence = result["http_error_evidence"]
+    compact = result["submit_adjudication_evidence"]
+    assert evidence["http_status"] == 200
+    assert evidence["okx_code"] == "1"
+    assert evidence["okx_msg"] == "All operations failed"
+    assert evidence["okx_data_count"] == 1
+    assert compact["HTTP_STATUS"] == 200
+    assert compact["TOP_LEVEL_OKX_CODE"] == "1"
+    assert compact["TOP_LEVEL_OKX_MSG"] == "All operations failed"
+    assert compact["OKX_DATA_COUNT"] == 1
+    row = compact["okx_data"][0]
+    assert row["sCode"] == "51008"
+    assert row["sMsg"] == "Order failed. Insufficient USDC balance in account."
+    assert row["ordId"] == ""
+    assert row["clOrdId"] == "canary-cl-1"
+    assert row["tag"] == "pt"
+    dumped = _dumped(result)
+    assert "51008" in dumped
+    assert compact["okx_data"] == result["http_error_evidence"]["okx_data"]
+
+
+def test_multiple_data_entries_preserve_count_and_order() -> None:
+    transport = _fake_transport()
+    transport.post_body = json.dumps(
+        {
+            "code": "1",
+            "msg": "All operations failed",
+            "data": [
+                {"sCode": "51008", "sMsg": "first", "clOrdId": "a"},
+                {"sCode": "51000", "sMsg": "second", "ordId": "ord-2", "clOrdId": "b"},
+            ],
+        }
+    ).encode("utf-8")
+    result = run_canary_submit_transport_v1(**_transport_kwargs(transport=transport))
+    compact = result["submit_adjudication_evidence"]
+    assert compact["OKX_DATA_COUNT"] == 2
+    assert len(compact["okx_data"]) == 2
+    assert compact["okx_data"][0]["sCode"] == "51008"
+    assert compact["okx_data"][0]["sMsg"] == "first"
+    assert "ordId" not in compact["okx_data"][0]
+    assert compact["okx_data"][1]["sCode"] == "51000"
+    assert compact["okx_data"][1]["ordId"] == "ord-2"
+    assert compact["okx_data"][1]["clOrdId"] == "b"
+
+
+def test_successful_response_behavior_unchanged() -> None:
+    transport = _fake_transport()
+    result = run_canary_submit_transport_v1(**_transport_kwargs(transport=transport))
+    assert result["ok"] is True
+    assert result["CANARY_RESULT"] == "ENTRY_SUBMIT_TRANSPORT_RETURNED"
+    assert result["LIVE_AUTHORIZED"] is False
+    assert result["LIVE_CANARY_MINIMUM_EXPOSURE_EXECUTED"] is False
+    assert result["RETRY_SAFE_NOW"] is False
+    compact = result["submit_adjudication_evidence"]
+    assert compact["HTTP_STATUS"] == 200
+    assert compact["TOP_LEVEL_OKX_CODE"] == "0"
+    assert compact["OKX_DATA_COUNT"] == 1
+    assert compact["okx_data"][0]["sCode"] == "0"
+    assert compact["okx_data"][0]["ordId"] == "ord-1"
+    posts = [call for call in transport.calls if call.method == "POST"]
+    assert len(posts) == 1
+
+
+def test_venue_native_request_retains_present_optional_fields_and_marks_absent() -> None:
+    present = extract_canary_venue_native_request_evidence_v1(
+        body_text=json.dumps(
+            {
+                "instId": "BTC-USD_UM_XPERP-310404",
+                "tdMode": "cross",
+                "side": "buy",
+                "ordType": "limit",
+                "sz": "1",
+                "px": "75149.7",
+                "posSide": "net",
+                "reduceOnly": False,
+                "ccy": "USDC",
+                "tgtCcy": "",
+                "banAmend": True,
+                "stpMode": "cancel_maker",
+                "tag": "pt",
+                "clOrdId": "cl-1",
+                "secret": "must-not-copy",
+                "OK-ACCESS-SIGN": "ok-access-sign-value",
+            },
+            separators=(",", ":"),
+        )
+    )
+    assert present["parse_error"] is None
+    fields = present["fields"]
+    assert fields["instId"] == "BTC-USD_UM_XPERP-310404"
+    assert fields["tdMode"] == "cross"
+    assert fields["side"] == "buy"
+    assert fields["ordType"] == "limit"
+    assert fields["sz"] == "1"
+    assert fields["px"] == "75149.7"
+    assert fields["posSide"] == "net"
+    assert fields["reduceOnly"] is False
+    assert fields["ccy"] == "USDC"
+    assert fields["tgtCcy"] == ""
+    assert fields["banAmend"] is True
+    assert fields["stpMode"] == "cancel_maker"
+    assert fields["tag"] == "pt"
+    assert fields["clOrdId"] == "cl-1"
+    assert "secret" not in fields
+    assert "OK-ACCESS-SIGN" not in fields
+    assert set(present["present_keys"]) == set(CANARY_VENUE_NATIVE_REQUEST_FIELDS_V1)
+    assert present["absent_keys"] == []
+    assert "must-not-copy" not in _dumped(present)
+
+    absent_optional = extract_canary_venue_native_request_evidence_v1(
+        body_text=json.dumps(
+            {
+                "instId": "BTC-USD_UM_XPERP-310404",
+                "tdMode": "cross",
+                "side": "buy",
+                "ordType": "limit",
+                "sz": "1",
+                "px": "75149.7",
+                "clOrdId": "cl-2",
+            },
+            separators=(",", ":"),
+        )
+    )
+    fields_absent = absent_optional["fields"]
+    assert "reduceOnly" not in fields_absent
+    assert "posSide" not in fields_absent
+    assert "ccy" not in fields_absent
+    assert "tgtCcy" not in fields_absent
+    assert "banAmend" not in fields_absent
+    assert "stpMode" not in fields_absent
+    assert "tag" not in fields_absent
+    assert "reduceOnly" in absent_optional["absent_keys"]
+    assert "px" in absent_optional["present_keys"]
+    assert fields_absent["px"] == "75149.7"
+
+
+def test_submit_result_preserves_actual_posted_wire_body_fields() -> None:
+    transport = _fake_transport()
+    result = run_canary_submit_transport_v1(**_transport_kwargs(transport=transport))
+    posts = [call for call in transport.calls if call.method == "POST"]
+    posted = json.loads(posts[0].body_text)
+    evidence = result["venue_native_request_evidence"]
+    compact = result["submit_adjudication_evidence"]
+    assert evidence["fields"] == compact["venue_native_request"]
+    for key, value in evidence["fields"].items():
+        assert posted[key] == value
+    for key in CANARY_VENUE_NATIVE_REQUEST_FIELDS_V1:
+        if key in posted:
+            assert key in evidence["present_keys"]
+            assert key in evidence["fields"]
+        else:
+            assert key in evidence["absent_keys"]
+            assert key not in evidence["fields"]
+    assert "reduceOnly" not in posted
+    assert "reduceOnly" not in evidence["fields"]
+
+
+def test_credential_material_is_redacted_from_persisted_evidence() -> None:
+    transport = _fake_transport()
+    transport.post_status_code = 200
+    transport.post_body = json.dumps(
+        {
+            "code": "1",
+            "msg": "All operations failed",
+            "data": [{"sCode": "1", "sMsg": "denied", "clOrdId": "x"}],
+            "api_secret": "B" * 32,
+        }
+    ).encode("utf-8")
+    transport.post_headers = {
+        "Content-Type": "application/json",
+        "OK-ACCESS-KEY": "must-not-leak",
+        "OK-ACCESS-SIGN": "ok-access-sign-value",
+        "OK-ACCESS-PASSPHRASE": "C" * 14,
+        "Authorization": "Bearer leaked-token",
+        "Set-Cookie": "session=secret",
+    }
+    result = run_canary_submit_transport_v1(**_transport_kwargs(transport=transport))
+    dumped = _dumped(result)
+    for marker in _SECRET_MARKERS:
+        assert marker not in dumped
+    headers = result["http_error_evidence"]["response_headers_safe"]
+    header_blob = _dumped(headers).lower()
+    assert "ok-access" not in header_blob
+    assert "authorization" not in header_blob
+    assert "cookie" not in header_blob
+    assert result["http_error_evidence"]["SECRET_VALUES_INCLUDED"] is False
+    assert result["submit_adjudication_evidence"]["SECRET_VALUES_INCLUDED"] is False
+    assert result["venue_native_request_evidence"]["SECRET_VALUES_INCLUDED"] is False
+    assert "api_secret" not in result["http_error_evidence"]["okx_data"][0]
+    assert FIXTURE_MATERIAL not in dumped
+
+
+def test_fail_closed_gates_remain_intact() -> None:
+    assert LIVE_AUTHORIZED is False
+    assert SUBMIT_UNLOCKED is False
+    assert GENERAL_LIVE_SUBMIT_UNLOCKED is False
+    kwargs = _transport_kwargs(owner_go=OWNER_GO_AUTHORING)
+    transport = kwargs["transport"]
+    try:
+        run_canary_submit_transport_v1(**kwargs)
+        raise AssertionError("authoring GO must remain fail-closed")
+    except (LiveCanarySubmitTransportError, Exception) as exc:
+        assert "AUTHORING_GO_CANNOT_EXECUTE_CANARY" in str(exc) or "OWNER_GO_MISMATCH" in str(exc)
+    assert all(call.method != "POST" for call in transport.calls)
+
+    blocked = _fake_transport()
+    blocked.bodies_by_endpoint["/api/v5/account/positions"] = json.dumps(
+        {"code": "0", "data": [{"instId": "BTC-USD_UM_XPERP-310404", "pos": "1"}]}
+    ).encode("utf-8")
+    try:
+        run_canary_submit_transport_v1(**_transport_kwargs(transport=blocked))
+        raise AssertionError("open position must remain fail-closed")
+    except LiveCanarySubmitTransportError as exc:
+        assert "OPEN_POSITION" in str(exc)
+    assert all(call.method != "POST" for call in blocked.calls)
+
+
+def test_extractor_does_not_drop_non_object_data_entries() -> None:
+    evidence = extract_canary_http_response_evidence_v1(
+        status_code=200,
+        body_bytes=json.dumps(
+            {
+                "code": "1",
+                "msg": "All operations failed",
+                "data": [
+                    {"sCode": "51008", "sMsg": "kept"},
+                    "not-an-object",
+                    {"sCode": "51000", "sMsg": "also-kept"},
+                ],
+            }
+        ).encode("utf-8"),
+    )
+    assert evidence["okx_data_count"] == 3
+    assert evidence["okx_data"][0]["sCode"] == "51008"
+    assert evidence["okx_data"][1]["_entry_not_object"] is True
+    assert evidence["okx_data"][2]["sMsg"] == "also-kept"


### PR DESCRIPTION
## Summary
- Preserve the parsed OKX order-submit `data[]` rows (`sCode`, `sMsg`, `ordId`, `clOrdId`, `tag`) plus top-level HTTP/code/msg through the existing canary HTTP evidence and compact `submit_adjudication_evidence` block.
- Capture the venue-native outbound POST body **after** final serialization and immediately before transport, retaining present optional fields without inventing absent ones.
- Credential material (auth headers, signatures, secrets) remains excluded from persisted evidence. Trading semantics, gates, and Owner-GO contracts are unchanged. No productive submit.

## Test plan
- [x] Focused observability + existing canary submit transport tests (`tests/ops/test_section_11_13_5_canary_submit_transport_observability_v1.py`, `tests/ops/test_section_11_13_5_canary_submit_transport_v1.py`)
- [x] Ruff format/check
- [x] Selector `PR_BOUNDED_FULL` path-equivalent pytest targets
- [x] Docs token/reference gates (no markdown changed)
- [ ] Do not merge in this step
- [ ] Do not run another productive canary in this PR


Made with [Cursor](https://cursor.com)