### PR TITLE
feat(ops): wire fail-closed productive flatten path after Z2AU

### DIFF
--- a/docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md
+++ b/docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md
@@ -29448,6 +29448,159 @@ treat offline construction as `LIVE_FLATTEN_PROVABILITY=PROVEN`.
 `LIVE_AUTHORIZED=false`. No execute. No merge of this persist without a
 separate `OWNER_MERGE_GO`.
 
+### 11.13.5.Z2AV Productive live-flatten wiring persist (BOUND; WIRING; NOT EXECUTE; NOT PROVEN)
+
+Owner-GO
+`OWNER_GO=SECTION_11_13_5_POST_Z2AU_PRODUCTIVE_LIVE_FLATTEN_WIRING_MAX_SAFE_SLICE_FAIL_CLOSED_NO_NETWORK_NO_GET_NO_POST_NO_EXECUTE`
+(one-shot; now **CONSUMED** as this wiring slice only) authorized the
+largest remaining **fail-closed source wiring** after Z2AU
+(`origin/main=7085b6e76fef9036319f6d9a4bce0329e5493b02`). This persist
+records that a dedicated productive flatten transport, runner
+`flatten_execute` wiring, separate flatten-execute confirm-token
+authority, and a full pre-send gate object now exist so a hypothetically
+valid productive flatten is **structurally reachable**. This persist
+does **not** prove live flatten, does **not** enable live wire as a
+standing default, does **not** execute Canary, Testnet, Live, or
+flatten, does **not** fund, does **not** perform GET or POST, does
+**not** consume Z2AP as flatten proof, does **not** consume Z2AR, does
+**not** rank either open P3 track, and does **not** invent a flatten
+execute Owner-GO.
+
+This persist is **additive**. §11.13.5.Z2AS remains the policy basis for
+independent parallel tracks. §11.13.5.Z2AP, §11.13.5.Z2AQ, §11.13.5.Z2AR,
+§11.13.5.Z2AS, §11.13.5.Z2AT, and §11.13.5.Z2AU remain historically and
+semantically unchanged. Bound scope:
+
+``` text
+AUTHORIZED_SCOPE=A_Z2AV_PRODUCTIVE_FLATTEN_WIRING_FAIL_CLOSED_NO_NETWORK_NO_GET_NO_POST_NO_EXECUTE_ONLY
+CURRENT_PHASE=SECTION_11_13_5_Z2AV_PRODUCTIVE_FLATTEN_WIRING
+OWNER_GO=SECTION_11_13_5_POST_Z2AU_PRODUCTIVE_LIVE_FLATTEN_WIRING_MAX_SAFE_SLICE_FAIL_CLOSED_NO_NETWORK_NO_GET_NO_POST_NO_EXECUTE
+OWNER_GO_STATUS=CONSUMED
+PERSIST_CLASS=WIRING_IMPLEMENTATION_PLUS_SSOT_PERSIST
+BASELINE_ORIGIN_MAIN_SHA=7085b6e76fef9036319f6d9a4bce0329e5493b02
+PARALLEL_TO_SECTION_11_13_5_Z2AS=true
+PARALLEL_TO_SECTION_11_13_5_Z2AP=true
+PARALLEL_TO_SECTION_11_13_5_Z2AR=true
+Z2AS_REMAINS_P3_POLICY_BASIS=true
+Z2AS_TEXT_REWRITTEN=false
+Z2AP_TEXT_REWRITTEN=false
+Z2AQ_TEXT_REWRITTEN=false
+Z2AR_TEXT_REWRITTEN=false
+Z2AT_TEXT_REWRITTEN=false
+Z2AU_TEXT_REWRITTEN=false
+Z2AP_CONSUMED=false
+Z2AR_CONSUMED=false
+P3_INDEPENDENT_PARALLEL_TRACKS_POLICY=true
+TRACK_RELATION=INDEPENDENT_PARALLEL
+GLOBAL_UNIQUE_CANONICAL_NEXT_STEP=NONE_BY_P3_POLICY
+NO_MAP_OF_TRUTH_MUTATION=true
+LAST_CANONICALLY_CLOSED_STEP=LF_12
+THIS_OWNER_GO_IS_NOT_FLATTEN_EXECUTE_TOKEN=true
+
+SLICE_IMPLEMENTED=true
+DEDICATED_PRODUCTIVE_FLATTEN_TRANSPORT_PRESENT=true
+PRODUCTIVE_FLATTEN_RUNNER_WIRING_PRESENT=true
+SEPARATE_FLATTEN_EXECUTE_AUTHORITY_PRESENT=true
+FULL_PRE_SEND_GATE_OBJECT_REQUIRED=true
+DEFAULT_PRODUCTIVE_SEND_DENIED=true
+B8_MANDATORY=true
+REDUCE_ONLY_MANDATORY=true
+LIMIT_ONLY_MANDATORY=true
+FRESHNESS_5000MS_MANDATORY=true
+ONE_SHOT_NO_RETRY=true
+DUPLICATE_POST_PROTECTION=true
+POST_SUBMIT_PROOF_CONTRACT_PRESERVED=true
+PRODUCTIVE_FLATTEN_PATH_STRUCTURALLY_REACHABLE=true
+PRODUCTIVE_WIRE_SEND_WITHOUT_FULL_RUNTIME_GATES=false
+PRODUCTIVE_WIRE_SEND_WITHOUT_SEPARATE_FLATTEN_EXECUTE_AUTHORITY=false
+NETWORK_USED_DURING_SLICE=false
+GET_EXECUTED_THIS_STEP=false
+POST_EXECUTED=false
+LIVE_FLATTEN_PROVABILITY=UNPROVEN
+PRODUCTIVE_PROOF_EXECUTED=false
+STRUCTURALLY_REACHABLE_NE_PRODUCTIVELY_PROVEN=true
+DEDICATED_FLATTEN_TRANSPORT_LIVE_WIRE_ENABLED=false
+STANDING_LIVE_AUTHORIZED=false
+STANDING_LIVE_ENABLED=false
+STANDING_LIVE_ARMED=false
+FAKE_TRANSPORT_CANNOT_MASQUERADE=true
+RUNNER_FLATTEN_EXECUTE_MODE=flatten_execute
+NO_AUTONOMOUS_FLATTEN_TRIGGER=true
+NO_IMPLICIT_FLATTEN_ON_STARTUP_SHUTDOWN_OR_GENERIC_RISK=true
+SOURCE_FLATTEN_EXECUTE_AUTHORITY=src/ops/section_11_13_5_live_canary_minimum_exposure_v1/flatten_execute_authority_v1.py
+SOURCE_FLATTEN_PRE_SEND_GATE=src/ops/section_11_13_5_live_canary_minimum_exposure_v1/flatten_pre_send_gate_v1.py
+SOURCE_FLATTEN_PRODUCTIVE_TRANSPORT=src/ops/section_11_13_5_live_canary_minimum_exposure_v1/flatten_productive_transport_v1.py
+SOURCE_FLATTEN_GATED_SUBMIT=src/ops/section_11_13_5_live_canary_minimum_exposure_v1/flatten_gated_submit_v1.py
+SOURCE_RUNNER=src/ops/section_11_13_5_live_canary_minimum_exposure_v1/runner_v1.py
+TEST_OWNER_Z2AV_WIRING=tests/ops/test_section_11_13_5_productive_flatten_wiring_v1.py
+TEST_OWNER_Z2AV_PERSIST=tests/ops/test_section_11_13_5_z2av_productive_flatten_wiring_persist_v1.py
+```
+
+Gate architecture. Productive send is denied unless every independent
+predicate in the pre-send object passes, including standing live flags
+remaining false, invocation live claims, dedicated flatten-execute
+token/purpose/owner-go (exact canonical expected-values; missing, wrong,
+forbidden, stale, or wrong-purpose deny), instrument binding, observed
+nonzero position, single-selected instrument match, empty pending-order
+state, B8 cap, close side and qty from the observed position, reduceOnly,
+LIMIT, canonical 5000 ms freshness, limit-price policy, overshoot/flip
+contract, one-shot, and duplicate-POST protection. A generic
+`allow_productive_wire_send=true` flag is never sufficient. Fake/offline
+transport remains distinct and cannot masquerade. The gated productive
+transport defaults `network_session_authorized=false` and this slice never
+sets it true. Runner mode `flatten_execute` is the only orchestration
+entry; preflight/forensic/execute do not invoke flatten.
+
+What this slice proves, and what it does **not** prove:
+
+``` text
+LIVE_FLATTEN_PROVABILITY=UNPROVEN
+PRODUCTIVE_PROOF_READY=true
+PRODUCTIVE_PROOF_EXECUTED=false
+STRUCTURALLY_REACHABLE=true
+PRODUCTIVELY_PROVEN=false
+GET_EXECUTED_THIS_STEP=false
+POST_EXECUTED=false
+NETWORK_REQUEST_EXECUTED=false
+ORDER_SUBMISSION=false
+FLATTEN_EXECUTION=false
+CANARY_EXECUTED=false
+TESTNET_ORDER_EXECUTED=false
+LIVE_ORDER_EXECUTED=false
+LIVE_AUTHORIZED=false
+TESTNET_AUTHORIZED=false
+CANARY_AUTHORIZED=false
+CAN_SUBMIT_ORDER_TODAY=false
+```
+
+Residual after this slice. Remaining evidence is still
+**execution-only**. Wiring does not consume that remainder.
+
+``` text
+EARLIEST_RESIDUAL_DEPENDENCY=SEPARATE_SCOPED_OWNER_GO_FOR_LIVE_READ_AND_OR_FLATTEN_EXECUTE_PLUS_PRODUCTIVE_RUNTIME_OBSERVATION_PLUS_NETWORK_SESSION_AUTHORIZATION_NOT_GRANTED_HERE
+NEXT_EVIDENCE_REQUIRES_SEPARATE_EXECUTION_GO=true
+NO_FLATTEN_EXECUTE_GO_INVENTED_BY_THIS_PERSIST=true
+Z2AP_TRACK_STATUS=OPEN_UNCONSUMED
+Z2AR_SUI_TRACK_STATUS=OPEN_UNCONSUMED
+GLOBAL_UNIQUE_CANONICAL_NEXT_STEP=NONE_BY_P3_POLICY
+```
+
+``` text
+CODE_OWNER=docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md
+CURRENT_CANONICAL_NEXT_STEP_AUTHORITY=SECTION_11_13_5
+SECTION_LOCAL_CANONICAL_NEXT_STEP_ROLE=RESIDUAL_AUTHORIZATION_BOUNDARY_OF_THIS_PERSIST_NOT_GLOBAL_UNIQUE_NEXT
+CANONICAL_NEXT_STEP=OWNER_GO_REQUIRED_SEPARATE_SCOPED_NAMED_TRACK_OR_NAMED_CLASS_PROGRESSION_NOT_AUTHORIZED_BY_THIS_PERSIST_Z2AV_PRODUCTIVE_FLATTEN_WIRING_ONLY_GLOBAL_UNIQUE_CANONICAL_NEXT_STEP_NONE_BY_P3_POLICY_NO_Z2AP_CONSUME_NO_Z2AR_CONSUME_NO_FLATTEN_EXECUTE_NO_LIVE_WIRE_NO_SUI_REPROOF_NO_CANONICAL_REBIND_NO_GET_NO_POST_NO_ORDER_NO_FUNDING_NO_CANARY_NOT_AUTHORIZED
+NEXT_OWNER_AUTHORIZATION_REQUIRED=OWNER_MERGE_GO_FOR_THIS_PERSIST_THEN_SEPARATE_EXPLICIT_EXECUTION_GO_REQUIRED_FOR_ANY_PRODUCTIVE_LIVE_FLATTEN_ATTEMPT
+HARD_STOP_AFTER_THIS_TASK=true
+```
+
+Hard stop. This Z2AV wiring GO is consumed as this slice only. Do **not**
+reuse it as flatten execute, live-read, GET, POST, order, funding, Canary,
+testnet, live, or merge authorization. `LIVE_FLATTEN_PROVABILITY=UNPROVEN`.
+`PRODUCTIVE_PROOF_EXECUTED=false`. `Z2AP_CONSUMED=false`.
+`Z2AR_CONSUMED=false`. `CAN_SUBMIT_ORDER_TODAY=false`. No execute. No
+merge of this persist without a separate `OWNER_MERGE_GO`.
+
 ## 11.14 Live order and economic evidence ladder
 
 Live proof claims must use a stricter ladder:

--- a/docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md
+++ b/docs/runbooks/canonical/PEAK_TRADE_MASTER_RUNBOOK.md
@@ -29454,7 +29454,7 @@ Owner-GO
 `OWNER_GO=SECTION_11_13_5_POST_Z2AU_PRODUCTIVE_LIVE_FLATTEN_WIRING_MAX_SAFE_SLICE_FAIL_CLOSED_NO_NETWORK_NO_GET_NO_POST_NO_EXECUTE`
 (one-shot; now **CONSUMED** as this wiring slice only) authorized the
 largest remaining **fail-closed source wiring** after Z2AU
-(`origin/main=7085b6e76fef9036319f6d9a4bce0329e5493b02`). This persist
+(`origin&#47;main=7085b6e76fef9036319f6d9a4bce0329e5493b02`). This persist
 records that a dedicated productive flatten transport, runner
 `flatten_execute` wiring, separate flatten-execute confirm-token
 authority, and a full pre-send gate object now exist so a hypothetically

--- a/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/config_v1.py
+++ b/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/config_v1.py
@@ -98,8 +98,15 @@ def example_incomplete_config_dict_v1() -> dict[str, Any]:
             "ctVal/tickSz must come from venue instrument metadata. SecretRef must use "
             "/live-canary-minimum-exposure/ path. Instrument minSz/lotSz/ctVal/tickSz "
             "are derived from venue GET at execute and must not be invented. "
-            "Authoring/transport-prep does not authorize execute."
+            "Authoring/transport-prep does not authorize execute. Flatten execute "
+            "defaults remain denied."
         ),
+        "flatten_live_wire_enabled": False,
+        "flatten_execute_token": "",
+        "flatten_execute_purpose": "",
+        "flatten_execute_owner_go": "",
+        "flatten_execute_bound_origin_main_sha": "",
+        "flatten_allow_productive_wire_send": False,
     }
 
 

--- a/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/flatten_execute_authority_v1.py
+++ b/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/flatten_execute_authority_v1.py
@@ -1,0 +1,88 @@
+"""Dedicated §11.13.5 flatten-execute authority (confirm token + purpose).
+
+Invocation-scoped only. Standing live flags remain false. This module does
+not authorize GET, POST, or flatten execution. Missing/wrong/stale/wrong-purpose
+tokens deny. Implementation Owner-GOs are forbidden as execute tokens.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+FLATTEN_EXECUTE_PURPOSE_CANONICAL = "SECTION_11_13_5_FLATTEN_EXECUTE"
+FLATTEN_EXECUTE_CONFIRM_TOKEN_CANONICAL = "I_AUTHORIZE_SECTION_11_13_5_FLATTEN_EXECUTE"
+FLATTEN_EXECUTE_OWNER_GO_CANONICAL = "SECTION_11_13_5_FLATTEN_EXECUTE_OWNER_GO"
+FLATTEN_EXECUTE_AUTHORITY_KIND = "FLATTEN_EXECUTE_CONFIRM"
+
+# Mechanism expected-value only. Presence in source is not execute authorization.
+# Default supplied token remains empty/absent → deny.
+FORBIDDEN_FLATTEN_EXECUTE_OWNER_GOS: frozenset[str] = frozenset(
+    {
+        "SECTION_11_13_5_POST_Z2AU_PRODUCTIVE_LIVE_FLATTEN_WIRING_MAX_SAFE_SLICE_FAIL_CLOSED_NO_NETWORK_NO_GET_NO_POST_NO_EXECUTE",
+        "SECTION_11_13_5_Z2AP_PRODUCTIVE_LIVE_FLATTEN_PROVABILITY_NEXT_MAX_SAFE_SLICE_FAIL_CLOSED_NO_IMPLICIT_EXECUTE",
+        "SECTION_11_13_5_PRODUCTIVE_LIVE_FLATTEN_PROOF_PRE_EXECUTION_GATE_AND_RUNTIME_READINESS_ONLY",
+        "SECTION_11_13_5_Z2AP_PRODUCTIVE_LIVE_FLATTEN_PROVABILITY_NEXT_MAX_SAFE_SLICE_FAIL_CLOSED_NO_IMPLICIT_EXECUTE",
+        "OWNER_GO_SECTION_11_13_LIVE_CANARY_PRODUCTIVE_SURFACE_AUTHORING",
+        "OWNER_GO_LIVE_CANARY_MINIMUM_EXPOSURE",
+    }
+)
+
+
+class LiveCanaryFlattenExecuteAuthorityError(RuntimeError):
+    """Fail-closed flatten-execute authority violation."""
+
+
+def evaluate_flatten_execute_authority_v1(
+    *,
+    token: str | None,
+    purpose: str | None,
+    owner_go: str | None,
+) -> tuple[bool, tuple[str, ...]]:
+    """Return (accepted, deny_reasons). Never treats this implementation GO as execute."""
+    reasons: list[str] = []
+    supplied = str(token or "")
+    if not supplied.strip():
+        reasons.append("FLATTEN_EXECUTE_TOKEN_MISSING")
+    elif supplied != FLATTEN_EXECUTE_CONFIRM_TOKEN_CANONICAL:
+        reasons.append("FLATTEN_EXECUTE_TOKEN_MISMATCH")
+
+    purpose_norm = str(purpose or "").strip()
+    if not purpose_norm:
+        reasons.append("FLATTEN_EXECUTE_PURPOSE_MISSING")
+    elif purpose_norm != FLATTEN_EXECUTE_PURPOSE_CANONICAL:
+        reasons.append("FLATTEN_EXECUTE_PURPOSE_INVALID")
+
+    go = str(owner_go or "").strip()
+    if not go:
+        reasons.append("FLATTEN_EXECUTE_OWNER_GO_MISSING")
+    elif go in FORBIDDEN_FLATTEN_EXECUTE_OWNER_GOS:
+        reasons.append("FLATTEN_EXECUTE_OWNER_GO_FORBIDDEN")
+    elif "NO_EXECUTE" in go.upper() or "NO_IMPLICIT_EXECUTE" in go.upper():
+        reasons.append("FLATTEN_EXECUTE_OWNER_GO_FORBIDDEN")
+    elif "AUTHORING" in go.upper() or "WIRING" in go.upper() or "READINESS" in go.upper():
+        reasons.append("FLATTEN_EXECUTE_OWNER_GO_FORBIDDEN")
+    elif go != FLATTEN_EXECUTE_OWNER_GO_CANONICAL:
+        reasons.append("FLATTEN_EXECUTE_OWNER_GO_MISMATCH")
+
+    return (not reasons, tuple(reasons))
+
+
+def flatten_execute_authority_audit_v1(
+    *,
+    token: str | None,
+    purpose: str | None,
+    owner_go: str | None,
+) -> dict[str, Any]:
+    accepted, reasons = evaluate_flatten_execute_authority_v1(
+        token=token,
+        purpose=purpose,
+        owner_go=owner_go,
+    )
+    return {
+        "kind": FLATTEN_EXECUTE_AUTHORITY_KIND,
+        "accepted": accepted,
+        "reasons": list(reasons),
+        "purpose_canonical": FLATTEN_EXECUTE_PURPOSE_CANONICAL,
+        "token_supplied": bool(str(token or "").strip()),
+        "implementation_go_is_not_execute_token": True,
+    }

--- a/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/flatten_gated_submit_v1.py
+++ b/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/flatten_gated_submit_v1.py
@@ -1,0 +1,250 @@
+"""Auditable productive-flatten submit boundary.
+
+Send is reached only after a full pre-send receipt. Fake transports cannot
+masquerade. This slice never opens a network session and never claims
+LIVE_FLATTEN_PROVABILITY.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.constants_v1 import (
+    DEFAULT_INSTRUMENT_ID,
+    ENDPOINT_SUBMIT,
+    REUSED_BINDING_REST_HOST,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.flatten_limit_price_contract_v1 import (
+    LIVE_FLATTEN_PROVABILITY_STATUS,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.flatten_pre_send_gate_v1 import (
+    FlattenPreSendGateInputV1,
+    FlattenPreSendGateReceiptV1,
+    evaluate_flatten_pre_send_gate_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.flatten_productive_transport_v1 import (
+    GatedProductiveFlattenTransportV1,
+    LiveCanaryFlattenProductiveTransportError,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.flatten_submit_transport_v1 import (
+    DEDICATED_FLATTEN_TRANSPORT_LIVE_WIRE_ENABLED,
+    LIVE_FLATTEN_PROVABILITY,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.http_client_v1 import (
+    LiveCanaryHttpRequestV1,
+    LiveCanaryHttpResponseV1,
+    RecordingFakeCanaryTransportV1,
+)
+
+DEFAULT_REST_BASE = "https://eea.okx.com"
+
+
+class LiveCanaryFlattenGatedSubmitError(RuntimeError):
+    """Fail-closed productive flatten submit-boundary violation."""
+
+
+@dataclass(frozen=True)
+class FlattenGatedSubmitResultV1:
+    """Boundary result. send_completed is not venue proof."""
+
+    allowed: bool
+    send_attempted: bool
+    send_completed: bool
+    reasons: tuple[str, ...]
+    receipt: FlattenPreSendGateReceiptV1
+    response: LiveCanaryHttpResponseV1 | None
+    live_flatten_provability: str
+    productive_venue_proof: bool
+    transport_class: str
+    fake_transport_rejected: bool
+    duplicate_blocked: bool
+    retry_attempted: bool
+    network_used: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "allowed": self.allowed,
+            "send_attempted": self.send_attempted,
+            "send_completed": self.send_completed,
+            "reasons": list(self.reasons),
+            "live_flatten_provability": self.live_flatten_provability,
+            "productive_venue_proof": self.productive_venue_proof,
+            "transport_class": self.transport_class,
+            "fake_transport_rejected": self.fake_transport_rejected,
+            "duplicate_blocked": self.duplicate_blocked,
+            "retry_attempted": self.retry_attempted,
+            "network_used": self.network_used,
+            "DEDICATED_FLATTEN_TRANSPORT_LIVE_WIRE_ENABLED": (
+                DEDICATED_FLATTEN_TRANSPORT_LIVE_WIRE_ENABLED
+            ),
+            "LIVE_FLATTEN_PROVABILITY": LIVE_FLATTEN_PROVABILITY,
+            "receipt": self.receipt.to_dict(),
+        }
+
+
+@dataclass
+class FlattenGatedSubmitBoundaryV1:
+    """Single auditable send boundary. One-shot. No retry."""
+
+    rest_base: str = DEFAULT_REST_BASE
+    rest_host: str = REUSED_BINDING_REST_HOST
+    timeout_seconds: float = 10.0
+    _submitted: bool = field(default=False, init=False, repr=False)
+
+    def submit(
+        self,
+        *,
+        gate_input: FlattenPreSendGateInputV1,
+        transport: Any,
+    ) -> FlattenGatedSubmitResultV1:
+        receipt = evaluate_flatten_pre_send_gate_v1(gate_input)
+        transport_class = str(getattr(transport, "transport_class", type(transport).__name__))
+        fake = isinstance(transport, RecordingFakeCanaryTransportV1) or bool(
+            getattr(transport, "is_fake_offline_flatten_transport", False)
+        )
+        productive = bool(getattr(transport, "is_productive_flatten_transport", False))
+
+        def _denied(
+            extra: tuple[str, ...],
+            *,
+            fake_rejected: bool = False,
+            duplicate_blocked: bool = False,
+            send_attempted: bool = False,
+        ) -> FlattenGatedSubmitResultV1:
+            return FlattenGatedSubmitResultV1(
+                allowed=False,
+                send_attempted=send_attempted,
+                send_completed=False,
+                reasons=tuple(receipt.reasons) + extra,
+                receipt=receipt,
+                response=None,
+                live_flatten_provability=LIVE_FLATTEN_PROVABILITY_STATUS,
+                productive_venue_proof=False,
+                transport_class=transport_class,
+                fake_transport_rejected=fake_rejected,
+                duplicate_blocked=duplicate_blocked,
+                retry_attempted=False,
+                network_used=False,
+            )
+
+        if fake:
+            return _denied(("FAKE_TRANSPORT_CANNOT_MASQUERADE",), fake_rejected=True)
+        if not productive:
+            return _denied(("NOT_PRODUCTIVE_FLATTEN_TRANSPORT",))
+        if not receipt.allowed:
+            return _denied(())
+        if self._submitted:
+            return _denied(("DUPLICATE_POST_FORBIDDEN",), duplicate_blocked=True)
+        if not isinstance(receipt.request_body, dict) or not receipt.request_body:
+            return _denied(("REQUEST_BODY_MISSING",))
+        if str(self.rest_host or "") != REUSED_BINDING_REST_HOST:
+            return _denied(("REST_HOST_BINDING_MISMATCH",))
+        try:
+            transport.attach_pre_send_receipt(receipt)
+        except LiveCanaryFlattenProductiveTransportError as exc:
+            return _denied((str(exc),))
+        body_text = json.dumps(receipt.request_body, separators=(",", ":"), ensure_ascii=True)
+        endpoint = ENDPOINT_SUBMIT
+        url = f"{self.rest_base.rstrip('/')}{endpoint}"
+        request = LiveCanaryHttpRequestV1(
+            method="POST",
+            url=url,
+            host=self.rest_host,
+            endpoint=endpoint,
+            headers={"User-Agent": "PeakTrade-Section-11-13-5-FlattenWiring/1"},
+            timeout_seconds=self.timeout_seconds,
+            body_text=body_text,
+        )
+        self._submitted = True
+        try:
+            response = transport.send(request)
+        except LiveCanaryFlattenProductiveTransportError as exc:
+            return FlattenGatedSubmitResultV1(
+                allowed=True,
+                send_attempted=True,
+                send_completed=False,
+                reasons=(str(exc),),
+                receipt=receipt,
+                response=None,
+                live_flatten_provability=LIVE_FLATTEN_PROVABILITY_STATUS,
+                productive_venue_proof=False,
+                transport_class=transport_class,
+                fake_transport_rejected=False,
+                duplicate_blocked="DUPLICATE_POST_FORBIDDEN" in str(exc),
+                retry_attempted=False,
+                network_used=False,
+            )
+        return FlattenGatedSubmitResultV1(
+            allowed=True,
+            send_attempted=True,
+            send_completed=True,
+            reasons=(),
+            receipt=receipt,
+            response=response,
+            live_flatten_provability=LIVE_FLATTEN_PROVABILITY_STATUS,
+            productive_venue_proof=False,
+            transport_class=transport_class,
+            fake_transport_rejected=False,
+            duplicate_blocked=False,
+            retry_attempted=False,
+            network_used=False,
+        )
+
+
+def submit_productive_flatten_v1(
+    *,
+    gate_input: FlattenPreSendGateInputV1,
+    transport: Any,
+    rest_base: str = DEFAULT_REST_BASE,
+    rest_host: str = REUSED_BINDING_REST_HOST,
+) -> FlattenGatedSubmitResultV1:
+    """One-shot helper around FlattenGatedSubmitBoundaryV1."""
+    boundary = FlattenGatedSubmitBoundaryV1(rest_base=rest_base, rest_host=rest_host)
+    return boundary.submit(gate_input=gate_input, transport=transport)
+
+
+def default_flatten_execute_gate_input_from_runner_v1(
+    *,
+    live_authorized: bool,
+    live_enabled: bool,
+    live_armed: bool,
+    flatten_live_wire_enabled: bool,
+    allow_productive_wire_send: bool,
+    flatten_execute_token: str | None,
+    flatten_execute_purpose: str | None,
+    flatten_execute_owner_go: str | None,
+    flatten_execute_bound_origin_main_sha: str | None,
+    positions_payload: Mapping[str, Any] | None,
+    pending_orders_payload: Mapping[str, Any] | None,
+    price_input: Any,
+    owner_go: str,
+    origin_main_sha: str,
+    instrument_id: str = DEFAULT_INSTRUMENT_ID,
+) -> FlattenPreSendGateInputV1 | None:
+    """Build a gate input. Returns None when price_input is absent (do not invent)."""
+    if price_input is None:
+        return None
+    return FlattenPreSendGateInputV1(
+        live_authorized=bool(live_authorized),
+        live_enabled=bool(live_enabled),
+        live_armed=bool(live_armed),
+        flatten_live_wire_enabled=bool(flatten_live_wire_enabled),
+        allow_productive_wire_send=bool(allow_productive_wire_send),
+        flatten_execute_token=flatten_execute_token,
+        flatten_execute_purpose=flatten_execute_purpose,
+        flatten_execute_owner_go=flatten_execute_owner_go,
+        positions_payload=dict(positions_payload or {}),
+        pending_orders_payload=pending_orders_payload,
+        price_input=price_input,
+        owner_go=str(owner_go or ""),
+        origin_main_sha=str(origin_main_sha or ""),
+        flatten_execute_bound_origin_main_sha=flatten_execute_bound_origin_main_sha,
+        instrument_id=instrument_id or DEFAULT_INSTRUMENT_ID,
+    )
+
+
+def default_gated_productive_flatten_transport_v1() -> GatedProductiveFlattenTransportV1:
+    """Runner default. Network session remains unauthorized."""
+    return GatedProductiveFlattenTransportV1()

--- a/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/flatten_pre_send_gate_v1.py
+++ b/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/flatten_pre_send_gate_v1.py
@@ -1,0 +1,446 @@
+"""Fail-closed pre-send gate object for productive flatten.
+
+Every material predicate is independently recorded. A generic
+allow_productive_wire_send flag is never sufficient. This evaluator
+never GETs, never POSTs, and never claims LIVE_FLATTEN_PROVABILITY.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from src.ops.pre_submit_open_position_cap_v1 import (
+    PreSubmitOpenPositionCapErrorV1,
+    assert_pre_submit_open_position_cap_allows_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.constants_v1 import (
+    DEFAULT_INSTRUMENT_ID,
+    LIVE_ARMED,
+    LIVE_AUTHORIZED,
+    LIVE_ENABLED,
+    LiveCanaryInstrumentBindingError,
+    assert_live_canary_instrument_binding_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.flatten_execute_authority_v1 import (
+    evaluate_flatten_execute_authority_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.flatten_limit_price_contract_v1 import (
+    FRESHNESS_THRESHOLD_MS,
+    FlattenPriceInputV1,
+    FlattenPricePermitV1,
+    LIVE_FLATTEN_PROVABILITY_STATUS,
+    evaluate_canary_flatten_limit_price_contract_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.flatten_orchestration_contract_v1 import (
+    CanaryFlattenOrderPlanV1,
+    CanaryFlattenSubmitPermitV1,
+    evaluate_canary_flatten_orchestration_contract_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.flatten_submit_transport_v1 import (
+    DEDICATED_FLATTEN_TRANSPORT_LIVE_WIRE_ENABLED,
+    LiveCanaryFlattenSubmitTransportError,
+    build_canary_flatten_submit_request_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.pre_submit_state_v1 import (
+    LiveCanaryPositionObservationError,
+    LiveCanaryPreSubmitStateError,
+    observe_target_position_flatten_candidate_v1,
+    open_order_instruments_v1,
+)
+
+GATE_NAMES: tuple[str, ...] = (
+    "STANDING_LIVE_FLAGS",
+    "LIVE_AUTHORIZED_CLAIM",
+    "LIVE_ENABLED_CLAIM",
+    "LIVE_ARMED_CLAIM",
+    "FLATTEN_LIVE_WIRE_CLAIM",
+    "ALLOW_PRODUCTIVE_WIRE_SEND",
+    "FLATTEN_EXECUTE_AUTHORITY",
+    "FLATTEN_EXECUTE_BOUND_SHA",
+    "INSTRUMENT_BINDING",
+    "PRODUCTIVE_POSITION_OBSERVED",
+    "PRE_POS_NONZERO",
+    "SINGLE_SELECTED_INSTRUMENT",
+    "OPEN_ORDER_CONFLICT",
+    "B8_CAP",
+    "CLOSE_SIDE",
+    "FLATTEN_QTY",
+    "REDUCE_ONLY",
+    "LIMIT_ONLY",
+    "QUOTE_FRESHNESS_5000MS",
+    "LIMIT_PRICE_POLICY",
+    "OVERSHOOT_FLIP",
+    "ONE_SHOT_NO_RETRY",
+    "DUPLICATE_POST_PROTECTION",
+)
+
+
+@dataclass(frozen=True)
+class FlattenPreSendGateInputV1:
+    """Caller-supplied runtime claims and snapshots. No network fetch."""
+
+    live_authorized: bool
+    live_enabled: bool
+    live_armed: bool
+    flatten_live_wire_enabled: bool
+    allow_productive_wire_send: bool
+    flatten_execute_token: str | None
+    flatten_execute_purpose: str | None
+    flatten_execute_owner_go: str | None
+    positions_payload: Mapping[str, Any]
+    pending_orders_payload: Mapping[str, Any] | None
+    price_input: FlattenPriceInputV1
+    owner_go: str
+    origin_main_sha: str
+    flatten_execute_bound_origin_main_sha: str | None = None
+    instrument_id: str = DEFAULT_INSTRUMENT_ID
+    one_shot_no_retry: bool = True
+    duplicate_post_protection: bool = True
+
+
+@dataclass(frozen=True)
+class FlattenPreSendGateReceiptV1:
+    """Auditable pre-send decision. allowed=True is not venue proof."""
+
+    allowed: bool
+    reasons: tuple[str, ...]
+    audit_decisions: tuple[tuple[str, str], ...]
+    observed_signed_pos: str | None
+    close_side: str | None
+    qty: str | None
+    reduce_only: bool
+    ord_type: str | None
+    limit_px: str | None
+    td_mode: str | None
+    request_body: dict[str, Any] | None
+    permit: CanaryFlattenSubmitPermitV1 | None
+    plan: CanaryFlattenOrderPlanV1 | None
+    price_permit: FlattenPricePermitV1 | None
+    gate_digest: str
+    live_flatten_provability: str
+    productive_venue_proof: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "allowed": self.allowed,
+            "reasons": list(self.reasons),
+            "audit_decisions": [list(item) for item in self.audit_decisions],
+            "observed_signed_pos": self.observed_signed_pos,
+            "close_side": self.close_side,
+            "qty": self.qty,
+            "reduce_only": self.reduce_only,
+            "ord_type": self.ord_type,
+            "limit_px": self.limit_px,
+            "td_mode": self.td_mode,
+            "request_body": self.request_body,
+            "gate_digest": self.gate_digest,
+            "live_flatten_provability": self.live_flatten_provability,
+            "productive_venue_proof": self.productive_venue_proof,
+        }
+
+
+def _decision(name: str, ok: bool, reason: str = "") -> tuple[str, str]:
+    if ok:
+        return (name, "PASS")
+    return (name, f"DENY:{reason}")
+
+
+def evaluate_flatten_pre_send_gate_v1(
+    gate: FlattenPreSendGateInputV1,
+) -> FlattenPreSendGateReceiptV1:
+    """Evaluate the full productive flatten pre-send object. Never transmits."""
+    decisions: list[tuple[str, str]] = []
+    reasons: list[str] = []
+
+    standing_ok = not (LIVE_AUTHORIZED or LIVE_ENABLED or LIVE_ARMED)
+    standing_ok = standing_ok and (DEDICATED_FLATTEN_TRANSPORT_LIVE_WIRE_ENABLED is False)
+    if not standing_ok:
+        reasons.append("STANDING_LIVE_FLAGS_MUST_REMAIN_FALSE")
+    decisions.append(_decision("STANDING_LIVE_FLAGS", standing_ok, "STANDING_LIVE_FLAGS_UNLOCKED"))
+
+    if gate.live_authorized is not True:
+        reasons.append("LIVE_AUTHORIZED_CLAIM_FALSE")
+        decisions.append(_decision("LIVE_AUTHORIZED_CLAIM", False, "LIVE_AUTHORIZED_CLAIM_FALSE"))
+    else:
+        decisions.append(_decision("LIVE_AUTHORIZED_CLAIM", True))
+
+    if gate.live_enabled is not True:
+        reasons.append("LIVE_ENABLED_CLAIM_FALSE")
+        decisions.append(_decision("LIVE_ENABLED_CLAIM", False, "LIVE_ENABLED_CLAIM_FALSE"))
+    else:
+        decisions.append(_decision("LIVE_ENABLED_CLAIM", True))
+
+    if gate.live_armed is not True:
+        reasons.append("LIVE_ARMED_CLAIM_FALSE")
+        decisions.append(_decision("LIVE_ARMED_CLAIM", False, "LIVE_ARMED_CLAIM_FALSE"))
+    else:
+        decisions.append(_decision("LIVE_ARMED_CLAIM", True))
+
+    if gate.flatten_live_wire_enabled is not True:
+        reasons.append("FLATTEN_LIVE_WIRE_CLAIM_FALSE")
+        decisions.append(
+            _decision("FLATTEN_LIVE_WIRE_CLAIM", False, "FLATTEN_LIVE_WIRE_CLAIM_FALSE")
+        )
+    else:
+        decisions.append(_decision("FLATTEN_LIVE_WIRE_CLAIM", True))
+
+    if gate.allow_productive_wire_send is not True:
+        reasons.append("ALLOW_PRODUCTIVE_WIRE_SEND_FALSE")
+        decisions.append(
+            _decision("ALLOW_PRODUCTIVE_WIRE_SEND", False, "ALLOW_PRODUCTIVE_WIRE_SEND_FALSE")
+        )
+    else:
+        decisions.append(_decision("ALLOW_PRODUCTIVE_WIRE_SEND", True))
+
+    auth_ok, auth_reasons = evaluate_flatten_execute_authority_v1(
+        token=gate.flatten_execute_token,
+        purpose=gate.flatten_execute_purpose,
+        owner_go=gate.flatten_execute_owner_go,
+    )
+    if not auth_ok:
+        reasons.extend(auth_reasons)
+        decisions.append(
+            _decision(
+                "FLATTEN_EXECUTE_AUTHORITY",
+                False,
+                ",".join(auth_reasons) or "FLATTEN_EXECUTE_AUTHORITY_DENIED",
+            )
+        )
+    else:
+        decisions.append(_decision("FLATTEN_EXECUTE_AUTHORITY", True))
+
+    bound = str(gate.flatten_execute_bound_origin_main_sha or "").strip().lower()
+    expected_sha = str(gate.origin_main_sha or "").strip().lower()
+    if not bound:
+        reasons.append("FLATTEN_EXECUTE_BOUND_SHA_MISSING")
+        decisions.append(
+            _decision("FLATTEN_EXECUTE_BOUND_SHA", False, "FLATTEN_EXECUTE_BOUND_SHA_MISSING")
+        )
+    elif len(bound) != 40 or any(ch not in "0123456789abcdef" for ch in bound):
+        reasons.append("FLATTEN_EXECUTE_BOUND_SHA_MALFORMED")
+        decisions.append(
+            _decision("FLATTEN_EXECUTE_BOUND_SHA", False, "FLATTEN_EXECUTE_BOUND_SHA_MALFORMED")
+        )
+    elif bound != expected_sha:
+        reasons.append("FLATTEN_EXECUTE_BOUND_SHA_STALE")
+        decisions.append(
+            _decision("FLATTEN_EXECUTE_BOUND_SHA", False, "FLATTEN_EXECUTE_BOUND_SHA_STALE")
+        )
+    else:
+        decisions.append(_decision("FLATTEN_EXECUTE_BOUND_SHA", True))
+
+    target = str(gate.instrument_id or "").strip()
+    try:
+        assert_live_canary_instrument_binding_v1(instrument_id=target)
+        decisions.append(_decision("INSTRUMENT_BINDING", True))
+    except LiveCanaryInstrumentBindingError as exc:
+        reasons.append(f"INSTRUMENT_BINDING:{exc}")
+        decisions.append(_decision("INSTRUMENT_BINDING", False, str(exc)))
+
+    observed_pos: str | None = None
+    close_side: str | None = None
+    qty: str | None = None
+    permit: CanaryFlattenSubmitPermitV1 | None = None
+    plan: CanaryFlattenOrderPlanV1 | None = None
+    price_permit: FlattenPricePermitV1 | None = None
+    body: dict[str, Any] | None = None
+
+    try:
+        observed = observe_target_position_flatten_candidate_v1(
+            positions_payload=gate.positions_payload,
+            instrument_id=target or DEFAULT_INSTRUMENT_ID,
+        )
+        observed_pos = format(observed.signed_pos, "f")
+        close_side = observed.candidate_flatten_side
+        qty = format(observed.candidate_flatten_qty, "f")
+        if observed.signed_pos == 0:
+            reasons.append("PRE_POS_ZERO")
+            decisions.append(_decision("PRODUCTIVE_POSITION_OBSERVED", False, "PRE_POS_ZERO"))
+            decisions.append(_decision("PRE_POS_NONZERO", False, "PRE_POS_ZERO"))
+        else:
+            decisions.append(_decision("PRODUCTIVE_POSITION_OBSERVED", True))
+            decisions.append(_decision("PRE_POS_NONZERO", True))
+        if observed.instrument_id != DEFAULT_INSTRUMENT_ID:
+            reasons.append("SINGLE_SELECTED_INSTRUMENT_MISMATCH")
+            decisions.append(
+                _decision(
+                    "SINGLE_SELECTED_INSTRUMENT",
+                    False,
+                    "SINGLE_SELECTED_INSTRUMENT_MISMATCH",
+                )
+            )
+        else:
+            decisions.append(_decision("SINGLE_SELECTED_INSTRUMENT", True))
+    except LiveCanaryPositionObservationError as exc:
+        reasons.append(f"POSITION_OBSERVATION:{exc}")
+        decisions.append(_decision("PRODUCTIVE_POSITION_OBSERVED", False, str(exc)))
+        decisions.append(_decision("PRE_POS_NONZERO", False, str(exc)))
+        decisions.append(_decision("SINGLE_SELECTED_INSTRUMENT", False, str(exc)))
+
+    if gate.pending_orders_payload is None:
+        reasons.append("OPEN_ORDER_STATE_UNAVAILABLE")
+        decisions.append(_decision("OPEN_ORDER_CONFLICT", False, "OPEN_ORDER_STATE_UNAVAILABLE"))
+    else:
+        try:
+            open_inst = open_order_instruments_v1(gate.pending_orders_payload)
+            if open_inst:
+                reasons.append("OPEN_ORDER_CONFLICT")
+                decisions.append(_decision("OPEN_ORDER_CONFLICT", False, "OPEN_ORDER_PRESENT"))
+            else:
+                decisions.append(_decision("OPEN_ORDER_CONFLICT", True))
+        except LiveCanaryPreSubmitStateError as exc:
+            reasons.append(f"OPEN_ORDER_STATE:{exc}")
+            decisions.append(_decision("OPEN_ORDER_CONFLICT", False, str(exc)))
+
+    try:
+        assert_pre_submit_open_position_cap_allows_v1(
+            target_instrument_id=target or DEFAULT_INSTRUMENT_ID,
+            positions_payload=gate.positions_payload,
+        )
+        decisions.append(_decision("B8_CAP", True))
+    except PreSubmitOpenPositionCapErrorV1 as exc:
+        reasons.append(f"B8_CAP:{exc.reason_code}")
+        decisions.append(_decision("B8_CAP", False, exc.reason_code))
+
+    orch = evaluate_canary_flatten_orchestration_contract_v1(
+        positions_payload=gate.positions_payload,
+        owner_go=gate.owner_go,
+        origin_main_sha=gate.origin_main_sha,
+        instrument_id=target or DEFAULT_INSTRUMENT_ID,
+    )
+    if orch.permit is None or orch.flatten_plan is None:
+        reasons.append("FLATTEN_ORCHESTRATION_DENIED")
+        decisions.append(_decision("CLOSE_SIDE", False, "ORCHESTRATION_DENIED"))
+        decisions.append(_decision("FLATTEN_QTY", False, "ORCHESTRATION_DENIED"))
+    else:
+        permit = orch.permit
+        plan = orch.flatten_plan
+        if close_side and plan.side != close_side:
+            reasons.append("CLOSE_SIDE_MISMATCH")
+            decisions.append(_decision("CLOSE_SIDE", False, "CLOSE_SIDE_MISMATCH"))
+        else:
+            decisions.append(_decision("CLOSE_SIDE", True))
+        if qty and str(plan.quantity) != qty:
+            reasons.append("FLATTEN_QTY_MISMATCH")
+            decisions.append(_decision("FLATTEN_QTY", False, "FLATTEN_QTY_MISMATCH"))
+        else:
+            decisions.append(_decision("FLATTEN_QTY", True))
+
+    price_decision = evaluate_canary_flatten_limit_price_contract_v1(gate.price_input)
+    if price_decision.permit is None:
+        reasons.extend(price_decision.reject_reasons or ("LIMIT_PRICE_POLICY_DENIED",))
+        decisions.append(
+            _decision(
+                "LIMIT_PRICE_POLICY",
+                False,
+                ",".join(price_decision.reject_reasons) or "LIMIT_PRICE_POLICY_DENIED",
+            )
+        )
+        freshness_fail = "STALE_QUOTE" in price_decision.reject_reasons
+        decisions.append(
+            _decision(
+                "QUOTE_FRESHNESS_5000MS",
+                not freshness_fail and price_decision.permit is not None,
+                "STALE_OR_INVALID_QUOTE",
+            )
+        )
+    else:
+        price_permit = price_decision.permit
+        decisions.append(_decision("LIMIT_PRICE_POLICY", True))
+        decisions.append(_decision("QUOTE_FRESHNESS_5000MS", True))
+        supplied_threshold = str(gate.price_input.freshness_threshold_ms or "").strip()
+        if supplied_threshold and supplied_threshold != str(FRESHNESS_THRESHOLD_MS):
+            reasons.append("FRESHNESS_THRESHOLD_NOT_CANONICAL")
+            decisions[-1] = _decision(
+                "QUOTE_FRESHNESS_5000MS", False, "FRESHNESS_THRESHOLD_NOT_CANONICAL"
+            )
+
+    if permit is not None and plan is not None and price_permit is not None:
+        try:
+            body = build_canary_flatten_submit_request_v1(
+                permit=permit,
+                plan=plan,
+                price_permit=price_permit,
+                positions_payload=gate.positions_payload,
+                instrument_id=target or DEFAULT_INSTRUMENT_ID,
+            )
+            if body.get("reduceOnly") is not True:
+                reasons.append("REDUCE_ONLY_REQUIRED")
+                decisions.append(_decision("REDUCE_ONLY", False, "REDUCE_ONLY_REQUIRED"))
+            else:
+                decisions.append(_decision("REDUCE_ONLY", True))
+            if str(body.get("ordType") or "").lower() != "limit":
+                reasons.append("LIMIT_ONLY_REQUIRED")
+                decisions.append(_decision("LIMIT_ONLY", False, "LIMIT_ONLY_REQUIRED"))
+            else:
+                decisions.append(_decision("LIMIT_ONLY", True))
+        except LiveCanaryFlattenSubmitTransportError as exc:
+            reasons.append(str(exc))
+            if "OVERSIZE" in str(exc) or "PARTIAL" in str(exc):
+                decisions.append(_decision("OVERSHOOT_FLIP", False, str(exc)))
+            decisions.append(_decision("REDUCE_ONLY", False, str(exc)))
+            decisions.append(_decision("LIMIT_ONLY", False, str(exc)))
+    else:
+        decisions.append(_decision("REDUCE_ONLY", False, "REQUEST_NOT_CONSTRUCTED"))
+        decisions.append(_decision("LIMIT_ONLY", False, "REQUEST_NOT_CONSTRUCTED"))
+
+    overshoot_ok = (
+        body is not None
+        and qty is not None
+        and str(body.get("sz") or "") == qty
+        and "OVERSIZE_FLATTEN" not in reasons
+        and "PARTIAL_FLATTEN_FORBIDDEN" not in reasons
+        and "OPEN_ORDER_CONFLICT" not in reasons
+        and "B8_CAP" not in "".join(reasons)
+    )
+    if overshoot_ok:
+        decisions.append(_decision("OVERSHOOT_FLIP", True))
+    elif all(item[0] != "OVERSHOOT_FLIP" for item in decisions):
+        decisions.append(_decision("OVERSHOOT_FLIP", False, "OVERSHOOT_OR_FLIP_UNPROVEN"))
+        if "OVERSHOOT_OR_FLIP_UNPROVEN" not in reasons and body is None:
+            reasons.append("OVERSHOOT_OR_FLIP_UNPROVEN")
+
+    if gate.one_shot_no_retry is not True:
+        reasons.append("ONE_SHOT_NO_RETRY_REQUIRED")
+        decisions.append(_decision("ONE_SHOT_NO_RETRY", False, "ONE_SHOT_NO_RETRY_REQUIRED"))
+    else:
+        decisions.append(_decision("ONE_SHOT_NO_RETRY", True))
+
+    if gate.duplicate_post_protection is not True:
+        reasons.append("DUPLICATE_POST_PROTECTION_REQUIRED")
+        decisions.append(
+            _decision("DUPLICATE_POST_PROTECTION", False, "DUPLICATE_POST_PROTECTION_REQUIRED")
+        )
+    else:
+        decisions.append(_decision("DUPLICATE_POST_PROTECTION", True))
+
+    allowed = not reasons
+    digest_material = json.dumps(
+        {"allowed": allowed, "reasons": reasons, "decisions": decisions},
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    digest = hashlib.sha256(digest_material.encode("utf-8")).hexdigest()
+    return FlattenPreSendGateReceiptV1(
+        allowed=allowed,
+        reasons=tuple(reasons),
+        audit_decisions=tuple(decisions),
+        observed_signed_pos=observed_pos,
+        close_side=close_side or (None if body is None else str(body.get("side") or "").upper()),
+        qty=qty,
+        reduce_only=bool(body is not None and body.get("reduceOnly") is True),
+        ord_type=None if body is None else str(body.get("ordType") or ""),
+        limit_px=None if body is None else str(body.get("px") or ""),
+        td_mode=None if body is None else str(body.get("tdMode") or ""),
+        request_body=body,
+        permit=permit,
+        plan=plan,
+        price_permit=price_permit,
+        gate_digest=digest,
+        live_flatten_provability=LIVE_FLATTEN_PROVABILITY_STATUS,
+        productive_venue_proof=False,
+    )

--- a/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/flatten_productive_transport_v1.py
+++ b/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/flatten_productive_transport_v1.py
@@ -1,0 +1,124 @@
+"""Dedicated productive flatten transport classes.
+
+Distinct from RecordingFakeCanaryTransportV1 and UrllibLiveCanaryTransportV1.
+Default: no network session. Send requires an attached passing pre-send receipt.
+This slice never authorizes urllib/network send.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.http_client_v1 import (
+    LiveCanaryHttpError,
+    LiveCanaryHttpRequestV1,
+    LiveCanaryHttpResponseV1,
+    sanitize_redirect_location_v1,
+)
+
+TRANSPORT_CLASS_PRODUCTIVE_FLATTEN_GATED = "PRODUCTIVE_FLATTEN_GATED"
+TRANSPORT_CLASS_PRODUCTIVE_FLATTEN_GATED_RECORDING = "PRODUCTIVE_FLATTEN_GATED_RECORDING"
+
+
+class FlattenPreSendReceiptLike(Protocol):
+    allowed: bool
+    gate_digest: str
+
+
+class LiveCanaryFlattenProductiveTransportError(RuntimeError):
+    """Fail-closed productive flatten transport violation."""
+
+
+def _response(
+    *,
+    request: LiveCanaryHttpRequestV1,
+    status_code: int,
+    body: bytes,
+) -> LiveCanaryHttpResponseV1:
+    wire = request.body_text.encode("utf-8") if request.body_text else b""
+    return LiveCanaryHttpResponseV1(
+        status_code=status_code,
+        body_bytes=body,
+        elapsed_seconds=0.01,
+        endpoint=request.endpoint,
+        method=request.method,
+        send_attempted=True,
+        wire_body_sha256=hashlib.sha256(wire).hexdigest(),
+        wire_body_byte_len=len(wire),
+        redirect_followed=False,
+        redirect_status=None,
+        redirect_location=sanitize_redirect_location_v1(None),
+        response_headers_safe={},
+    )
+
+
+@dataclass
+class RecordingProductiveFlattenTransportV1:
+    """Test double of the productive flatten class. Records send; no network."""
+
+    is_productive_flatten_transport: bool = True
+    is_fake_offline_flatten_transport: bool = False
+    transport_class: str = TRANSPORT_CLASS_PRODUCTIVE_FLATTEN_GATED_RECORDING
+    venue_live_contact: bool = False
+    network_session_authorized: bool = False
+    calls: list[LiveCanaryHttpRequestV1] = field(default_factory=list)
+    post_body: bytes = (
+        b'{"code":"0","data":[{"sCode":"0","ordId":"synthetic-flatten","clOrdId":"x","sz":"1"}]}'
+    )
+    post_status_code: int = 200
+    _receipt: FlattenPreSendReceiptLike | None = field(default=None, init=False, repr=False)
+
+    def attach_pre_send_receipt(self, receipt: FlattenPreSendReceiptLike) -> None:
+        if receipt is None or not bool(receipt.allowed):
+            raise LiveCanaryFlattenProductiveTransportError("PRODUCTIVE_SEND_RECEIPT_NOT_ALLOWED")
+        self._receipt = receipt
+
+    def send(self, request: LiveCanaryHttpRequestV1) -> LiveCanaryHttpResponseV1:
+        if self._receipt is None or not bool(self._receipt.allowed):
+            raise LiveCanaryFlattenProductiveTransportError("PRODUCTIVE_SEND_WITHOUT_GATE_RECEIPT")
+        if self.calls:
+            raise LiveCanaryFlattenProductiveTransportError("DUPLICATE_POST_FORBIDDEN")
+        self.calls.append(request)
+        return _response(
+            request=request,
+            status_code=int(self.post_status_code),
+            body=self.post_body,
+        )
+
+
+@dataclass
+class GatedProductiveFlattenTransportV1:
+    """Productive flatten transport. Network session defaults unauthorized.
+
+    Even with a passing gate receipt, urllib is not opened unless
+    network_session_authorized is independently True. This wiring slice
+    never sets that flag.
+    """
+
+    is_productive_flatten_transport: bool = True
+    is_fake_offline_flatten_transport: bool = False
+    transport_class: str = TRANSPORT_CLASS_PRODUCTIVE_FLATTEN_GATED
+    venue_live_contact: bool = True
+    network_session_authorized: bool = False
+    _receipt: FlattenPreSendReceiptLike | None = field(default=None, init=False, repr=False)
+    _sent: bool = field(default=False, init=False, repr=False)
+
+    def attach_pre_send_receipt(self, receipt: FlattenPreSendReceiptLike) -> None:
+        if receipt is None or not bool(receipt.allowed):
+            raise LiveCanaryFlattenProductiveTransportError("PRODUCTIVE_SEND_RECEIPT_NOT_ALLOWED")
+        self._receipt = receipt
+
+    def send(self, request: LiveCanaryHttpRequestV1) -> LiveCanaryHttpResponseV1:
+        del request
+        if self._receipt is None or not bool(self._receipt.allowed):
+            raise LiveCanaryFlattenProductiveTransportError("PRODUCTIVE_SEND_WITHOUT_GATE_RECEIPT")
+        if self._sent:
+            raise LiveCanaryFlattenProductiveTransportError("DUPLICATE_POST_FORBIDDEN")
+        self._sent = True
+        if not self.network_session_authorized:
+            raise LiveCanaryFlattenProductiveTransportError(
+                "PRODUCTIVE_NETWORK_SESSION_NOT_AUTHORIZED"
+            )
+        raise LiveCanaryHttpError("PRODUCTIVE_FLATTEN_URLLIB_NOT_AUTHORIZED_BY_WIRING_SLICE")

--- a/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/runner_v1.py
+++ b/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/runner_v1.py
@@ -62,6 +62,17 @@ from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.submit_transport_v1
 from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.trade_permission_forensic_v1 import (
     build_trade_permission_forensic_v1,
 )
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.flatten_gated_submit_v1 import (
+    FlattenGatedSubmitBoundaryV1,
+    default_flatten_execute_gate_input_from_runner_v1,
+    default_gated_productive_flatten_transport_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.flatten_submit_transport_v1 import (
+    LIVE_FLATTEN_PROVABILITY,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.constants_v1 import (
+    DEFAULT_INSTRUMENT_ID as _FLATTEN_DEFAULT_INSTRUMENT_ID,
+)
 
 
 class LiveCanaryRunnerError(RuntimeError):
@@ -106,9 +117,17 @@ def run_section_11_13_5_live_canary_minimum_exposure_v1(
     vault_backend: Any = None,
     vault_file: str | None = None,
     live_canary_cybersecurity_gate: str = "PASS",
+    flatten_execute_token: str | None = None,
+    flatten_execute_purpose: str | None = None,
+    flatten_execute_owner_go: str | None = None,
+    flatten_execute_bound_origin_main_sha: str | None = None,
+    flatten_live_wire_enabled: bool = False,
+    positions_payload: Mapping[str, Any] | None = None,
+    pending_orders_payload: Mapping[str, Any] | None = None,
+    price_input: Any = None,
 ) -> LiveCanaryRunnerResultV1:
     mode_norm = str(mode or "").strip().lower()
-    if mode_norm not in {"preflight", "forensic", "execute"}:
+    if mode_norm not in {"preflight", "forensic", "execute", "flatten_execute"}:
         raise LiveCanaryRunnerError(f"UNKNOWN_MODE:{mode}")
 
     if CAPABILITY_11_9_LIVE_CANARY_ACTIVATED or not CAPABILITY_11_9_REMAINS_FIXTURE_ONLY:
@@ -136,6 +155,27 @@ def run_section_11_13_5_live_canary_minimum_exposure_v1(
         )
     except LiveCanaryConfigError as exc:
         raise LiveCanaryRunnerError(str(exc)) from exc
+
+    if mode_norm == "flatten_execute":
+        return _run_flatten_execute_mode_v1(
+            cfg=cfg,
+            origin_main_sha=origin_main_sha,
+            executed_code_sha=executed_code_sha,
+            owner_go=owner_go,
+            live_canary_authorized=bool(live_canary_authorized),
+            live_enabled=live_enabled,
+            live_armed=live_armed,
+            allow_productive_wire_send=allow_productive_wire_send,
+            transport=transport,
+            flatten_execute_token=flatten_execute_token,
+            flatten_execute_purpose=flatten_execute_purpose,
+            flatten_execute_owner_go=flatten_execute_owner_go,
+            flatten_execute_bound_origin_main_sha=flatten_execute_bound_origin_main_sha,
+            flatten_live_wire_enabled=flatten_live_wire_enabled,
+            positions_payload=positions_payload,
+            pending_orders_payload=pending_orders_payload,
+            price_input=price_input,
+        )
 
     repo = _repo_root()
     forensic = prove_forensic_classification_contract_v1(repo_root=repo)
@@ -282,6 +322,107 @@ def run_section_11_13_5_live_canary_minimum_exposure_v1(
                 classify_from_sealed_evidence_roots_v1(repo_root=repo).get("ok")
             ),
         },
+    )
+
+
+def _run_flatten_execute_mode_v1(
+    *,
+    cfg: Any,
+    origin_main_sha: str,
+    executed_code_sha: str | None,
+    owner_go: str | None,
+    live_canary_authorized: bool,
+    live_enabled: bool,
+    live_armed: bool,
+    allow_productive_wire_send: bool,
+    transport: Any,
+    flatten_execute_token: str | None,
+    flatten_execute_purpose: str | None,
+    flatten_execute_owner_go: str | None,
+    flatten_execute_bound_origin_main_sha: str | None,
+    flatten_live_wire_enabled: bool,
+    positions_payload: Mapping[str, Any] | None,
+    pending_orders_payload: Mapping[str, Any] | None,
+    price_input: Any,
+) -> LiveCanaryRunnerResultV1:
+    """Explicit flatten_execute only. Never runs on preflight/forensic/execute."""
+    payload_cfg = dict(getattr(cfg, "payload", {}) or {})
+    token = flatten_execute_token
+    if token is None:
+        token = str(payload_cfg.get("flatten_execute_token") or "")
+    purpose = flatten_execute_purpose
+    if purpose is None:
+        purpose = str(payload_cfg.get("flatten_execute_purpose") or "")
+    flatten_go = flatten_execute_owner_go
+    if flatten_go is None:
+        flatten_go = str(payload_cfg.get("flatten_execute_owner_go") or "")
+    bound = flatten_execute_bound_origin_main_sha
+    if bound is None:
+        bound = str(payload_cfg.get("flatten_execute_bound_origin_main_sha") or "") or None
+    wire = bool(flatten_live_wire_enabled) or bool(payload_cfg.get("flatten_live_wire_enabled"))
+    instrument_id = str(payload_cfg.get("instrument_id") or "").strip() or None
+    if instrument_id is None:
+        from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.constants_v1 import (
+            DEFAULT_INSTRUMENT_ID,
+        )
+
+        instrument_id = DEFAULT_INSTRUMENT_ID
+    flatten_transport = (
+        transport if transport is not None else default_gated_productive_flatten_transport_v1()
+    )
+    if price_input is None:
+        result_payload = {
+            "ok": False,
+            "mode": "flatten_execute",
+            "send_attempted": False,
+            "send_completed": False,
+            "reasons": ["RUNTIME_PRICE_INPUT_UNAVAILABLE"],
+            "LIVE_FLATTEN_PROVABILITY": LIVE_FLATTEN_PROVABILITY,
+            "NETWORK_EFFECT": "NONE",
+            "PRODUCTIVE_VENUE_PROOF": False,
+            "origin_main_sha": origin_main_sha,
+            "executed_code_sha": executed_code_sha or origin_main_sha,
+            "owner_go_observed": owner_go,
+        }
+        return LiveCanaryRunnerResultV1(ok=False, mode="flatten_execute", payload=result_payload)
+    gate_input = default_flatten_execute_gate_input_from_runner_v1(
+        live_authorized=bool(live_canary_authorized),
+        live_enabled=bool(live_enabled),
+        live_armed=bool(live_armed),
+        flatten_live_wire_enabled=wire,
+        allow_productive_wire_send=bool(allow_productive_wire_send),
+        flatten_execute_token=token,
+        flatten_execute_purpose=purpose,
+        flatten_execute_owner_go=flatten_go,
+        flatten_execute_bound_origin_main_sha=bound,
+        positions_payload=positions_payload,
+        pending_orders_payload=pending_orders_payload,
+        price_input=price_input,
+        owner_go=str(owner_go or ""),
+        origin_main_sha=origin_main_sha,
+        instrument_id=instrument_id,
+    )
+    if gate_input is None:
+        raise LiveCanaryRunnerError("FLATTEN_GATE_INPUT_UNAVAILABLE")
+    boundary = FlattenGatedSubmitBoundaryV1()
+    outcome = boundary.submit(gate_input=gate_input, transport=flatten_transport)
+    result_payload = outcome.to_dict()
+    result_payload.update(
+        {
+            "ok": bool(outcome.send_completed),
+            "mode": "flatten_execute",
+            "LIVE_FLATTEN_PROVABILITY": LIVE_FLATTEN_PROVABILITY,
+            "NETWORK_EFFECT": "NONE",
+            "PRODUCTIVE_VENUE_PROOF": False,
+            "origin_main_sha": origin_main_sha,
+            "executed_code_sha": executed_code_sha or origin_main_sha,
+            "owner_go_observed": owner_go,
+        }
+    )
+    return LiveCanaryRunnerResultV1(
+        ok=bool(outcome.send_completed),
+        mode="flatten_execute",
+        payload=result_payload,
     )
 
 

--- a/tests/ops/test_section_11_13_5_productive_flatten_wiring_v1.py
+++ b/tests/ops/test_section_11_13_5_productive_flatten_wiring_v1.py
@@ -1,0 +1,410 @@
+"""§11.13.5 productive flatten wiring tests. Synthetic only. No network."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import pytest
+
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.config_v1 import (
+    example_incomplete_config_dict_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.constants_v1 import (
+    DEFAULT_INSTRUMENT_ID,
+    LIVE_ARMED,
+    LIVE_AUTHORIZED,
+    LIVE_ENABLED,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.flatten_execute_authority_v1 import (
+    FLATTEN_EXECUTE_CONFIRM_TOKEN_CANONICAL,
+    FLATTEN_EXECUTE_OWNER_GO_CANONICAL,
+    FLATTEN_EXECUTE_PURPOSE_CANONICAL,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.flatten_gated_submit_v1 import (
+    FlattenGatedSubmitBoundaryV1,
+    submit_productive_flatten_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.flatten_limit_price_contract_v1 import (
+    FRESHNESS_THRESHOLD_MS,
+    FlattenPriceInputV1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.flatten_post_action_proof_contract_v1 import (
+    evaluate_canary_flatten_post_action_proof_contract_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.flatten_post_submit_evidence_state_v1 import (
+    evaluate_canary_flatten_post_submit_evidence_state_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.flatten_pre_send_gate_v1 import (
+    FlattenPreSendGateInputV1,
+    evaluate_flatten_pre_send_gate_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.flatten_productive_transport_v1 import (
+    GatedProductiveFlattenTransportV1,
+    RecordingProductiveFlattenTransportV1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.flatten_submit_transport_v1 import (
+    DEDICATED_FLATTEN_TRANSPORT_LIVE_WIRE_ENABLED,
+    LIVE_FLATTEN_PROVABILITY,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.http_client_v1 import (
+    RecordingFakeCanaryTransportV1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.runner_v1 import (
+    run_section_11_13_5_live_canary_minimum_exposure_v1,
+)
+
+OWNER_GO = "OWNER_GO_LIVE_CANARY_MINIMUM_EXPOSURE"
+ORIGIN_SHA = "7085b6e76fef9036319f6d9a4bce0329e5493b02"
+TARGET = DEFAULT_INSTRUMENT_ID
+OTHER = "ETH-USDT-SWAP"
+QUOTE_TS = "1787145055768"
+EVAL_TS = "1787145056000"
+WIRING_GO = (
+    "SECTION_11_13_5_POST_Z2AU_PRODUCTIVE_LIVE_FLATTEN_WIRING_MAX_SAFE_SLICE_"
+    "FAIL_CLOSED_NO_NETWORK_NO_GET_NO_POST_NO_EXECUTE"
+)
+
+
+@pytest.fixture(autouse=True)
+def _block_network(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _blocked(*_a: Any, **_k: Any) -> Any:
+        raise AssertionError("NETWORK_FORBIDDEN_IN_FLATTEN_WIRING_TESTS")
+
+    monkeypatch.setattr("urllib.request.urlopen", _blocked)
+    monkeypatch.setattr("socket.create_connection", _blocked)
+
+
+def _positions(*rows: Mapping[str, Any]) -> dict[str, Any]:
+    return {"code": "0", "data": list(rows)}
+
+
+def _pending(*rows: Mapping[str, Any]) -> dict[str, Any]:
+    return {"code": "0", "data": list(rows)}
+
+
+def _price(*, side: str = "SELL", pos: str = "1", **overrides: Any) -> FlattenPriceInputV1:
+    payload: dict[str, Any] = {
+        "flatten_side": side,
+        "observed_signed_pos": pos,
+        "bid": "64805.6",
+        "ask": "64805.7",
+        "quote_timestamp_ms": QUOTE_TS,
+        "evaluation_timestamp_ms": EVAL_TS,
+        "tick_sz": "0.1",
+        "freshness_threshold_ms": str(FRESHNESS_THRESHOLD_MS),
+    }
+    payload.update(overrides)
+    return FlattenPriceInputV1(**payload)
+
+
+def _valid_gate(**overrides: Any) -> FlattenPreSendGateInputV1:
+    payload: dict[str, Any] = {
+        "live_authorized": True,
+        "live_enabled": True,
+        "live_armed": True,
+        "flatten_live_wire_enabled": True,
+        "allow_productive_wire_send": True,
+        "flatten_execute_token": FLATTEN_EXECUTE_CONFIRM_TOKEN_CANONICAL,
+        "flatten_execute_purpose": FLATTEN_EXECUTE_PURPOSE_CANONICAL,
+        "flatten_execute_owner_go": FLATTEN_EXECUTE_OWNER_GO_CANONICAL,
+        "positions_payload": _positions({"instId": TARGET, "pos": "1"}),
+        "pending_orders_payload": _pending(),
+        "price_input": _price(),
+        "owner_go": OWNER_GO,
+        "origin_main_sha": ORIGIN_SHA,
+        "flatten_execute_bound_origin_main_sha": ORIGIN_SHA,
+        "instrument_id": TARGET,
+        "one_shot_no_retry": True,
+        "duplicate_post_protection": True,
+    }
+    payload.update(overrides)
+    return FlattenPreSendGateInputV1(**payload)
+
+
+def test_standing_defaults_remain_fail_closed() -> None:
+    assert LIVE_AUTHORIZED is False
+    assert LIVE_ENABLED is False
+    assert LIVE_ARMED is False
+    assert DEDICATED_FLATTEN_TRANSPORT_LIVE_WIRE_ENABLED is False
+    assert LIVE_FLATTEN_PROVABILITY == "UNPROVEN"
+
+
+def test_synthetic_valid_set_is_structurally_reachable() -> None:
+    transport = RecordingProductiveFlattenTransportV1()
+    result = submit_productive_flatten_v1(gate_input=_valid_gate(), transport=transport)
+    assert result.allowed is True
+    assert result.send_attempted is True
+    assert result.send_completed is True
+    assert result.network_used is False
+    assert result.productive_venue_proof is False
+    assert result.live_flatten_provability == "UNPROVEN"
+    assert len(transport.calls) == 1
+    body = result.receipt.request_body
+    assert body is not None
+    assert body.get("reduceOnly") is True
+    assert str(body.get("ordType") or "").lower() == "limit"
+    assert str(body.get("sz")) == "1"
+    assert str(body.get("instId")) == TARGET
+    assert result.receipt.qty == "1"
+
+
+def test_default_gate_and_config_cannot_reach_productive_send() -> None:
+    denied = evaluate_flatten_pre_send_gate_v1(
+        FlattenPreSendGateInputV1(
+            live_authorized=False,
+            live_enabled=False,
+            live_armed=False,
+            flatten_live_wire_enabled=False,
+            allow_productive_wire_send=False,
+            flatten_execute_token="",
+            flatten_execute_purpose="",
+            flatten_execute_owner_go="",
+            positions_payload=_positions({"instId": TARGET, "pos": "1"}),
+            pending_orders_payload=_pending(),
+            price_input=_price(),
+            owner_go=OWNER_GO,
+            origin_main_sha=ORIGIN_SHA,
+        )
+    )
+    assert denied.allowed is False
+    transport = RecordingProductiveFlattenTransportV1()
+    result = submit_productive_flatten_v1(
+        gate_input=_valid_gate(
+            live_authorized=False,
+            live_enabled=False,
+            live_armed=False,
+            flatten_live_wire_enabled=False,
+            allow_productive_wire_send=False,
+            flatten_execute_token="",
+            flatten_execute_purpose="",
+            flatten_execute_owner_go="",
+            flatten_execute_bound_origin_main_sha=None,
+        ),
+        transport=transport,
+    )
+    assert result.send_attempted is False
+    assert transport.calls == []
+    cfg = example_incomplete_config_dict_v1()
+    assert cfg.get("flatten_live_wire_enabled") is False
+    assert cfg.get("flatten_execute_token") == ""
+    runner = run_section_11_13_5_live_canary_minimum_exposure_v1(
+        mode="flatten_execute",
+        origin_main_sha=ORIGIN_SHA,
+        config_payload=cfg,
+    )
+    assert runner.payload.get("send_attempted") is False
+    assert runner.payload.get("send_completed") is False
+    assert runner.ok is False
+
+
+@pytest.mark.parametrize(
+    "override,needle",
+    [
+        ({"live_authorized": False}, "LIVE_AUTHORIZED_CLAIM_FALSE"),
+        ({"live_enabled": False}, "LIVE_ENABLED_CLAIM_FALSE"),
+        ({"live_armed": False}, "LIVE_ARMED_CLAIM_FALSE"),
+        ({"flatten_live_wire_enabled": False}, "FLATTEN_LIVE_WIRE_CLAIM_FALSE"),
+        ({"allow_productive_wire_send": False}, "ALLOW_PRODUCTIVE_WIRE_SEND_FALSE"),
+        ({"flatten_execute_token": None}, "FLATTEN_EXECUTE_TOKEN_MISSING"),
+        ({"flatten_execute_token": "WRONG"}, "FLATTEN_EXECUTE_TOKEN_MISMATCH"),
+        ({"flatten_execute_purpose": "WRONG_PURPOSE"}, "FLATTEN_EXECUTE_PURPOSE_INVALID"),
+        ({"flatten_execute_owner_go": WIRING_GO}, "FLATTEN_EXECUTE_OWNER_GO_FORBIDDEN"),
+        (
+            {"flatten_execute_owner_go": "SECTION_11_13_5_FLATTEN_EXECUTE"},
+            "FLATTEN_EXECUTE_OWNER_GO_MISMATCH",
+        ),
+        ({"flatten_execute_bound_origin_main_sha": None}, "FLATTEN_EXECUTE_BOUND_SHA_MISSING"),
+        ({"flatten_execute_bound_origin_main_sha": "abcd"}, "FLATTEN_EXECUTE_BOUND_SHA_MALFORMED"),
+        ({"flatten_execute_bound_origin_main_sha": "a" * 40}, "FLATTEN_EXECUTE_BOUND_SHA_STALE"),
+        ({"pending_orders_payload": None}, "OPEN_ORDER_STATE_UNAVAILABLE"),
+        (
+            {"pending_orders_payload": _pending({"instId": TARGET, "ordId": "1"})},
+            "OPEN_ORDER_CONFLICT",
+        ),
+        ({"one_shot_no_retry": False}, "ONE_SHOT_NO_RETRY_REQUIRED"),
+        ({"duplicate_post_protection": False}, "DUPLICATE_POST_PROTECTION_REQUIRED"),
+        (
+            {
+                "positions_payload": _positions(
+                    {"instId": TARGET, "pos": "1"}, {"instId": OTHER, "pos": "1"}
+                )
+            },
+            "B8_CAP",
+        ),
+        ({"price_input": _price(quote_timestamp_ms="1")}, "STALE"),
+    ],
+)
+def test_each_independent_gate_fails_closed(override: dict[str, Any], needle: str) -> None:
+    transport = RecordingProductiveFlattenTransportV1()
+    result = submit_productive_flatten_v1(gate_input=_valid_gate(**override), transport=transport)
+    assert result.send_attempted is False
+    assert transport.calls == []
+    joined = " ".join(result.reasons)
+    assert needle in joined
+
+
+def test_boolean_allow_flag_is_never_sufficient() -> None:
+    transport = RecordingProductiveFlattenTransportV1()
+    result = submit_productive_flatten_v1(
+        gate_input=_valid_gate(
+            flatten_execute_token="",
+            flatten_execute_purpose="",
+            flatten_execute_owner_go="",
+            flatten_execute_bound_origin_main_sha=None,
+            allow_productive_wire_send=True,
+        ),
+        transport=transport,
+    )
+    assert result.send_attempted is False
+    assert transport.calls == []
+    assert any("FLATTEN_EXECUTE" in item for item in result.reasons)
+
+
+def test_fake_transport_cannot_masquerade_as_productive() -> None:
+    fake = RecordingFakeCanaryTransportV1()
+    result = submit_productive_flatten_v1(gate_input=_valid_gate(), transport=fake)
+    assert result.fake_transport_rejected is True
+    assert result.send_attempted is False
+    assert result.send_completed is False
+
+
+def test_productive_transport_cannot_send_without_full_receipt() -> None:
+    transport = RecordingProductiveFlattenTransportV1()
+    result = submit_productive_flatten_v1(
+        gate_input=_valid_gate(allow_productive_wire_send=False),
+        transport=transport,
+    )
+    assert result.send_attempted is False
+    assert transport.calls == []
+
+
+def test_gated_transport_never_opens_network_even_with_valid_gate() -> None:
+    transport = GatedProductiveFlattenTransportV1()
+    result = submit_productive_flatten_v1(gate_input=_valid_gate(), transport=transport)
+    assert result.send_attempted is True
+    assert result.send_completed is False
+    assert result.network_used is False
+    assert "PRODUCTIVE_NETWORK_SESSION_NOT_AUTHORIZED" in " ".join(result.reasons)
+
+
+def test_duplicate_send_is_blocked() -> None:
+    transport = RecordingProductiveFlattenTransportV1()
+    boundary = FlattenGatedSubmitBoundaryV1()
+    first = boundary.submit(gate_input=_valid_gate(), transport=transport)
+    assert first.send_completed is True
+    second = boundary.submit(gate_input=_valid_gate(), transport=transport)
+    assert second.send_attempted is False
+    assert second.duplicate_blocked is True
+    assert len(transport.calls) == 1
+
+
+def test_retry_remains_prohibited_on_transport() -> None:
+    transport = RecordingProductiveFlattenTransportV1()
+    first = submit_productive_flatten_v1(gate_input=_valid_gate(), transport=transport)
+    assert first.send_completed is True
+    with pytest.raises(Exception, match="DUPLICATE_POST_FORBIDDEN"):
+        transport.send(transport.calls[0])
+
+
+def test_reduce_only_limit_and_b8_survive_composition() -> None:
+    receipt = evaluate_flatten_pre_send_gate_v1(_valid_gate())
+    assert receipt.allowed is True
+    assert receipt.reduce_only is True
+    assert str(receipt.ord_type).lower() == "limit"
+    body = receipt.request_body or {}
+    assert body.get("reduceOnly") is True
+    assert str(body.get("ordType")).lower() == "limit"
+    denied = evaluate_flatten_pre_send_gate_v1(
+        _valid_gate(
+            positions_payload=_positions(
+                {"instId": TARGET, "pos": "1"},
+                {"instId": OTHER, "pos": "2"},
+            )
+        )
+    )
+    assert denied.allowed is False
+    assert any("B8_CAP" in item for item in denied.reasons)
+
+
+def test_runner_does_not_flatten_on_preflight_or_execute() -> None:
+    preflight = run_section_11_13_5_live_canary_minimum_exposure_v1(
+        mode="preflight",
+        origin_main_sha=ORIGIN_SHA,
+        transport=RecordingProductiveFlattenTransportV1(),
+    )
+    assert preflight.mode == "preflight"
+    assert preflight.payload.get("send_completed") is not True
+    spy = RecordingProductiveFlattenTransportV1()
+    with pytest.raises(Exception):
+        run_section_11_13_5_live_canary_minimum_exposure_v1(
+            mode="execute",
+            origin_main_sha=ORIGIN_SHA,
+            owner_go=OWNER_GO,
+            live_canary_authorized=True,
+            live_enabled=True,
+            live_armed=True,
+            transport=spy,
+            allow_productive_wire_send=True,
+        )
+    assert spy.calls == []
+
+
+def test_runner_flatten_execute_reaches_recording_transport_only_when_fully_gated() -> None:
+    transport = RecordingProductiveFlattenTransportV1()
+    result = run_section_11_13_5_live_canary_minimum_exposure_v1(
+        mode="flatten_execute",
+        origin_main_sha=ORIGIN_SHA,
+        owner_go=OWNER_GO,
+        live_canary_authorized=True,
+        live_enabled=True,
+        live_armed=True,
+        allow_productive_wire_send=True,
+        flatten_execute_token=FLATTEN_EXECUTE_CONFIRM_TOKEN_CANONICAL,
+        flatten_execute_purpose=FLATTEN_EXECUTE_PURPOSE_CANONICAL,
+        flatten_execute_owner_go=FLATTEN_EXECUTE_OWNER_GO_CANONICAL,
+        flatten_execute_bound_origin_main_sha=ORIGIN_SHA,
+        flatten_live_wire_enabled=True,
+        positions_payload=_positions({"instId": TARGET, "pos": "1"}),
+        pending_orders_payload=_pending(),
+        price_input=_price(),
+        transport=transport,
+    )
+    assert result.payload.get("send_completed") is True
+    assert result.payload.get("network_used") is False
+    assert result.payload.get("productive_venue_proof") is False
+    assert result.payload.get("LIVE_FLATTEN_PROVABILITY") == "UNPROVEN"
+    assert len(transport.calls) == 1
+
+
+def test_post_submit_offline_contract_preserved() -> None:
+    pre = _positions({"instId": TARGET, "pos": "1"})
+    post = _positions({"instId": TARGET, "pos": "0"})
+    pending = _pending()
+    proof = evaluate_canary_flatten_post_action_proof_contract_v1(
+        pre_positions_payload=pre,
+        post_positions_payload=post,
+        post_pending_orders_payload=pending,
+        instrument_id=TARGET,
+    )
+    assert proof.pre_pos_nonzero is True
+    assert proof.post_pos_zero is True
+    assert proof.pending_empty is True
+    assert proof.no_flip is True
+    assert proof.offline_contract_satisfied is True
+    assert proof.live_flatten_provability == "UNPROVEN"
+    assert proof.submit_reachable is False
+    assert proof.live_wire_enabled is False
+    state = evaluate_canary_flatten_post_submit_evidence_state_v1(
+        submit_attempted=True,
+        send_attempted=True,
+        http_status=200,
+        response_body={"code": "0", "data": [{"sCode": "0"}]},
+        pre_positions_payload=pre,
+        post_positions_payload=post,
+        post_pending_orders_payload=pending,
+        instrument_id=TARGET,
+        requested_qty="1",
+    )
+    assert state.productive_venue_proof is False
+    assert state.live_flatten_provability == "UNPROVEN"
+    assert state.actual_post is True  # injected send_attempted evidence, not venue POST

--- a/tests/ops/test_section_11_13_5_z2au_offline_flatten_construction_and_gate_binding_persist_v1.py
+++ b/tests/ops/test_section_11_13_5_z2au_offline_flatten_construction_and_gate_binding_persist_v1.py
@@ -47,11 +47,16 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+Z2AV_HEADING = "### 11.13.5.Z2AV Productive live-flatten wiring persist"
+
+
 def _z2au_section(text: str) -> str:
     start = text.find(Z2AU_HEADING)
     assert start >= 0, "missing §11.13.5.Z2AU heading"
-    end = text.find(LADDER_HEADING, start)
-    assert end > start, "missing §11.14 boundary after Z2AU"
+    end = text.find(Z2AV_HEADING, start)
+    if end < 0:
+        end = text.find(LADDER_HEADING, start)
+    assert end > start, "missing Z2AV/§11.14 boundary after Z2AU"
     return text[start:end]
 
 

--- a/tests/ops/test_section_11_13_5_z2av_productive_flatten_wiring_persist_v1.py
+++ b/tests/ops/test_section_11_13_5_z2av_productive_flatten_wiring_persist_v1.py
@@ -1,0 +1,139 @@
+"""§11.13.5.Z2AV productive flatten wiring persist.
+
+Docs/governance invariants only. Records the wiring slice: dedicated
+productive flatten transport, runner flatten_execute wiring, separate
+flatten-execute authority, and full pre-send gate object. Does not prove
+live flatten, does not consume Z2AP/Z2AR, and does not invent a unique
+global next.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.flatten_limit_price_contract_v1 import (
+    FRESHNESS_THRESHOLD_MS,
+    LIVE_FLATTEN_PROVABILITY_STATUS,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.flatten_submit_transport_v1 import (
+    DEDICATED_FLATTEN_TRANSPORT_LIVE_WIRE_ENABLED,
+    LIVE_FLATTEN_PROVABILITY,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MASTER_RUNBOOK = REPO_ROOT / "docs" / "runbooks" / "canonical" / "PEAK_TRADE_MASTER_RUNBOOK.md"
+MAP_OF_TRUTH = REPO_ROOT / "docs" / "governance" / "PEAK_TRADE_MAP_OF_TRUTH.md"
+
+Z2AV_HEADING = "### 11.13.5.Z2AV Productive live-flatten wiring persist"
+Z2AU_HEADING = "### 11.13.5.Z2AU Offline Z2AP live-flatten construction and gate-binding persist"
+LADDER_HEADING = "## 11.14 Live order and economic evidence ladder"
+OWNER_GO = (
+    "SECTION_11_13_5_POST_Z2AU_PRODUCTIVE_LIVE_FLATTEN_WIRING_MAX_SAFE_SLICE_"
+    "FAIL_CLOSED_NO_NETWORK_NO_GET_NO_POST_NO_EXECUTE"
+)
+BASELINE_SHA = "7085b6e76fef9036319f6d9a4bce0329e5493b02"
+NEXT_POINTER = (
+    "OWNER_GO_REQUIRED_SEPARATE_SCOPED_NAMED_TRACK_OR_NAMED_CLASS_"
+    "PROGRESSION_NOT_AUTHORIZED_BY_THIS_PERSIST_Z2AV_PRODUCTIVE_"
+    "FLATTEN_WIRING_ONLY_GLOBAL_UNIQUE_CANONICAL_NEXT_STEP_NONE_BY_"
+    "P3_POLICY_NO_Z2AP_CONSUME_NO_Z2AR_CONSUME_NO_FLATTEN_EXECUTE_"
+    "NO_LIVE_WIRE_NO_SUI_REPROOF_NO_CANONICAL_REBIND_NO_GET_NO_POST_"
+    "NO_ORDER_NO_FUNDING_NO_CANARY_NOT_AUTHORIZED"
+)
+
+
+def _read(path: Path) -> str:
+    assert path.is_file(), f"missing canonical path: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def _z2av_section(text: str) -> str:
+    start = text.find(Z2AV_HEADING)
+    assert start >= 0, "missing §11.13.5.Z2AV heading"
+    end = text.find(LADDER_HEADING, start)
+    assert end > start, "missing §11.14 boundary after Z2AV"
+    return text[start:end]
+
+
+def test_z2av_heading_is_unique_and_follows_z2au() -> None:
+    text = _read(MASTER_RUNBOOK)
+    assert text.count(Z2AV_HEADING) == 1
+    z2au = text.find(Z2AU_HEADING)
+    z2av = text.find(Z2AV_HEADING)
+    ladder = text.find(LADDER_HEADING)
+    assert 0 <= z2au < z2av < ladder
+
+
+def test_z2av_docs_bind_wiring_slice_without_execution_or_track_consumption() -> None:
+    section = _z2av_section(_read(MASTER_RUNBOOK))
+    required = (
+        "AUTHORIZED_SCOPE=A_Z2AV_PRODUCTIVE_FLATTEN_WIRING_FAIL_CLOSED_NO_NETWORK_NO_GET_NO_POST_NO_EXECUTE_ONLY",
+        f"OWNER_GO={OWNER_GO}",
+        "OWNER_GO_STATUS=CONSUMED",
+        "PERSIST_CLASS=WIRING_IMPLEMENTATION_PLUS_SSOT_PERSIST",
+        f"BASELINE_ORIGIN_MAIN_SHA={BASELINE_SHA}",
+        "Z2AS_REMAINS_P3_POLICY_BASIS=true",
+        "Z2AS_TEXT_REWRITTEN=false",
+        "Z2AP_TEXT_REWRITTEN=false",
+        "Z2AR_TEXT_REWRITTEN=false",
+        "Z2AU_TEXT_REWRITTEN=false",
+        "Z2AP_CONSUMED=false",
+        "Z2AR_CONSUMED=false",
+        "P3_INDEPENDENT_PARALLEL_TRACKS_POLICY=true",
+        "GLOBAL_UNIQUE_CANONICAL_NEXT_STEP=NONE_BY_P3_POLICY",
+        "NO_MAP_OF_TRUTH_MUTATION=true",
+        "PRODUCTIVE_FLATTEN_PATH_STRUCTURALLY_REACHABLE=true",
+        "PRODUCTIVE_WIRE_SEND_WITHOUT_FULL_RUNTIME_GATES=false",
+        "PRODUCTIVE_WIRE_SEND_WITHOUT_SEPARATE_FLATTEN_EXECUTE_AUTHORITY=false",
+        "NETWORK_USED_DURING_SLICE=false",
+        "GET_EXECUTED_THIS_STEP=false",
+        "POST_EXECUTED=false",
+        "LIVE_FLATTEN_PROVABILITY=UNPROVEN",
+        "PRODUCTIVE_PROOF_EXECUTED=false",
+        "STRUCTURALLY_REACHABLE_NE_PRODUCTIVELY_PROVEN=true",
+        "DEDICATED_FLATTEN_TRANSPORT_LIVE_WIRE_ENABLED=false",
+        "B8_MANDATORY=true",
+        "REDUCE_ONLY_MANDATORY=true",
+        "LIMIT_ONLY_MANDATORY=true",
+        "FRESHNESS_5000MS_MANDATORY=true",
+        "ONE_SHOT_NO_RETRY=true",
+        "DUPLICATE_POST_PROTECTION=true",
+        "POST_SUBMIT_PROOF_CONTRACT_PRESERVED=true",
+        "DEFAULT_PRODUCTIVE_SEND_DENIED=true",
+        "NO_AUTONOMOUS_FLATTEN_TRIGGER=true",
+        "THIS_OWNER_GO_IS_NOT_FLATTEN_EXECUTE_TOKEN=true",
+        "NO_FLATTEN_EXECUTE_GO_INVENTED_BY_THIS_PERSIST=true",
+        f"CANONICAL_NEXT_STEP={NEXT_POINTER}",
+        "HARD_STOP_AFTER_THIS_TASK=true",
+    )
+    for marker in required:
+        assert marker in section, f"missing Z2AV marker: {marker}"
+    forbidden = (
+        "\nLIVE_AUTHORIZED=true\n",
+        "\nTESTNET_AUTHORIZED=true\n",
+        "\nCANARY_AUTHORIZED=true\n",
+        "\nCAN_SUBMIT_ORDER_TODAY=true\n",
+        "\nPRODUCTIVE_PROOF_EXECUTED=true\n",
+        "\nLIVE_FLATTEN_PROVABILITY=PROVEN\n",
+        "\nZ2AP_CONSUMED=true\n",
+        "\nZ2AR_CONSUMED=true\n",
+        "\nGET_EXECUTED_THIS_STEP=true\n",
+        "\nPOST_EXECUTED=true\n",
+        "\nDEDICATED_FLATTEN_TRANSPORT_LIVE_WIRE_ENABLED=true\n",
+        "\nFLATTEN_EXECUTION=true\n",
+        "\nNETWORK_USED_DURING_SLICE=true\n",
+        "\nPRODUCTIVE_WIRE_SEND_WITHOUT_FULL_RUNTIME_GATES=true\n",
+    )
+    for marker in forbidden:
+        assert marker not in section, f"forbidden Z2AV marker present: {marker!r}"
+    assert LIVE_FLATTEN_PROVABILITY == LIVE_FLATTEN_PROVABILITY_STATUS == "UNPROVEN"
+    assert DEDICATED_FLATTEN_TRANSPORT_LIVE_WIRE_ENABLED is False
+    assert FRESHNESS_THRESHOLD_MS == 5000
+
+
+def test_z2av_map_of_truth_remains_navigation_only_without_z2av_ssot_row() -> None:
+    mot = _read(MAP_OF_TRUTH)
+    assert "THIS_DOCUMENT_DEFINES_NO_SEMANTICS=true" in mot
+    assert "LIVE_AUTHORIZED=false" in mot
+    assert "§11.13.5.Z2AV |" not in mot
+    assert f"NEXT_CANONICAL_STEP_POINTER={NEXT_POINTER}\n" not in mot


### PR DESCRIPTION
## Summary
- Wire a dedicated productive flatten transport, `flatten_execute` runner mode, and a separate flatten-execute confirm-token authority so a hypothetically valid flatten is structurally reachable.
- Keep defaults denied: no standing live flags, no live wire, no autonomous trigger, no GET/POST, and `allow_productive_wire_send` is never sufficient by itself.
- Persist the slice as §11.13.5.Z2AV. `LIVE_FLATTEN_PROVABILITY=UNPROVEN`. This PR does not execute flatten and must not be merged without a separate `OWNER_MERGE_GO`.

## Test plan
- [x] `pytest tests/ops/test_section_11_13_5_productive_flatten_wiring_v1.py`
- [x] `pytest tests/ops/test_section_11_13_5_z2av_productive_flatten_wiring_persist_v1.py`
- [x] `pytest tests/ops/test_section_11_13_5_z2au_offline_flatten_construction_and_gate_binding_v1.py tests/ops/test_section_11_13_5_dedicated_flatten_submit_transport_v1.py`
- [x] ruff format/check on changed Python
- [ ] GitHub required checks (do not merge without `OWNER_MERGE_GO`)

Made with [Cursor](https://cursor.com)