### PR TITLE
chore(pre-commit): exclude bound forensic raw copies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,14 +24,20 @@ repos:
     hooks:
       # KILLER FEATURE: verhindert "new blank line at EOF" Noise zuverlässig.
       - id: end-of-file-fixer
+        exclude: |
+          (?x)^(forensic/post_step32_knowledge_integration_v0/evidence/raw_verbatim_identity_copies_authority_none/(desktop|transcripts)/.*)$
 
       # Trim trailing whitespace; behält Markdown-Linebreaks ("two spaces") bei.
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md, --markdown-linebreak-ext=markdown]
+        exclude: |
+          (?x)^(forensic/post_step32_knowledge_integration_v0/evidence/raw_verbatim_identity_copies_authority_none/(desktop|transcripts)/.*)$
 
       # Einheitliche Line Endings (LF) erzwingen.
       - id: mixed-line-ending
         args: [--fix=lf]
+        exclude: |
+          (?x)^(forensic/post_step32_knowledge_integration_v0/evidence/raw_verbatim_identity_copies_authority_none/(desktop|transcripts)/.*)$
 
       # Kleiner Safety-Net-Stack (low noise, high value)
       - id: check-merge-conflict


### PR DESCRIPTION
## Scope
Updates `.pre-commit-config.yaml` so the mutating fixers exclude the bound forensic raw-copy boundary.
## Change surface
- `.pre-commit-config.yaml` only
- single commit
- no CLASS_D admission
- no trading logic changes
- no runtime authorization changes
## Safety
This PR does not create canonical authority for the forensic working material and does not admit CLASS_D content.
TARGET_AUTHORITY remains `NONE`.
## Merge
Do not merge without a separate Owner merge authorization and green required checks.

Made with [Cursor](https://cursor.com)