### PR TITLE
feat(ops): bind read-only Category-C algo pending GET

### DIFF
--- a/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/category_c_open_algo_pending_observer_v1.py
+++ b/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/category_c_open_algo_pending_observer_v1.py
@@ -1,0 +1,382 @@
+"""Read-only Category-C open algo-pending observer.
+
+Reuses an injected LiveCanary GET client. Does not submit, cancel, amend,
+flatten, or construct execution permits. Local mock/tests only in this slice;
+this module does not authorize an Exchange GET.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Any, Callable, Mapping, Protocol
+from urllib.parse import quote
+
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.constants_v1 import (
+    DEFAULT_INST_TYPE,
+    DEFAULT_INSTRUMENT_ID,
+    ENDPOINT_ORDERS_ALGO_PENDING,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.http_client_v1 import (
+    LiveCanaryHttpError,
+    LiveCanaryHttpResponseV1,
+    parse_json_object_v1,
+)
+
+CATEGORY_C_PAGE_LIMIT = 100
+CATEGORY_C_INST_TYPE = DEFAULT_INST_TYPE
+CATEGORY_C_ORD_TYPE_VARIANTS: tuple[str, ...] = (
+    "conditional,oco",
+    "trigger",
+    "move_order_stop",
+)
+CATEGORY_C_NAMED_ORD_TYPES: frozenset[str] = frozenset(
+    {"conditional", "oco", "trigger", "move_order_stop"}
+)
+CATEGORY_C_OPEN_STATES: frozenset[str] = frozenset({"live", "pause"})
+CATEGORY_C_DEFAULT_MAX_REQUESTS = 30
+CATEGORY_C_DEFAULT_MAX_PAGES_PER_VARIANT = 10
+_EVIDENCE_KEYS: tuple[str, ...] = (
+    "algoId",
+    "instId",
+    "ordType",
+    "side",
+    "sz",
+    "state",
+    "tpTriggerPx",
+    "tpOrdPx",
+    "slTriggerPx",
+    "slOrdPx",
+    "triggerPx",
+    "reduceOnly",
+    "attachAlgoOrds",
+    "cTime",
+    "uTime",
+)
+
+
+class CategoryCGetClientV1(Protocol):
+    """GET-only client surface used by the observer."""
+
+    rest_base: str
+
+    def get(
+        self,
+        *,
+        endpoint: str,
+        headers: Mapping[str, str] | None = None,
+    ) -> LiveCanaryHttpResponseV1:
+        """Issue one GET. Must not be used as a POST dispatcher."""
+
+
+class CategoryCObservationOutcomeV1(str, Enum):
+    OBSERVATION_UNPROVEN = "OBSERVATION_UNPROVEN"
+    CATEGORY_C_OBSERVATION_INCOMPLETE = "CATEGORY_C_OBSERVATION_INCOMPLETE"
+    CATEGORY_C_UNKNOWN_TYPE_PRESENT = "CATEGORY_C_UNKNOWN_TYPE_PRESENT"
+    TARGET_CATEGORY_C_NOT_OBSERVED = "TARGET_CATEGORY_C_NOT_OBSERVED"
+    TARGET_CATEGORY_C_OBSERVED = "TARGET_CATEGORY_C_OBSERVED"
+
+
+@dataclass(frozen=True)
+class CategoryCAlgoPendingRowEvidenceV1:
+    """Present-key snapshot only. Absent OKX fields are omitted."""
+
+    values: Mapping[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return dict(self.values)
+
+
+@dataclass(frozen=True)
+class CategoryCOpenAlgoPendingObservationV1:
+    outcome: CategoryCObservationOutcomeV1
+    target_instrument_id: str
+    request_count: int
+    endpoints_requested: tuple[str, ...]
+    variants_completed: tuple[str, ...]
+    methods_used: tuple[str, ...]
+    target_rows: tuple[CategoryCAlgoPendingRowEvidenceV1, ...]
+    fail_closed_reason: str | None = None
+    canonical_binding_status: str = "UNBOUND"
+    runtime_authorization_effect: str = "NONE"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "outcome": self.outcome.value,
+            "target_instrument_id": self.target_instrument_id,
+            "request_count": self.request_count,
+            "endpoints_requested": list(self.endpoints_requested),
+            "variants_completed": list(self.variants_completed),
+            "methods_used": list(self.methods_used),
+            "target_rows": [row.to_dict() for row in self.target_rows],
+            "fail_closed_reason": self.fail_closed_reason,
+            "canonical_binding_status": self.canonical_binding_status,
+            "runtime_authorization_effect": self.runtime_authorization_effect,
+        }
+
+
+def _enc(value: str) -> str:
+    return quote(str(value), safe=",")
+
+
+def build_category_c_orders_algo_pending_endpoint_v1(
+    *,
+    ord_type: str,
+    instrument_id: str = DEFAULT_INSTRUMENT_ID,
+    inst_type: str = CATEGORY_C_INST_TYPE,
+    limit: int = CATEGORY_C_PAGE_LIMIT,
+    after: str | None = None,
+) -> str:
+    """Deterministic GET path+query. Comma in ordType remains unencoded."""
+    parts = [
+        f"ordType={_enc(ord_type)}",
+        f"instType={_enc(inst_type)}",
+        f"instId={_enc(instrument_id)}",
+        f"limit={int(limit)}",
+    ]
+    if after is not None:
+        parts.append(f"after={_enc(after)}")
+    return f"{ENDPOINT_ORDERS_ALGO_PENDING}?{'&'.join(parts)}"
+
+
+def _result(
+    *,
+    outcome: CategoryCObservationOutcomeV1,
+    target_instrument_id: str,
+    request_count: int,
+    endpoints_requested: list[str],
+    variants_completed: list[str],
+    methods_used: list[str],
+    target_rows: list[CategoryCAlgoPendingRowEvidenceV1],
+    fail_closed_reason: str | None = None,
+) -> CategoryCOpenAlgoPendingObservationV1:
+    return CategoryCOpenAlgoPendingObservationV1(
+        outcome=outcome,
+        target_instrument_id=target_instrument_id,
+        request_count=request_count,
+        endpoints_requested=tuple(endpoints_requested),
+        variants_completed=tuple(variants_completed),
+        methods_used=tuple(methods_used),
+        target_rows=tuple(target_rows),
+        fail_closed_reason=fail_closed_reason,
+    )
+
+
+def _evidence_from_row(row: Mapping[str, Any]) -> CategoryCAlgoPendingRowEvidenceV1:
+    copied: dict[str, Any] = {}
+    for key in _EVIDENCE_KEYS:
+        if key in row:
+            copied[key] = row[key]
+    return CategoryCAlgoPendingRowEvidenceV1(values=MappingProxyType(copied))
+
+
+def observe_category_c_open_algo_pending_v1(
+    *,
+    client: CategoryCGetClientV1,
+    instrument_id: str = DEFAULT_INSTRUMENT_ID,
+    headers: Mapping[str, str] | None = None,
+    header_factory: Callable[[str], Mapping[str, str]] | None = None,
+    max_requests: int = CATEGORY_C_DEFAULT_MAX_REQUESTS,
+    max_pages_per_variant: int = CATEGORY_C_DEFAULT_MAX_PAGES_PER_VARIANT,
+) -> CategoryCOpenAlgoPendingObservationV1:
+    """Observe untriggered named Category-C algo families via GET only."""
+    target = str(instrument_id or "").strip()
+    endpoints_requested: list[str] = []
+    variants_completed: list[str] = []
+    methods_used: list[str] = []
+    target_rows: list[CategoryCAlgoPendingRowEvidenceV1] = []
+    request_count = 0
+
+    def _done(
+        outcome: CategoryCObservationOutcomeV1,
+        reason: str | None = None,
+    ) -> CategoryCOpenAlgoPendingObservationV1:
+        return _result(
+            outcome=outcome,
+            target_instrument_id=target,
+            request_count=request_count,
+            endpoints_requested=endpoints_requested,
+            variants_completed=variants_completed,
+            methods_used=methods_used,
+            target_rows=target_rows,
+            fail_closed_reason=reason,
+        )
+
+    if not target:
+        return _done(
+            CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN,
+            "TARGET_INSTRUMENT_REQUIRED",
+        )
+    if int(max_requests) <= 0 or int(max_pages_per_variant) <= 0:
+        return _done(
+            CategoryCObservationOutcomeV1.CATEGORY_C_OBSERVATION_INCOMPLETE,
+            "REQUEST_OR_PAGE_GUARD_INVALID",
+        )
+
+    seen_algo_ids: set[str] = set()
+    for variant in CATEGORY_C_ORD_TYPE_VARIANTS:
+        after: str | None = None
+        used_after: set[str] = set()
+        pages = 0
+        while True:
+            if request_count >= int(max_requests):
+                return _done(
+                    CategoryCObservationOutcomeV1.CATEGORY_C_OBSERVATION_INCOMPLETE,
+                    "REQUEST_GUARD_EXCEEDED",
+                )
+            if pages >= int(max_pages_per_variant):
+                return _done(
+                    CategoryCObservationOutcomeV1.CATEGORY_C_OBSERVATION_INCOMPLETE,
+                    "PAGE_GUARD_EXCEEDED",
+                )
+            if after is not None:
+                if after in used_after:
+                    return _done(
+                        CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN,
+                        "CYCLIC_PAGINATION",
+                    )
+                used_after.add(after)
+            endpoint = build_category_c_orders_algo_pending_endpoint_v1(
+                ord_type=variant,
+                instrument_id=target,
+                after=after,
+            )
+            req_headers: dict[str, str] = {str(k): str(v) for k, v in dict(headers or {}).items()}
+            if header_factory is not None:
+                full_url = f"{str(client.rest_base).rstrip('/')}{endpoint}"
+                req_headers.update(
+                    {str(k): str(v) for k, v in dict(header_factory(full_url)).items()}
+                )
+            endpoints_requested.append(endpoint)
+            request_count += 1
+            pages += 1
+            try:
+                response = client.get(
+                    endpoint=endpoint,
+                    headers=req_headers or None,
+                )
+            except (KeyboardInterrupt, SystemExit):
+                raise
+            except Exception as exc:
+                methods_used.append("GET")
+                return _done(
+                    CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN,
+                    f"TRANSPORT_OR_CLIENT_ERROR:{type(exc).__name__}",
+                )
+            methods_used.append(str(response.method or "GET"))
+            if str(response.method or "").upper() != "GET":
+                return _done(
+                    CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN,
+                    "NON_GET_RESPONSE",
+                )
+            if int(response.status_code) != 200:
+                return _done(
+                    CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN,
+                    f"HTTP_STATUS_{int(response.status_code)}",
+                )
+            try:
+                payload = parse_json_object_v1(response.body_bytes)
+            except LiveCanaryHttpError:
+                return _done(
+                    CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN,
+                    "MALFORMED_RESPONSE",
+                )
+            if payload.get("code") != "0":
+                return _done(
+                    CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN,
+                    "API_CODE_NOT_SUCCESS",
+                )
+            if "data" not in payload:
+                return _done(
+                    CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN,
+                    "DATA_MISSING",
+                )
+            data = payload.get("data")
+            if data is None:
+                return _done(
+                    CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN,
+                    "DATA_NULL",
+                )
+            if not isinstance(data, list):
+                return _done(
+                    CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN,
+                    "DATA_NOT_LIST",
+                )
+            if len(data) > CATEGORY_C_PAGE_LIMIT:
+                return _done(
+                    CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN,
+                    "PAGE_EXCEEDS_LIMIT",
+                )
+            for row in data:
+                if not isinstance(row, Mapping):
+                    return _done(
+                        CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN,
+                        "ROW_NOT_OBJECT",
+                    )
+                if "instId" not in row or str(row.get("instId") or "").strip() == "":
+                    return _done(
+                        CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN,
+                        "INSTID_MISSING",
+                    )
+                inst_s = str(row.get("instId")).strip()
+                if inst_s != target:
+                    return _done(
+                        CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN,
+                        "FOREIGN_INSTID",
+                    )
+                if "ordType" not in row or str(row.get("ordType") or "").strip() == "":
+                    return _done(
+                        CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN,
+                        "ORDTYPE_MISSING",
+                    )
+                ord_type = str(row.get("ordType")).strip()
+                if ord_type not in CATEGORY_C_NAMED_ORD_TYPES:
+                    target_rows.append(_evidence_from_row(row))
+                    return _done(
+                        CategoryCObservationOutcomeV1.CATEGORY_C_UNKNOWN_TYPE_PRESENT,
+                        f"UNKNOWN_ORDTYPE:{ord_type}",
+                    )
+                if "state" not in row or str(row.get("state") or "").strip() == "":
+                    return _done(
+                        CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN,
+                        "STATE_MISSING",
+                    )
+                state = str(row.get("state")).strip()
+                if state not in CATEGORY_C_OPEN_STATES:
+                    return _done(
+                        CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN,
+                        f"STATE_UNEXPECTED:{state}",
+                    )
+                if "algoId" not in row or str(row.get("algoId") or "").strip() == "":
+                    return _done(
+                        CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN,
+                        "ALGOID_MISSING",
+                    )
+                algo_id = str(row.get("algoId")).strip()
+                if algo_id in seen_algo_ids:
+                    return _done(
+                        CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN,
+                        "DUPLICATE_ALGO_ID",
+                    )
+                seen_algo_ids.add(algo_id)
+                target_rows.append(_evidence_from_row(row))
+            if len(data) < CATEGORY_C_PAGE_LIMIT:
+                variants_completed.append(variant)
+                break
+            last_id = str(data[-1].get("algoId") or "").strip()
+            if not last_id:
+                return _done(
+                    CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN,
+                    "PAGINATION_CURSOR_MISSING",
+                )
+            after = last_id
+
+    if len(variants_completed) != len(CATEGORY_C_ORD_TYPE_VARIANTS):
+        return _done(
+            CategoryCObservationOutcomeV1.CATEGORY_C_OBSERVATION_INCOMPLETE,
+            "REQUIRED_VARIANTS_INCOMPLETE",
+        )
+    if target_rows:
+        return _done(CategoryCObservationOutcomeV1.TARGET_CATEGORY_C_OBSERVED)
+    return _done(CategoryCObservationOutcomeV1.TARGET_CATEGORY_C_NOT_OBSERVED)

--- a/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/constants_v1.py
+++ b/src/ops/section_11_13_5_live_canary_minimum_exposure_v1/constants_v1.py
@@ -276,6 +276,7 @@ CLORDID_WIRE_ALPHANUMERIC_PREFIX = "ptcanary"
 IDEMPOTENCY_POLICY = "ONE_SHOT_CLORDID_PER_OWNER_GO_BINDING"
 ENDPOINT_ORDERS_HISTORY = "/api/v5/trade/orders-history"
 ENDPOINT_ORDER_GET = "/api/v5/trade/order"
+ENDPOINT_ORDERS_ALGO_PENDING = "/api/v5/trade/orders-algo-pending"
 GET_ENDPOINTS_PUBLIC: tuple[str, ...] = (
     "/api/v5/public/instruments",
     "/api/v5/market/ticker",
@@ -285,6 +286,7 @@ GET_ENDPOINTS_PRIVATE: tuple[str, ...] = (
     "/api/v5/account/config",
     "/api/v5/account/positions",
     "/api/v5/trade/orders-pending",
+    ENDPOINT_ORDERS_ALGO_PENDING,
     "/api/v5/trade/orders-history",
     "/api/v5/trade/order",
 )

--- a/tests/ops/test_section_11_13_5_category_c_open_algo_pending_observer_v1.py
+++ b/tests/ops/test_section_11_13_5_category_c_open_algo_pending_observer_v1.py
@@ -1,0 +1,459 @@
+"""Deterministic mock-only tests for Category-C open algo-pending observer.
+
+No Exchange network. No urllib wire send. No submit/cancel/amend/flatten.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+from typing import Any, Mapping
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.category_c_open_algo_pending_observer_v1 import (
+    CATEGORY_C_ORD_TYPE_VARIANTS,
+    CATEGORY_C_PAGE_LIMIT,
+    CategoryCObservationOutcomeV1,
+    build_category_c_orders_algo_pending_endpoint_v1,
+    observe_category_c_open_algo_pending_v1,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.constants_v1 import (
+    DEFAULT_INSTRUMENT_ID,
+    ENDPOINT_ORDERS_ALGO_PENDING,
+    GET_ENDPOINTS_PRIVATE,
+    LIVE_ARMED,
+    LIVE_AUTHORIZED,
+    LIVE_ENABLED,
+    POST_ENDPOINTS_GATED,
+    TESTNET_AUTHORIZED,
+)
+from src.ops.section_11_13_5_live_canary_minimum_exposure_v1.http_client_v1 import (
+    LiveCanaryHttpClientV1,
+    LiveCanaryHttpError,
+    RecordingFakeCanaryTransportV1,
+)
+
+_OBSERVER_PATH = Path(
+    "src/ops/section_11_13_5_live_canary_minimum_exposure_v1/"
+    "category_c_open_algo_pending_observer_v1.py"
+)
+_FOREIGN_INST = "BTC-USDT-SWAP"
+_REGULAR_PENDING = "/api/v5/trade/orders-pending"
+
+
+def _ok_body(rows: list[Mapping[str, Any]] | None = None) -> bytes:
+    return json.dumps({"code": "0", "data": list(rows or [])}).encode()
+
+
+def _row(**overrides: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "algoId": "algo-1",
+        "instId": DEFAULT_INSTRUMENT_ID,
+        "ordType": "conditional",
+        "side": "sell",
+        "sz": "1",
+        "state": "live",
+        "tpTriggerPx": "80000",
+        "tpOrdPx": "-1",
+        "slTriggerPx": "",
+        "slOrdPx": "",
+        "triggerPx": "",
+        "reduceOnly": "true",
+        "attachAlgoOrds": [],
+        "cTime": "1",
+        "uTime": "1",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _endpoint(ord_type: str, *, after: str | None = None) -> str:
+    return build_category_c_orders_algo_pending_endpoint_v1(
+        ord_type=ord_type,
+        instrument_id=DEFAULT_INSTRUMENT_ID,
+        after=after,
+    )
+
+
+def _transport(
+    bodies: Mapping[str, bytes] | None = None,
+    *,
+    default: bytes | None = None,
+) -> RecordingFakeCanaryTransportV1:
+    return RecordingFakeCanaryTransportV1(
+        body=default if default is not None else _ok_body(),
+        bodies_by_endpoint=dict(bodies or {}),
+    )
+
+
+def _client(
+    transport: RecordingFakeCanaryTransportV1,
+    *,
+    max_request_count: int = 64,
+) -> LiveCanaryHttpClientV1:
+    return LiveCanaryHttpClientV1(
+        rest_base="https://eea.okx.com",
+        rest_host="eea.okx.com",
+        transport=transport,
+        max_request_count=max_request_count,
+    )
+
+
+def _observe(
+    transport: RecordingFakeCanaryTransportV1,
+    **kwargs: Any,
+) -> Any:
+    return observe_category_c_open_algo_pending_v1(
+        client=_client(transport),
+        instrument_id=DEFAULT_INSTRUMENT_ID,
+        **kwargs,
+    )
+
+
+def _query(endpoint: str) -> dict[str, list[str]]:
+    return parse_qs(urlparse(endpoint).query, keep_blank_values=True)
+
+
+def test_algo_endpoint_constant_and_private_allowlist() -> None:
+    assert ENDPOINT_ORDERS_ALGO_PENDING == "/api/v5/trade/orders-algo-pending"
+    assert ENDPOINT_ORDERS_ALGO_PENDING in GET_ENDPOINTS_PRIVATE
+    assert ENDPOINT_ORDERS_ALGO_PENDING not in POST_ENDPOINTS_GATED
+    assert _REGULAR_PENDING in GET_ENDPOINTS_PRIVATE
+    assert _REGULAR_PENDING != ENDPOINT_ORDERS_ALGO_PENDING
+
+
+def test_observer_issues_required_get_variants_with_filters_and_no_body() -> None:
+    transport = _transport()
+    result = _observe(transport)
+    assert result.outcome is CategoryCObservationOutcomeV1.TARGET_CATEGORY_C_NOT_OBSERVED
+    assert len(transport.calls) == 3
+    assert {c.method for c in transport.calls} == {"GET"}
+    assert all(c.body_text == "" for c in transport.calls)
+    seen_ord: list[str] = []
+    for call in transport.calls:
+        path = urlparse(call.endpoint).path or call.endpoint.split("?", 1)[0]
+        assert path == ENDPOINT_ORDERS_ALGO_PENDING
+        assert _REGULAR_PENDING not in call.endpoint
+        query = _query(call.endpoint)
+        seen_ord.extend(query["ordType"])
+        assert query["instType"] == ["FUTURES"]
+        assert query["instId"] == [DEFAULT_INSTRUMENT_ID]
+        assert query["limit"] == ["100"]
+        assert "after" not in query
+    assert seen_ord == list(CATEGORY_C_ORD_TYPE_VARIANTS)
+    assert CATEGORY_C_ORD_TYPE_VARIANTS == (
+        "conditional,oco",
+        "trigger",
+        "move_order_stop",
+    )
+
+
+@pytest.mark.parametrize(
+    ("ord_type", "variant"),
+    [
+        ("conditional", "conditional,oco"),
+        ("oco", "conditional,oco"),
+        ("trigger", "trigger"),
+        ("move_order_stop", "move_order_stop"),
+    ],
+)
+def test_target_named_row_is_observed(ord_type: str, variant: str) -> None:
+    ep = _endpoint(variant)
+    transport = _transport({ep: _ok_body([_row(ordType=ord_type, algoId=f"id-{ord_type}")])})
+    result = _observe(transport)
+    assert result.outcome is CategoryCObservationOutcomeV1.TARGET_CATEGORY_C_OBSERVED
+    assert len(result.target_rows) == 1
+    assert result.target_rows[0].to_dict()["ordType"] == ord_type
+    assert result.target_rows[0].to_dict()["algoId"] == f"id-{ord_type}"
+    assert result.canonical_binding_status == "UNBOUND"
+
+
+def test_len_100_paginates_with_after_last_algo_id_and_empty_followup_terminates() -> None:
+    first_rows = [
+        _row(algoId=f"algo-{index:03d}", ordType="trigger")
+        for index in range(CATEGORY_C_PAGE_LIMIT)
+    ]
+    first_ep = _endpoint("trigger")
+    last_id = f"algo-{CATEGORY_C_PAGE_LIMIT - 1:03d}"
+    second_ep = _endpoint("trigger", after=last_id)
+    transport = _transport(
+        {
+            first_ep: _ok_body(first_rows),
+            second_ep: _ok_body([]),
+        }
+    )
+    result = _observe(transport)
+    assert result.outcome is CategoryCObservationOutcomeV1.TARGET_CATEGORY_C_OBSERVED
+    trigger_calls = [c for c in transport.calls if "ordType=trigger" in c.endpoint]
+    assert len(trigger_calls) == 2
+    assert "after=" not in trigger_calls[0].endpoint
+    assert _query(trigger_calls[1].endpoint)["after"] == [last_id]
+    assert len(result.target_rows) == CATEGORY_C_PAGE_LIMIT
+
+
+def test_short_page_terminates_variant_without_after() -> None:
+    ep = _endpoint("conditional,oco")
+    transport = _transport({ep: _ok_body([_row(), _row(algoId="algo-2", ordType="oco")])})
+    result = _observe(transport)
+    assert result.outcome is CategoryCObservationOutcomeV1.TARGET_CATEGORY_C_OBSERVED
+    variant_calls = [c for c in transport.calls if "ordType=conditional,oco" in c.endpoint]
+    assert len(variant_calls) == 1
+    assert "after=" not in variant_calls[0].endpoint
+    assert len(result.target_rows) == 2
+    assert [row.to_dict()["algoId"] for row in result.target_rows] == ["algo-1", "algo-2"]
+
+
+def test_transport_error_is_unproven() -> None:
+    class _Boom(RecordingFakeCanaryTransportV1):
+        def send(self, request):  # type: ignore[no-untyped-def]
+            self.calls.append(request)
+            raise LiveCanaryHttpError("FAKE_TRANSPORT")
+
+    transport = _Boom()
+    result = _observe(transport)
+    assert result.outcome is CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN
+    assert result.fail_closed_reason == "TRANSPORT_OR_CLIENT_ERROR:LiveCanaryHttpError"
+    assert {c.method for c in transport.calls} == {"GET"}
+
+
+@pytest.mark.parametrize(
+    ("body", "reason"),
+    [
+        (json.dumps({"code": "50000", "data": []}).encode(), "API_CODE_NOT_SUCCESS"),
+        (json.dumps({"code": "0"}).encode(), "DATA_MISSING"),
+        (json.dumps({"code": "0", "data": None}).encode(), "DATA_NULL"),
+        (json.dumps({"code": "0", "data": {"rows": []}}).encode(), "DATA_NOT_LIST"),
+        (json.dumps({"code": "0", "data": ["not-an-object"]}).encode(), "ROW_NOT_OBJECT"),
+    ],
+)
+def test_malformed_or_unsuccessful_payload_is_unproven(body: bytes, reason: str) -> None:
+    transport = _transport(default=body)
+    result = _observe(transport)
+    assert result.outcome is CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN
+    assert result.fail_closed_reason == reason
+    assert result.outcome is not CategoryCObservationOutcomeV1.TARGET_CATEGORY_C_NOT_OBSERVED
+
+
+def test_missing_instid_is_unproven() -> None:
+    row = _row()
+    del row["instId"]
+    transport = _transport({_endpoint("conditional,oco"): _ok_body([row])})
+    result = _observe(transport)
+    assert result.outcome is CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN
+    assert result.fail_closed_reason == "INSTID_MISSING"
+
+
+def test_foreign_instid_must_not_yield_not_observed() -> None:
+    transport = _transport({_endpoint("conditional,oco"): _ok_body([_row(instId=_FOREIGN_INST)])})
+    result = _observe(transport)
+    assert result.outcome is CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN
+    assert result.fail_closed_reason == "FOREIGN_INSTID"
+    assert result.outcome is not CategoryCObservationOutcomeV1.TARGET_CATEGORY_C_NOT_OBSERVED
+
+
+def test_unknown_ordtype_is_unknown_type_present() -> None:
+    transport = _transport({_endpoint("trigger"): _ok_body([_row(ordType="iceberg", algoId="x")])})
+    result = _observe(transport)
+    assert result.outcome is CategoryCObservationOutcomeV1.CATEGORY_C_UNKNOWN_TYPE_PRESENT
+    assert result.fail_closed_reason == "UNKNOWN_ORDTYPE:iceberg"
+    assert result.outcome is not CategoryCObservationOutcomeV1.TARGET_CATEGORY_C_NOT_OBSERVED
+
+
+def test_missing_state_is_unproven() -> None:
+    row = _row()
+    del row["state"]
+    transport = _transport({_endpoint("conditional,oco"): _ok_body([row])})
+    result = _observe(transport)
+    assert result.outcome is CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN
+    assert result.fail_closed_reason == "STATE_MISSING"
+
+
+def test_unexpected_state_is_unproven() -> None:
+    transport = _transport({_endpoint("conditional,oco"): _ok_body([_row(state="filled")])})
+    result = _observe(transport)
+    assert result.outcome is CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN
+    assert result.fail_closed_reason == "STATE_UNEXPECTED:filled"
+
+
+def test_missing_algoid_is_unproven() -> None:
+    row = _row()
+    del row["algoId"]
+    transport = _transport({_endpoint("conditional,oco"): _ok_body([row])})
+    result = _observe(transport)
+    assert result.outcome is CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN
+    assert result.fail_closed_reason == "ALGOID_MISSING"
+
+
+def test_duplicate_algo_id_is_unproven() -> None:
+    transport = _transport(
+        {
+            _endpoint("conditional,oco"): _ok_body(
+                [_row(algoId="dup"), _row(algoId="dup", ordType="oco")]
+            )
+        }
+    )
+    result = _observe(transport)
+    assert result.outcome is CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN
+    assert result.fail_closed_reason == "DUPLICATE_ALGO_ID"
+
+
+def test_cyclic_pagination_cursor_is_unproven() -> None:
+    page = [_row(algoId=f"algo-{index:03d}") for index in range(CATEGORY_C_PAGE_LIMIT)]
+    last_id = f"algo-{CATEGORY_C_PAGE_LIMIT - 1:03d}"
+    transport = _transport(
+        {
+            _endpoint("conditional,oco"): _ok_body(page),
+            _endpoint("conditional,oco", after=last_id): _ok_body(page),
+        }
+    )
+    result = _observe(transport)
+    assert result.outcome is CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN
+    assert result.fail_closed_reason == "DUPLICATE_ALGO_ID"
+
+
+def test_missing_algoid_on_full_page_fails_closed() -> None:
+    rows = [_row(algoId=f"algo-{index:03d}") for index in range(CATEGORY_C_PAGE_LIMIT)]
+    del rows[-1]["algoId"]
+    transport = _transport({_endpoint("conditional,oco"): _ok_body(rows)})
+    result = _observe(transport)
+    assert result.outcome is CategoryCObservationOutcomeV1.OBSERVATION_UNPROVEN
+    assert result.fail_closed_reason == "ALGOID_MISSING"
+    assert result.outcome is not CategoryCObservationOutcomeV1.TARGET_CATEGORY_C_NOT_OBSERVED
+
+
+def test_incomplete_variant_coverage_cannot_yield_not_observed() -> None:
+    transport = _transport()
+    result = _observe(transport, max_requests=1)
+    assert result.outcome is CategoryCObservationOutcomeV1.CATEGORY_C_OBSERVATION_INCOMPLETE
+    assert result.fail_closed_reason == "REQUEST_GUARD_EXCEEDED"
+    assert result.outcome is not CategoryCObservationOutcomeV1.TARGET_CATEGORY_C_NOT_OBSERVED
+    assert len(transport.calls) == 1
+
+
+def test_page_guard_exceeded_is_incomplete() -> None:
+    rows = [_row(algoId=f"algo-{index:03d}") for index in range(CATEGORY_C_PAGE_LIMIT)]
+    transport = _transport({_endpoint("conditional,oco"): _ok_body(rows)})
+    result = _observe(transport, max_pages_per_variant=1)
+    assert result.outcome is CategoryCObservationOutcomeV1.CATEGORY_C_OBSERVATION_INCOMPLETE
+    assert result.fail_closed_reason == "PAGE_GUARD_EXCEEDED"
+    assert result.outcome is not CategoryCObservationOutcomeV1.TARGET_CATEGORY_C_NOT_OBSERVED
+
+
+def test_regular_pending_emptiness_has_no_bearing_and_is_not_called() -> None:
+    transport = _transport()
+    result = _observe(transport)
+    assert result.outcome is CategoryCObservationOutcomeV1.TARGET_CATEGORY_C_NOT_OBSERVED
+    assert all(_REGULAR_PENDING not in c.endpoint for c in transport.calls)
+    assert all(_REGULAR_PENDING not in c.url for c in transport.calls)
+    signature = inspect.signature(observe_category_c_open_algo_pending_v1)
+    assert "pending" not in signature.parameters
+    assert "orders_pending" not in signature.parameters
+
+
+def test_no_submit_cancel_amend_flatten_invoked_and_calls_are_get_only() -> None:
+    transport = _transport()
+    client = _client(transport)
+    result = observe_category_c_open_algo_pending_v1(
+        client=client, instrument_id=DEFAULT_INSTRUMENT_ID
+    )
+    assert result.outcome is CategoryCObservationOutcomeV1.TARGET_CATEGORY_C_NOT_OBSERVED
+    assert client.counters.entry_submit_count == 0
+    assert client.counters.flatten_submit_count == 0
+    assert client.counters.cancel_request_count == 0
+    assert client.counters.amend_request_count == 0
+    assert client.counters.write_request_count == 0
+    assert all(m == "GET" for m in result.methods_used)
+    assert {c.method for c in transport.calls} == {"GET"}
+    source = _OBSERVER_PATH.read_text(encoding="utf-8")
+    for needle in (
+        "post_entry_order",
+        "post_flatten_order",
+        "wire_send_enabled=True",
+        "CanaryEntrySubmitPermitV1",
+        "CanaryFlattenHttpPermitV1",
+    ):
+        assert needle not in source
+
+
+def test_live_and_testnet_authorization_flags_unchanged() -> None:
+    before = (LIVE_AUTHORIZED, LIVE_ENABLED, LIVE_ARMED, TESTNET_AUTHORIZED)
+    transport = _transport()
+    _observe(transport)
+    after = (LIVE_AUTHORIZED, LIVE_ENABLED, LIVE_ARMED, TESTNET_AUTHORIZED)
+    assert before == after == (False, False, False, False)
+
+
+def test_observer_import_and_construction_do_not_use_network() -> None:
+    source = _OBSERVER_PATH.read_text(encoding="utf-8")
+    for needle in (
+        "urlopen",
+        "UrllibLiveCanaryTransportV1",
+        "wire_send_enabled",
+        "urllib.request",
+    ):
+        assert needle not in source
+    transport = _transport()
+    assert transport.venue_live_contact is False
+    _observe(transport)
+    assert transport.venue_live_contact is False
+
+
+def test_present_evidence_fields_retained_absent_fields_not_invented() -> None:
+    row = {
+        "algoId": "keep-1",
+        "instId": DEFAULT_INSTRUMENT_ID,
+        "ordType": "conditional",
+        "side": "sell",
+        "sz": "1",
+        "state": "pause",
+    }
+    transport = _transport({_endpoint("conditional,oco"): _ok_body([row])})
+    result = _observe(transport)
+    assert result.outcome is CategoryCObservationOutcomeV1.TARGET_CATEGORY_C_OBSERVED
+    values = result.target_rows[0].to_dict()
+    assert values["algoId"] == "keep-1"
+    assert values["state"] == "pause"
+    assert "tpTriggerPx" not in values
+    assert "attachAlgoOrds" not in values
+
+
+def test_header_factory_receives_full_url_and_get_has_no_body() -> None:
+    seen: list[str] = []
+
+    def factory(url: str) -> dict[str, str]:
+        seen.append(url)
+        return {"X-Test": "1"}
+
+    transport = _transport()
+    observe_category_c_open_algo_pending_v1(
+        client=_client(transport),
+        instrument_id=DEFAULT_INSTRUMENT_ID,
+        header_factory=factory,
+    )
+    assert len(seen) == 3
+    assert all(u.startswith("https://eea.okx.com/api/v5/trade/orders-algo-pending?") for u in seen)
+    assert all(c.body_text == "" for c in transport.calls)
+    assert all(c.headers.get("X-Test") == "1" for c in transport.calls)
+
+
+def test_short_followup_page_after_full_page_terminates() -> None:
+    first_rows = [_row(algoId=f"algo-{index:03d}") for index in range(CATEGORY_C_PAGE_LIMIT)]
+    last_id = f"algo-{CATEGORY_C_PAGE_LIMIT - 1:03d}"
+    transport = _transport(
+        {
+            _endpoint("conditional,oco"): _ok_body(first_rows),
+            _endpoint("conditional,oco", after=last_id): _ok_body(
+                [_row(algoId="algo-tail", ordType="oco")]
+            ),
+        }
+    )
+    result = _observe(transport)
+    assert result.outcome is CategoryCObservationOutcomeV1.TARGET_CATEGORY_C_OBSERVED
+    q1_calls = [c for c in transport.calls if "ordType=conditional,oco" in c.endpoint]
+    assert len(q1_calls) == 2
+    assert _query(q1_calls[1].endpoint)["after"] == [last_id]
+    assert result.target_rows[-1].to_dict()["algoId"] == "algo-tail"
+    assert len(result.variants_completed) == 3


### PR DESCRIPTION
## Summary

- Add `/api/v5/trade/orders-algo-pending` to the authenticated private GET allowlist (`GET_ENDPOINTS_PRIVATE` only).
- Add a dedicated fail-closed Category-C open-Algo observer (injected GET client, mock/tests only).
- Explicit query variants: `conditional,oco`, `trigger`, `move_order_stop`.
- Server-side target filters (`instType=FUTURES`, `instId=BTC-USD_UM_XPERP-310404`, `limit=100`) plus local exact `instId` validation, `after=<algoId>` pagination, duplicate/cyclic protection, and bounded observation.
- Deterministic fake/mock-only tests. No Exchange request is performed in this PR.

## Safety

- GET-only capability. No POST authority added (`POST_ENDPOINTS_GATED` unchanged).
- No exchange request performed. No runtime observation. No runtime GET.
- No submit / cancel / amend / flatten / generic wire send.
- No `/api/v5/trade/orders-pending` alias as an Algo surface.
- No live / testnet / armed / enabled / config mutation.
- Runtime authorization effect: none.

## Validation

- `pytest -q tests/ops/test_section_11_13_5_category_c_open_algo_pending_observer_v1.py` → **32 passed**
- `pytest -q` observer + `tests/ops/test_section_11_13_5_canary_submit_transport_v1.py` + `tests/ops/test_section_11_13_5_z2m_fee_reserve_rates_rebind_get_path_v1.py` → **103 passed**
- `pytest -q tests/ops/test_section_11_13_5_live_canary_minimum_exposure_v1.py` → **25 passed**
- Path-equivalent `PR_BOUNDED_FULL` selector targets → **729 passed** in 37.66s
- `ruff format --check` on the three files → PASS
- `ruff check` on the three files → PASS
- Real network this slice: 0. Exchange GET: 0. Algo GET: 0. Exchange POST: 0.

## Canonical distinction

- Repository implementation is persisted in this open PR (source + tests only).
- Runtime Category-C observation remains **UNPROVEN**.
- No runtime GET was executed. This PR does **not** claim that target Algo orders exist or do not exist.
- Canonical SSOT binding status remains whatever `origin/main` currently states (`CATEGORY_C_BINDING_STATUS=UNBOUND`) until separately adjudicated/persisted.
- This PR does **not** authorize merge, runtime GET, or exchange network activity.

## Test plan

- [x] Observer mock tests (32)
- [x] Observer + canary submit transport + Z2M (103)
- [x] Core live-canary package tests (25)
- [x] PR_BOUNDED_FULL selector targets (729)
- [x] ruff format --check / ruff check
- [ ] GitHub required checks green (inspect only; no merge in this slice)

Made with [Cursor](https://cursor.com)