### PR TITLE
fix(ops): fail-closed second-open-instrument cap before canary and SP-04 submit

### DIFF
--- a/src/ops/pre_submit_open_position_cap_v1.py
+++ b/src/ops/pre_submit_open_position_cap_v1.py
@@ -1,0 +1,161 @@
+"""Pure pre-submit admission: would this intent open a second instrument?
+
+Offline, side-effect-free. No network, no exchange client, no config load.
+Does not implement sizing, direction, reduceOnly, or hedge/posSide policy.
+Does not reuse LiveRiskLimits.check_orders batch-symbol counting or
+MAX_POSITIONS_EFFECTIVE selection policy.
+
+Proven OKX net/signed semantics: envelope code=="0", data list, pos/posSize.
+Uniqueness of a nonzero instId must be proven; otherwise fail closed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
+from typing import Any, Mapping
+
+REASON_ALLOW_NO_OPEN_POSITION = "ALLOW_NO_OPEN_POSITION"
+REASON_ALLOW_TARGET_INSTRUMENT_ALREADY_OPEN = "ALLOW_TARGET_INSTRUMENT_ALREADY_OPEN"
+REASON_DENY_OTHER_OPEN_INSTRUMENT_PRESENT = "DENY_OTHER_OPEN_INSTRUMENT_PRESENT"
+REASON_DENY_AMBIGUOUS_POSITION_ROWS = "DENY_AMBIGUOUS_POSITION_ROWS"
+REASON_DENY_INVALID_POSITION_PAYLOAD = "DENY_INVALID_POSITION_PAYLOAD"
+REASON_DENY_POSITION_STATE_UNAVAILABLE = "DENY_POSITION_STATE_UNAVAILABLE"
+
+_ALLOW_REASONS = frozenset(
+    {
+        REASON_ALLOW_NO_OPEN_POSITION,
+        REASON_ALLOW_TARGET_INSTRUMENT_ALREADY_OPEN,
+    }
+)
+
+
+class PreSubmitOpenPositionCapErrorV1(RuntimeError):
+    """Fail-closed second-open-instrument admission denial."""
+
+    def __init__(self, reason_code: str, message: str | None = None) -> None:
+        self.reason_code = str(reason_code)
+        super().__init__(message or self.reason_code)
+
+
+@dataclass(frozen=True)
+class PreSubmitOpenPositionCapDecisionV1:
+    admitted: bool
+    reason_code: str
+    open_instrument_ids: tuple[str, ...]
+
+
+def _deny(reason_code: str) -> PreSubmitOpenPositionCapDecisionV1:
+    return PreSubmitOpenPositionCapDecisionV1(
+        admitted=False,
+        reason_code=reason_code,
+        open_instrument_ids=(),
+    )
+
+
+def _parse_signed_pos(row: Mapping[str, Any]) -> Decimal | None:
+    raw = row.get("pos")
+    if raw is None:
+        raw = row.get("posSize")
+    if raw is None or str(raw).strip() == "":
+        raw = "0"
+    try:
+        return Decimal(str(raw).strip())
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+
+
+def evaluate_pre_submit_open_position_cap_v1(
+    *,
+    target_instrument_id: str,
+    positions_payload: Any,
+) -> PreSubmitOpenPositionCapDecisionV1:
+    """Decide whether a new intent could create a second open instrument.
+
+    A) no nonzero instrument → ALLOW_NO_OPEN_POSITION
+    B) only target already open → ALLOW_TARGET_INSTRUMENT_ALREADY_OPEN
+       (add/reduce/close/flip remain host rules; this cap invents none)
+    C) a different instrument already open → DENY_OTHER_OPEN_INSTRUMENT_PRESENT
+    D) ambiguous rows → DENY_AMBIGUOUS_POSITION_ROWS
+    E) missing/unproven payload → DENY_POSITION_STATE_UNAVAILABLE
+       or DENY_INVALID_POSITION_PAYLOAD
+    """
+    if positions_payload is None:
+        return _deny(REASON_DENY_POSITION_STATE_UNAVAILABLE)
+    if not isinstance(positions_payload, Mapping):
+        return _deny(REASON_DENY_INVALID_POSITION_PAYLOAD)
+
+    target = str(target_instrument_id or "").strip()
+    if not target:
+        return _deny(REASON_DENY_INVALID_POSITION_PAYLOAD)
+
+    if "code" not in positions_payload:
+        return _deny(REASON_DENY_INVALID_POSITION_PAYLOAD)
+    # Proven OKX envelope uses code == "0". Integer 0 is accepted via str().
+    if str(positions_payload.get("code")) != "0":
+        return _deny(REASON_DENY_INVALID_POSITION_PAYLOAD)
+
+    data = positions_payload.get("data")
+    if data is None:
+        data = []
+    if not isinstance(data, list):
+        return _deny(REASON_DENY_INVALID_POSITION_PAYLOAD)
+
+    sizes_by_inst: dict[str, list[Decimal]] = {}
+    for row in data:
+        if not isinstance(row, Mapping):
+            return _deny(REASON_DENY_INVALID_POSITION_PAYLOAD)
+        signed = _parse_signed_pos(row)
+        if signed is None:
+            return _deny(REASON_DENY_INVALID_POSITION_PAYLOAD)
+        inst = str(row.get("instId") or "").strip()
+        if not inst:
+            if signed != 0:
+                return _deny(REASON_DENY_INVALID_POSITION_PAYLOAD)
+            continue
+        sizes_by_inst.setdefault(inst, []).append(signed)
+
+    open_ids: list[str] = []
+    for inst, sizes in sizes_by_inst.items():
+        nonzero = [size for size in sizes if size != 0]
+        if len(nonzero) > 1:
+            return _deny(REASON_DENY_AMBIGUOUS_POSITION_ROWS)
+        if len(sizes) > 1 and nonzero:
+            return _deny(REASON_DENY_AMBIGUOUS_POSITION_ROWS)
+        if nonzero:
+            open_ids.append(inst)
+
+    open_tuple = tuple(open_ids)
+    if not open_tuple:
+        return PreSubmitOpenPositionCapDecisionV1(
+            admitted=True,
+            reason_code=REASON_ALLOW_NO_OPEN_POSITION,
+            open_instrument_ids=open_tuple,
+        )
+    others = tuple(inst for inst in open_tuple if inst != target)
+    if others:
+        return PreSubmitOpenPositionCapDecisionV1(
+            admitted=False,
+            reason_code=REASON_DENY_OTHER_OPEN_INSTRUMENT_PRESENT,
+            open_instrument_ids=open_tuple,
+        )
+    return PreSubmitOpenPositionCapDecisionV1(
+        admitted=True,
+        reason_code=REASON_ALLOW_TARGET_INSTRUMENT_ALREADY_OPEN,
+        open_instrument_ids=open_tuple,
+    )
+
+
+def assert_pre_submit_open_position_cap_allows_v1(
+    *,
+    target_instrument_id: str,
+    positions_payload: Any,
+) -> PreSubmitOpenPositionCapDecisionV1:
+    """Raise typed fail-closed error unless the cap admits the intent."""
+    decision = evaluate_pre_submit_open_position_cap_v1(
+        target_instrument_id=target_instrument_id,
+        positions_payload=positions_payload,
+    )
+    if not decision.admitted or decision.reason_code not in _ALLOW_REASONS:
+        raise PreSubmitOpenPositionCapErrorV1(decision.reason_code)
+    return decision

--- a/src/ops/section_11_12_8_actual_productive_testnet_campaign_run_start_v1/productive_execution_port_v1.py
+++ b/src/ops/section_11_12_8_actual_productive_testnet_campaign_run_start_v1/productive_execution_port_v1.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from src.ops.pre_submit_open_position_cap_v1 import (
+    PreSubmitOpenPositionCapErrorV1,
+    assert_pre_submit_open_position_cap_allows_v1,
+)
 from src.ops.section_11_12_8_actual_productive_testnet_campaign_run_start_v1.constants_v1 import (
     CANONICAL_ALLOWED_ORDER_TYPES,
     CANONICAL_INSTRUMENT_SCOPE,
@@ -16,12 +20,17 @@ from src.ops.section_11_12_8_actual_productive_testnet_campaign_run_start_v1.con
     SWAP_RUNTIME_FALLBACK,
     SWAP_WRITE_AUTHORIZATION,
 )
+from src.ops.section_11_12_8_actual_productive_testnet_campaign_run_start_v1.final_exchange_reconcile_cleanup_v1 import (
+    ActualStartFinalReconcileError,
+    exchange_payload_from_transport_result_v1,
+)
 from src.ops.section_11_12_8_actual_productive_testnet_campaign_run_start_v1.okx_response_mapper_v1 import (
     build_venue_native_cancel_body_v1,
     build_venue_native_order_body_v1,
     parse_okx_order_response_v1,
 )
 from src.ops.section_11_12_8_actual_productive_testnet_campaign_run_start_v1.testnet_transport_v1 import (
+    ActualStartTransportError,
     StubbedTestnetTransportV1,
     TestnetTransportPortV1,
 )
@@ -99,6 +108,7 @@ class ProductiveTestnetExecutionPortV1:
             quantity=quantity,
             px=px,
         )
+        self._require_account_wide_open_position_cap_v1(instrument=instrument)
         result = self.transport.request(
             method="POST",
             endpoint="/api/v5/trade/order",
@@ -165,6 +175,40 @@ class ProductiveTestnetExecutionPortV1:
         }
         self.submit_attempts.append(attempt)
         return attempt
+
+    def _require_account_wide_open_position_cap_v1(self, *, instrument: str) -> None:
+        """Fail-closed GET /api/v5/account/positions then shared second-open cap.
+
+        Reuses the existing TestnetTransportPortV1.request GET surface. No new
+        networking layer. Does not invent reduce/close/sizing policy.
+        """
+        if self.transport is None:
+            raise ActualStartPortError("TRANSPORT_NOT_BOUND")
+        try:
+            get_result = self.transport.request(
+                method="GET",
+                endpoint="/api/v5/account/positions",
+                body=None,
+            )
+        except ActualStartPortError:
+            raise
+        except (ActualStartTransportError, TypeError, ValueError) as exc:
+            raise ActualStartPortError("DENY_POSITION_STATE_UNAVAILABLE") from exc
+        except Exception as exc:  # noqa: BLE001 — GET failure is fail-closed
+            raise ActualStartPortError("DENY_POSITION_STATE_UNAVAILABLE") from exc
+        if not isinstance(get_result, dict):
+            raise ActualStartPortError("DENY_POSITION_STATE_UNAVAILABLE")
+        try:
+            payload = exchange_payload_from_transport_result_v1(get_result)
+        except ActualStartFinalReconcileError as exc:
+            raise ActualStartPortError("DENY_POSITION_STATE_UNAVAILABLE") from exc
+        try:
+            assert_pre_submit_open_position_cap_allows_v1(
+                target_instrument_id=instrument,
+                positions_payload=payload,
+            )
+        except PreSubmitOpenPositionCapErrorV1 as exc:
+            raise ActualStartPortError(f"ACCOUNT_WIDE_OPEN_POSITION_CAP:{exc.reason_code}") from exc
 
     def cancel_order_v1(
         self,

--- a/src/ops/section_11_12_8_actual_productive_testnet_campaign_run_start_v1/testnet_transport_v1.py
+++ b/src/ops/section_11_12_8_actual_productive_testnet_campaign_run_start_v1/testnet_transport_v1.py
@@ -61,6 +61,14 @@ class StubbedTestnetTransportV1:
             "submitted": False,
         }
         self.calls.append(record)
+        path = endpoint.split("?", 1)[0]
+        if method.upper() == "GET" and path == "/api/v5/account/positions":
+            response_body: dict[str, Any] = {"code": "0", "data": []}
+        else:
+            response_body = {
+                "code": "0",
+                "data": [{"sCode": "0", "sMsg": "stubbed", "clOrdId": (body or {}).get("clOrdId")}],
+            }
         return {
             "ok": True,
             "http_status": 200,
@@ -69,10 +77,7 @@ class StubbedTestnetTransportV1:
             "network_send_boundary_reached": True,
             "account_identity": "acct-uid-testnet-demo",
             "next_effect": self.next_effect_pending,
-            "response_body": {
-                "code": "0",
-                "data": [{"sCode": "0", "sMsg": "stubbed", "clOrdId": (body or {}).get("clOrdId")}],
-            },
+            "response_body": response_body,
         }
 
 

--- a/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/submit_transport_v1.py
+++ b/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/submit_transport_v1.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from typing import Any, Mapping
 from uuid import uuid4
 
+from src.ops.pre_submit_open_position_cap_v1 import (
+    PreSubmitOpenPositionCapErrorV1,
+    assert_pre_submit_open_position_cap_allows_v1,
+)
 from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.config_v1 import (
     LiveCanaryConfigV1,
 )
@@ -322,6 +326,19 @@ def run_canary_submit_transport_v1(
         except LiveCanaryPreSubmitStateError as exc:
             raise LiveCanarySubmitTransportError(f"PRE_SUBMIT_STATE_BLOCK:{exc}") from exc
 
+        # Account-wide second-open-instrument cap on the already fetched
+        # GET /api/v5/account/positions payload. Does not replace
+        # same-instrument OPEN_POSITION_PRESENT / OPEN_ORDER_PRESENT.
+        try:
+            assert_pre_submit_open_position_cap_allows_v1(
+                target_instrument_id=plan.instrument_id,
+                positions_payload=positions,
+            )
+        except PreSubmitOpenPositionCapErrorV1 as exc:
+            raise LiveCanarySubmitTransportError(
+                f"ACCOUNT_WIDE_OPEN_POSITION_CAP:{exc.reason_code}"
+            ) from exc
+
         submit_gate = evaluate_canary_submit_gates_v1(
             owner_go=owner_go,
             owner_go_consumed=owner_go_consumed,
@@ -341,6 +358,9 @@ def run_canary_submit_transport_v1(
             max_notional=plan.max_notional,
             min_executable_notional=plan.min_executable_notional,
             order_count=1,
+            # LEGACY/NON-AUTHORITATIVE: hardcoded 0 feeds POSITION_COUNT_LIMIT
+            # only. Account-wide second-open-instrument admission is
+            # assert_pre_submit_open_position_cap_allows_v1 on the GET payload.
             position_count=0,
             exposure_above_minimum_bound=False,
             live_canary_cybersecurity_gate=live_canary_cybersecurity_gate,

--- a/tests/ops/test_pre_submit_open_position_cap_v1.py
+++ b/tests/ops/test_pre_submit_open_position_cap_v1.py
@@ -1,0 +1,179 @@
+"""Offline tests for the shared pre-submit second-open-instrument cap."""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from src.live.risk_limits import LiveRiskLimits
+from src.ops.config_truth_alignment_contract_v1 import parse_phase1_max_open_positions
+from src.ops.pre_submit_open_position_cap_v1 import (
+    REASON_ALLOW_NO_OPEN_POSITION,
+    REASON_ALLOW_TARGET_INSTRUMENT_ALREADY_OPEN,
+    REASON_DENY_AMBIGUOUS_POSITION_ROWS,
+    REASON_DENY_INVALID_POSITION_PAYLOAD,
+    REASON_DENY_OTHER_OPEN_INSTRUMENT_PRESENT,
+    REASON_DENY_POSITION_STATE_UNAVAILABLE,
+    PreSubmitOpenPositionCapErrorV1,
+    assert_pre_submit_open_position_cap_allows_v1,
+    evaluate_pre_submit_open_position_cap_v1,
+)
+from src.ops.single_selected_future_policy_v1.constants_v1 import MAX_POSITIONS_EFFECTIVE
+
+INSTR_A = "INST-A"
+INSTR_B = "INST-B"
+INSTR_C = "INST-C"
+
+
+def _envelope(*rows: dict) -> dict:
+    return {"code": "0", "data": list(rows)}
+
+
+def test_t1_empty_positions_allows_no_open() -> None:
+    decision = evaluate_pre_submit_open_position_cap_v1(
+        target_instrument_id=INSTR_B,
+        positions_payload=_envelope(),
+    )
+    assert decision.admitted is True
+    assert decision.reason_code == REASON_ALLOW_NO_OPEN_POSITION
+
+
+def test_t2_open_other_instrument_denied() -> None:
+    decision = evaluate_pre_submit_open_position_cap_v1(
+        target_instrument_id=INSTR_B,
+        positions_payload=_envelope({"instId": INSTR_A, "pos": "1"}),
+    )
+    assert decision.admitted is False
+    assert decision.reason_code == REASON_DENY_OTHER_OPEN_INSTRUMENT_PRESENT
+    with pytest.raises(
+        PreSubmitOpenPositionCapErrorV1, match=REASON_DENY_OTHER_OPEN_INSTRUMENT_PRESENT
+    ):
+        assert_pre_submit_open_position_cap_allows_v1(
+            target_instrument_id=INSTR_B,
+            positions_payload=_envelope({"instId": INSTR_A, "pos": "1"}),
+        )
+
+
+def test_t3_same_instrument_already_open_allows_without_sizing_policy() -> None:
+    decision = evaluate_pre_submit_open_position_cap_v1(
+        target_instrument_id=INSTR_A,
+        positions_payload=_envelope({"instId": INSTR_A, "pos": "-2"}),
+    )
+    assert decision.admitted is True
+    assert decision.reason_code == REASON_ALLOW_TARGET_INSTRUMENT_ALREADY_OPEN
+    allowed = assert_pre_submit_open_position_cap_allows_v1(
+        target_instrument_id=INSTR_A,
+        positions_payload=_envelope({"instId": INSTR_A, "pos": "-2"}),
+    )
+    assert allowed.admitted is True
+
+
+def test_t4_zero_size_row_is_not_open() -> None:
+    decision = evaluate_pre_submit_open_position_cap_v1(
+        target_instrument_id=INSTR_B,
+        positions_payload=_envelope({"instId": INSTR_A, "pos": "0"}),
+    )
+    assert decision.admitted is True
+    assert decision.reason_code == REASON_ALLOW_NO_OPEN_POSITION
+
+
+def test_t5_open_other_plus_zero_target_denied() -> None:
+    decision = evaluate_pre_submit_open_position_cap_v1(
+        target_instrument_id=INSTR_B,
+        positions_payload=_envelope(
+            {"instId": INSTR_A, "pos": "1"},
+            {"instId": INSTR_B, "pos": "0"},
+        ),
+    )
+    assert decision.admitted is False
+    assert decision.reason_code == REASON_DENY_OTHER_OPEN_INSTRUMENT_PRESENT
+
+
+def test_t6_two_distinct_nonzero_instruments_denied() -> None:
+    decision = evaluate_pre_submit_open_position_cap_v1(
+        target_instrument_id=INSTR_B,
+        positions_payload=_envelope(
+            {"instId": INSTR_A, "pos": "1"},
+            {"instId": INSTR_C, "pos": "2"},
+        ),
+    )
+    assert decision.admitted is False
+    assert decision.reason_code == REASON_DENY_OTHER_OPEN_INSTRUMENT_PRESENT
+
+
+def test_t7_duplicate_nonzero_same_instid_ambiguous() -> None:
+    decision = evaluate_pre_submit_open_position_cap_v1(
+        target_instrument_id=INSTR_B,
+        positions_payload=_envelope(
+            {"instId": INSTR_A, "pos": "1"},
+            {"instId": INSTR_A, "pos": "2"},
+        ),
+    )
+    assert decision.admitted is False
+    assert decision.reason_code == REASON_DENY_AMBIGUOUS_POSITION_ROWS
+
+
+def test_t8_malformed_payload_invalid() -> None:
+    bad_pos = evaluate_pre_submit_open_position_cap_v1(
+        target_instrument_id=INSTR_B,
+        positions_payload=_envelope({"instId": INSTR_A, "pos": "not-a-number"}),
+    )
+    assert bad_pos.reason_code == REASON_DENY_INVALID_POSITION_PAYLOAD
+    bad_data = evaluate_pre_submit_open_position_cap_v1(
+        target_instrument_id=INSTR_B,
+        positions_payload={"code": "0", "data": "not-a-list"},
+    )
+    assert bad_data.reason_code == REASON_DENY_INVALID_POSITION_PAYLOAD
+    bad_code = evaluate_pre_submit_open_position_cap_v1(
+        target_instrument_id=INSTR_B,
+        positions_payload={"code": "1", "data": []},
+    )
+    assert bad_code.reason_code == REASON_DENY_INVALID_POSITION_PAYLOAD
+    non_mapping_row = evaluate_pre_submit_open_position_cap_v1(
+        target_instrument_id=INSTR_B,
+        positions_payload={"code": "0", "data": ["nope"]},
+    )
+    assert non_mapping_row.reason_code == REASON_DENY_INVALID_POSITION_PAYLOAD
+
+
+def test_t9_missing_instid_on_nonzero_fail_closed() -> None:
+    decision = evaluate_pre_submit_open_position_cap_v1(
+        target_instrument_id=INSTR_B,
+        positions_payload=_envelope({"pos": "1"}),
+    )
+    assert decision.admitted is False
+    assert decision.reason_code == REASON_DENY_INVALID_POSITION_PAYLOAD
+
+
+def test_t10_unavailable_none_payload() -> None:
+    decision = evaluate_pre_submit_open_position_cap_v1(
+        target_instrument_id=INSTR_B,
+        positions_payload=None,
+    )
+    assert decision.admitted is False
+    assert decision.reason_code == REASON_DENY_POSITION_STATE_UNAVAILABLE
+    with pytest.raises(
+        PreSubmitOpenPositionCapErrorV1, match=REASON_DENY_POSITION_STATE_UNAVAILABLE
+    ):
+        assert_pre_submit_open_position_cap_allows_v1(
+            target_instrument_id=INSTR_B,
+            positions_payload=None,
+        )
+
+
+def test_reduce_close_same_instrument_is_not_blanket_blocked() -> None:
+    """Count-only open>=1 reject-any-order is unsafe; same-instrument stays ALLOW."""
+    decision = evaluate_pre_submit_open_position_cap_v1(
+        target_instrument_id=INSTR_A,
+        positions_payload=_envelope({"instId": INSTR_A, "posSize": "3"}),
+    )
+    assert decision.reason_code == REASON_ALLOW_TARGET_INSTRUMENT_ALREADY_OPEN
+
+
+def test_regression_max_positions_effective_and_batch_symbol_semantics_untouched() -> None:
+    assert MAX_POSITIONS_EFFECTIVE == 1
+    source = inspect.getsource(LiveRiskLimits.check_orders)
+    assert "n_symbols" in source
+    assert "max_open_positions" in source
+    assert parse_phase1_max_open_positions.__name__ == "parse_phase1_max_open_positions"

--- a/tests/ops/test_section_11_12_8_bounded_long_running_productive_testnet_campaign_v1.py
+++ b/tests/ops/test_section_11_12_8_bounded_long_running_productive_testnet_campaign_v1.py
@@ -515,6 +515,16 @@ def test_refuse_invalid_duration_bound() -> None:
 def test_exchange_order_id_persisted_on_port_attempt() -> None:
     class _AckTransport:
         def request(self, *, method: str, endpoint: str, body: dict | None = None) -> dict:
+            path = endpoint.split("?", 1)[0]
+            if method.upper() == "GET" and path == "/api/v5/account/positions":
+                return {
+                    "ok": True,
+                    "stubbed": False,
+                    "wire_sent": False,
+                    "network_send_boundary_reached": True,
+                    "http_status": 200,
+                    "response_body": {"code": "0", "data": []},
+                }
             return {
                 "ok": True,
                 "stubbed": False,
@@ -605,6 +615,16 @@ def test_campaign_executor_emits_alphanumeric_clordid_and_preserves_order_fields
 
     class _CaptureTransport:
         def request(self, *, method: str, endpoint: str, body: dict | None = None) -> dict:
+            path = endpoint.split("?", 1)[0]
+            if method.upper() == "GET" and path == "/api/v5/account/positions":
+                return {
+                    "ok": True,
+                    "stubbed": True,
+                    "wire_sent": False,
+                    "network_send_boundary_reached": True,
+                    "http_status": 200,
+                    "response_body": {"code": "0", "data": []},
+                }
             captured.append(dict(body or {}))
             return {
                 "ok": True,

--- a/tests/ops/test_section_11_12_8_second_open_position_cap_v1.py
+++ b/tests/ops/test_section_11_12_8_second_open_position_cap_v1.py
@@ -1,0 +1,135 @@
+"""Offline SP-04 pre-submit second-open-instrument cap binding tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.ops.section_11_12_8_actual_productive_testnet_campaign_run_start_v1.constants_v1 import (
+    CANONICAL_INSTRUMENT_SCOPE,
+    CANONICAL_ORDER_SZ_FOR_VENUE_NATIVE_BODY_V1,
+)
+from src.ops.section_11_12_8_actual_productive_testnet_campaign_run_start_v1.productive_execution_port_v1 import (
+    ActualStartPortError,
+    construct_productive_testnet_execution_port_v1,
+)
+
+TARGET = CANONICAL_INSTRUMENT_SCOPE[0]
+OTHER = "ETH-USD_UM_XPERP-310328"
+POSITIONS_EP = "/api/v5/account/positions"
+ORDER_EP = "/api/v5/trade/order"
+
+
+class _RecordingPositionsTransport:
+    def __init__(self, positions_result: dict | BaseException) -> None:
+        self.positions_result = positions_result
+        self.calls: list[tuple[str, str]] = []
+
+    def request(self, *, method: str, endpoint: str, body: dict | None = None) -> dict:
+        self.calls.append((method.upper(), endpoint))
+        if method.upper() == "GET" and endpoint == POSITIONS_EP:
+            if isinstance(self.positions_result, BaseException):
+                raise self.positions_result
+            return dict(self.positions_result)
+        if method.upper() == "POST" and endpoint == ORDER_EP:
+            return {
+                "ok": True,
+                "stubbed": True,
+                "wire_sent": False,
+                "network_send_boundary_reached": True,
+                "http_status": 200,
+                "response_body": {
+                    "code": "0",
+                    "data": [
+                        {"sCode": "0", "sMsg": "stubbed", "clOrdId": (body or {}).get("clOrdId")}
+                    ],
+                },
+            }
+        raise AssertionError(f"unexpected {method} {endpoint}")
+
+
+def _submit(port) -> dict:
+    return port.submit_order_v1(
+        client_order_id="c-cap",
+        instrument=TARGET,
+        order_type="LIMIT",
+        side="buy",
+        quantity=CANONICAL_ORDER_SZ_FOR_VENUE_NATIVE_BODY_V1,
+        px="10000",
+    )
+
+
+def _ok_positions(rows: list[dict]) -> dict:
+    return {
+        "ok": True,
+        "stubbed": True,
+        "wire_sent": False,
+        "response_body": {"code": "0", "data": rows},
+    }
+
+
+def test_t18_open_different_instrument_no_post() -> None:
+    transport = _RecordingPositionsTransport(_ok_positions([{"instId": OTHER, "pos": "1"}]))
+    port = construct_productive_testnet_execution_port_v1(
+        authorized=True, transport=transport, stubbed=True
+    )
+    with pytest.raises(ActualStartPortError, match="DENY_OTHER_OPEN_INSTRUMENT_PRESENT"):
+        _submit(port)
+    assert transport.calls == [("GET", POSITIONS_EP)]
+
+
+def test_t19_no_open_positions_mocked_post_proceeds() -> None:
+    transport = _RecordingPositionsTransport(_ok_positions([]))
+    port = construct_productive_testnet_execution_port_v1(
+        authorized=True, transport=transport, stubbed=True
+    )
+    effect = _submit(port)
+    assert effect["stubbed"] is True
+    assert effect["live_order_effect"] == "NONE"
+    assert transport.calls == [("GET", POSITIONS_EP), ("POST", ORDER_EP)]
+
+
+def test_t20_positions_get_failure_no_post() -> None:
+    transport = _RecordingPositionsTransport(RuntimeError("GET_FAILED"))
+    port = construct_productive_testnet_execution_port_v1(
+        authorized=True, transport=transport, stubbed=True
+    )
+    with pytest.raises(ActualStartPortError, match="DENY_POSITION_STATE_UNAVAILABLE"):
+        _submit(port)
+    assert transport.calls == [("GET", POSITIONS_EP)]
+
+
+def test_t21_malformed_and_ambiguous_positions_no_post() -> None:
+    malformed = _RecordingPositionsTransport(_ok_positions([{"instId": OTHER, "pos": "abc"}]))
+    port = construct_productive_testnet_execution_port_v1(
+        authorized=True, transport=malformed, stubbed=True
+    )
+    with pytest.raises(ActualStartPortError, match="DENY_INVALID_POSITION_PAYLOAD"):
+        _submit(port)
+    assert malformed.calls == [("GET", POSITIONS_EP)]
+
+    ambiguous = _RecordingPositionsTransport(
+        _ok_positions(
+            [
+                {"instId": OTHER, "pos": "1"},
+                {"instId": OTHER, "pos": "1"},
+            ]
+        )
+    )
+    port = construct_productive_testnet_execution_port_v1(
+        authorized=True, transport=ambiguous, stubbed=True
+    )
+    with pytest.raises(ActualStartPortError, match="DENY_AMBIGUOUS_POSITION_ROWS"):
+        _submit(port)
+    assert ambiguous.calls == [("GET", POSITIONS_EP)]
+
+
+def test_t22_get_occurs_before_post() -> None:
+    transport = _RecordingPositionsTransport(_ok_positions([]))
+    port = construct_productive_testnet_execution_port_v1(
+        authorized=True, transport=transport, stubbed=True
+    )
+    _submit(port)
+    methods = [method for method, _endpoint in transport.calls]
+    assert methods.index("GET") < methods.index("POST")
+    assert transport.calls[0] == ("GET", POSITIONS_EP)
+    assert transport.calls[1] == ("POST", ORDER_EP)

--- a/tests/ops/test_section_11_13_5_canary_submit_transport_v1.py
+++ b/tests/ops/test_section_11_13_5_canary_submit_transport_v1.py
@@ -20,6 +20,7 @@ from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.config_v1 import (
 from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.constants_v1 import (
     AUTHORIZATION_SCOPE,
     CANARY_SUBMIT_TRANSPORT_IMPLEMENTED,
+    DEFAULT_INSTRUMENT_ID,
     GENERAL_LIVE_SUBMIT_UNLOCKED,
     LIVE_AUTHORIZED,
     OWNER_GO_AUTHORING,
@@ -1049,3 +1050,90 @@ def test_xperp_economic_baseline_contract_does_not_inherit_swap_or_demo() -> Non
     assert contract["rejected_swap_instrument"] == "BTC-USDT-SWAP"
     assert contract["rejected_demo_instrument"] == "BTC-USD_UM_XPERP-310328"
     assert contract["CANARY_INSTRUMENT"] != contract["rejected_demo_instrument"]
+
+
+def _assert_no_post(transport: RecordingFakeCanaryTransportV1) -> None:
+    assert all(call.method != "POST" for call in transport.calls)
+
+
+def test_t11_leftover_other_instrument_rejects_before_post() -> None:
+    leftover = "ETH-USD_UM_XPERP-999999"
+    transport = _fake_transport()
+    transport.bodies_by_endpoint["/api/v5/account/positions"] = json.dumps(
+        {"code": "0", "data": [{"instId": leftover, "pos": "1"}]}
+    ).encode()
+    with pytest.raises(LiveCanarySubmitTransportError, match="DENY_OTHER_OPEN_INSTRUMENT_PRESENT"):
+        run_canary_submit_transport_v1(**_transport_kwargs(transport=transport))
+    _assert_no_post(transport)
+    assert any("/api/v5/account/positions" in call.endpoint for call in transport.calls)
+
+
+def test_t12_no_open_positions_reaches_downstream_fake_post_without_real_network() -> None:
+    transport = _fake_transport()
+    assert transport.venue_live_contact is False
+    result = run_canary_submit_transport_v1(**_transport_kwargs(transport=transport))
+    assert result["ok"] is True
+    posts = [call for call in transport.calls if call.method == "POST"]
+    assert len(posts) == 1
+    assert posts[0].endpoint == "/api/v5/trade/order"
+    assert transport.venue_live_contact is False
+    position_gets = [
+        call
+        for call in transport.calls
+        if call.method == "GET" and "/api/v5/account/positions" in call.endpoint
+    ]
+    assert len(position_gets) == 1
+
+
+def test_t13_open_canonical_canary_instrument_still_open_position_present() -> None:
+    transport = _fake_transport()
+    transport.bodies_by_endpoint["/api/v5/account/positions"] = json.dumps(
+        {"code": "0", "data": [{"instId": DEFAULT_INSTRUMENT_ID, "pos": "1"}]}
+    ).encode()
+    with pytest.raises(LiveCanarySubmitTransportError, match="OPEN_POSITION_PRESENT"):
+        run_canary_submit_transport_v1(**_transport_kwargs(transport=transport))
+    _assert_no_post(transport)
+
+
+def test_t14_positions_fetch_failure_no_post() -> None:
+    transport = _fake_transport()
+    transport.bodies_by_endpoint["/api/v5/account/positions"] = b"not-json"
+    with pytest.raises((LiveCanarySubmitTransportError, LiveCanaryHttpError)):
+        run_canary_submit_transport_v1(**_transport_kwargs(transport=transport))
+    _assert_no_post(transport)
+
+
+def test_t15_ambiguous_duplicate_rows_no_post() -> None:
+    leftover = "ETH-USD_UM_XPERP-999999"
+    transport = _fake_transport()
+    transport.bodies_by_endpoint["/api/v5/account/positions"] = json.dumps(
+        {
+            "code": "0",
+            "data": [
+                {"instId": leftover, "pos": "1"},
+                {"instId": leftover, "pos": "1"},
+            ],
+        }
+    ).encode()
+    with pytest.raises(LiveCanarySubmitTransportError, match="DENY_AMBIGUOUS_POSITION_ROWS"):
+        run_canary_submit_transport_v1(**_transport_kwargs(transport=transport))
+    _assert_no_post(transport)
+
+
+def test_t16_pending_order_gate_still_rejects() -> None:
+    transport = _fake_transport()
+    transport.bodies_by_endpoint["/api/v5/trade/orders-pending"] = json.dumps(
+        {"code": "0", "data": [{"instId": DEFAULT_INSTRUMENT_ID, "ordId": "pending-1"}]}
+    ).encode()
+    with pytest.raises(LiveCanarySubmitTransportError, match="OPEN_ORDER_PRESENT"):
+        run_canary_submit_transport_v1(**_transport_kwargs(transport=transport))
+    _assert_no_post(transport)
+
+
+def test_t17_wrong_selected_instrument_still_rejects_binding() -> None:
+    kwargs = _transport_kwargs()
+    kwargs["cfg"].payload["instrument_id"] = "BTC-USDT-SWAP"
+    transport = kwargs["transport"]
+    with pytest.raises(LiveCanarySubmitTransportError, match="INSTRUMENT_BINDING"):
+        run_canary_submit_transport_v1(**kwargs)
+    _assert_no_post(transport)


### PR DESCRIPTION
## Summary
- Closes the B8 execution-time gap: a leftover **other-instrument** open position could previously reach submit on the §11.13.5 canary entry path (instrument-filtered only) and on the §11.12.8 SP-04 productive testnet submit port (no pre-submit open-position check).
- Adds a **pure, offline, side-effect-free** shared evaluator (`src/ops/pre_submit_open_position_cap_v1.py`) that adjudicates account-wide nonzero `instId`s against the target instrument. It is **not** a count-only `open >= 1 => reject everything` gate and does **not** redefine `LiveRiskLimits.check_orders`, `max_open_positions`, or `MAX_POSITIONS_EFFECTIVE=1`.
- **Canary binding:** reuses the existing `GET /api/v5/account/positions` payload (no extra positions GET). Account-wide cap runs after the same-instrument `OPEN_POSITION_PRESENT` / `OPEN_ORDER_PRESENT` checks and before POST. `position_count=0` remains legacy/non-authoritative.
- **SP-04 binding:** immediately before `POST /api/v5/trade/order`, uses the existing `TestnetTransportPortV1.request` GET surface. Transport/unwrap/parse failure and cap DENY are fail-closed (no POST). Stub GET returns an explicit empty positions envelope so offline tests model proven-empty state.
- Fail-closed reasons: `ALLOW_NO_OPEN_POSITION`, `ALLOW_TARGET_INSTRUMENT_ALREADY_OPEN`, `DENY_OTHER_OPEN_INSTRUMENT_PRESENT`, `DENY_AMBIGUOUS_POSITION_ROWS`, `DENY_INVALID_POSITION_PAYLOAD`, `DENY_POSITION_STATE_UNAVAILABLE`.
- Second-position counterexamples: leftover other `instId` blocks POST; duplicate nonzero rows of the same `instId` fail closed; GET/parse failure never POSTs.
- Reduce/close non-regression: same-instrument already-open is `ALLOW_TARGET_INSTRUMENT_ALREADY_OPEN` (this cap invents no sizing/direction/reduceOnly policy). Canary entry still additionally blocked by existing `OPEN_POSITION_PRESENT` and `ENTRY_REDUCE_ONLY_FORBIDDEN`. Flatten wire is not enabled.

## Test plan
- [x] Offline `./scripts/pt -m pytest` on B8 evaluator + canary submit transport + SP-04 port/campaign tests → **126 passed**
- [x] `ruff format --check` and `ruff check` on all changed B8 files → PASS
- [x] `git diff --check` → PASS
- [ ] GitHub required checks on this PR (adjudicate; **do not merge** in this GO)

## Safety
- No live / testnet / canary execution in this slice.
- No private productive API calls; tests are fixture/fake/stub only.
- No credentials, config.toml, bounded_live.toml, Master Runbook, Map of Truth, or forensic mutation.
- Out of scope: Kraken, LiveSessionRunner, strategy/sizing, LiveRiskLimits semantic rewrite.

**Merge is not authorized by this Owner-GO. HARD STOP pre-merge.**

Made with [Cursor](https://cursor.com)